### PR TITLE
Compatibility fixes for ruby-1.8

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,7 @@ module ApplicationHelper
     end
   end
   
-  def time_tag(content = nil, time)
+  def time_tag(content, time)
     zone = time.strftime("%z")
     datetime = time.strftime("%Y-%m-%dT%H:%M" + zone[0, 3] + ":" + zone[3, 2])
     

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Danbooru::Application.config.session_store :cookie_store, key: '_danbooru_session'
+Danbooru::Application.config.session_store :cookie_store, :key => '_danbooru_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -4,7 +4,7 @@
 # is enabled by default.
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActionController::Base.wrap_parameters format: [:json]
+ActionController::Base.wrap_parameters :format => [:json]
 
 # Disable root element in JSON by default.
 if defined?(ActiveRecord)


### PR DESCRIPTION
I'm not quite sure if this is the road you want to go down, seeing as the hashrocket syntax is becoming deprecated. But these small fixes were all that was required to get Danbooru2 to also work with ruby-1.8.
