### PR TITLE
Unit test compatibility fixes for ruby-1.8

### DIFF
--- a/test/unit/advertisement_test.rb
+++ b/test/unit/advertisement_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class AdvertisementTest < ActiveSupport::TestCase
   context "An advertisement" do

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class ArtistTest < ActiveSupport::TestCase
   context "An artist" do

--- a/test/unit/artist_url_test.rb
+++ b/test/unit/artist_url_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class ArtistUrlTest < ActiveSupport::TestCase
   context "An artist url" do

--- a/test/unit/ban_test.rb
+++ b/test/unit/ban_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class BanTest < ActiveSupport::TestCase
   context "A ban" do

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
   context "A comment" do

--- a/test/unit/current_user_test.rb
+++ b/test/unit/current_user_test.rb
@@ -1,4 +1,4 @@
-require_relative "../test_helper"
+require 'test_helper'
 
 class ArtistTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/dmail_test.rb
+++ b/test/unit/dmail_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class DmailTest < ActiveSupport::TestCase
   context "A dmail" do

--- a/test/unit/download_test.rb
+++ b/test/unit/download_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class DownloadTest < ActiveSupport::TestCase
   context "A post download" do

--- a/test/unit/favorite_test.rb
+++ b/test/unit/favorite_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class FavoriteTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class ForumPostTest < ActiveSupport::TestCase
   context "A forum post" do

--- a/test/unit/forum_topic_test.rb
+++ b/test/unit/forum_topic_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class ForumTopicTest < ActiveSupport::TestCase
   context "A forum topic" do

--- a/test/unit/janitor_trial_test.rb
+++ b/test/unit/janitor_trial_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class JanitorTrialTest < ActiveSupport::TestCase
   context "A janitor trial" do

--- a/test/unit/note_test.rb
+++ b/test/unit/note_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class NoteTest < ActiveSupport::TestCase
   context "In all cases" do

--- a/test/unit/pixiv_proxy_test.rb
+++ b/test/unit/pixiv_proxy_test.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require_relative '../test_helper'
+require 'test_helper'
 
 class PixivProxyTest < ActiveSupport::TestCase
   context "The proxy" do

--- a/test/unit/pool_test.rb
+++ b/test/unit/pool_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class PoolTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/post_disapproval_test.rb
+++ b/test/unit/post_disapproval_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class PostDisapprovalTest < ActiveSupport::TestCase
   context "In all cases" do

--- a/test/unit/post_sets/favorite_test.rb
+++ b/test/unit/post_sets/favorite_test.rb
@@ -1,4 +1,4 @@
-require_relative '../../test_helper'
+require 'test_helper'
 
 module PostSets
   class FavoriteTest < ActiveSupport::TestCase

--- a/test/unit/post_sets/pool_test.rb
+++ b/test/unit/post_sets/pool_test.rb
@@ -1,4 +1,4 @@
-require_relative '../../test_helper'
+require 'test_helper'
 
 module PostSets
   class PoolTest < ActiveSupport::TestCase

--- a/test/unit/post_sets/post_test.rb
+++ b/test/unit/post_sets/post_test.rb
@@ -1,4 +1,4 @@
-require_relative '../../test_helper'
+require 'test_helper'
 require "danbooru/paginator/pagination_error"
 
 module PostSets

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class PostTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/post_version_test.rb
+++ b/test/unit/post_version_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class PostVersionTest < ActiveSupport::TestCase
   context "A post" do

--- a/test/unit/post_vote_test.rb
+++ b/test/unit/post_vote_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class PostVoteTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/related_tag_calculator_test.rb
+++ b/test/unit/related_tag_calculator_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class RelatedTagCalculatorTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/tag_implication_test.rb
+++ b/test/unit/tag_implication_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class TagImplicationTest < ActiveSupport::TestCase
   context "A tag implication" do

--- a/test/unit/tag_subscription_test.rb
+++ b/test/unit/tag_subscription_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class TagSubscriptionTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class TagTest < ActiveSupport::TestCase
   setup do

--- a/test/unit/upload_test.rb
+++ b/test/unit/upload_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class UploadTest < ActiveSupport::TestCase
   context "In all cases" do

--- a/test/unit/user_feedback_test.rb
+++ b/test/unit/user_feedback_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class UserFeedbackTest < ActiveSupport::TestCase
   context "A user's feedback" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   context "A user" do

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require 'test_helper'
 
 class WikiPageTest < ActiveSupport::TestCase
   setup do


### PR DESCRIPTION
Right. In the last pull request, I completely forgot about the unit tests.

I changed the instances of `require_relative` to something that should work on both rubies. Running the tests on ruby-1.9, both before and after those changes, results in (at least on my box) all tests passing except for two, which suggests to me that the status quo is being maintained.

And when running the tests on ruby-1.8, there are four tests which don't pass. But I'd assume that's most likely related to other incompatibilities in the codebase.

Pull at your discretion.

Note: There were a few different ways in which I could've `require`'d a file relatively, but they're all ugly, so it was a matter of picking a poison.
