### PR TITLE
Use scrypt to hash passwords instead of current insecure salting with SHA-1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'rmagick', :require => "RMagick"
 gem 'daemons'
 gem 'net-ssh'
 gem 'net-sftp'
+gem 'scrypt'
 
 group :development do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
+    scrypt (1.1.0)
     shoulda (3.3.2)
       shoulda-context (~> 1.0.1)
       shoulda-matchers (~> 1.4.1)
@@ -203,6 +204,7 @@ DEPENDENCIES
   ruby-prof
   sanitize!
   sass-rails
+  scrypt
   shoulda
   simple_form
   simplecov


### PR DESCRIPTION
Resolves issue #367 using the scrypt hash algorithm.  Old logins will fail to work until they have been reset.  It is recommended to properly remove all old hashes from the database after patching (`UPDATE users SET password_hash=''`).
