### PR TITLE
More accurate and simple note scaling

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -88,54 +88,20 @@ Danbooru.Note = {
     },
 
     scale: function($note_box) {
-      var $image = $("#image");
-      var original_width = parseFloat($image.data("original-width"));
-      var ratio = $image.width() / original_width;
-
-      if (ratio < 1) {
-        var scaled_width = Math.round($note_box.width() * ratio);
-        var scaled_height = Math.round($note_box.height() * ratio);
-        var scaled_top = Math.round($note_box.position().top * ratio);
-        var scaled_left = Math.round($note_box.position().left * ratio);
-        $note_box.css({
-          top: scaled_top,
-          left: scaled_left,
-          width: scaled_width,
-          height: scaled_height
-        });
-        Danbooru.Note.Box.resize_inner_border($note_box);
-      }
+      var ratio = $image.width() / parseFloat($("#image").data("original-width"));
+      var $note = $("#notes > article[data-id=" + $note_box.data("id") + "]");
+      $note_box.css({
+        top: parseFloat($note.data("y")) * ratio,
+        left: parseFloat($note.data("x")) * ratio,
+        width: parseFloat($note.data("width")) * ratio,
+        height: parseFloat($note.data("height")) * ratio
+      });
+      Danbooru.Note.Box.resize_inner_border($note_box);
     },
 
     scale_all: function() {
       $(".note-box").each(function(i, v) {
         Danbooru.Note.Box.scale($(v));
-      });
-    },
-
-    descale: function($note_box) {
-      var $image = $("#image");
-      var original_width = parseFloat($image.data("original-width"));
-      var ratio = original_width / $image.width();
-
-      if (ratio > 1) {
-        var scaled_width = Math.round($note_box.width() * ratio);
-        var scaled_height = Math.round($note_box.height() * ratio);
-        var scaled_top = Math.round($note_box.position().top * ratio);
-        var scaled_left = Math.round($note_box.position().left * ratio);
-        $note_box.css({
-          top: scaled_top,
-          left: scaled_left,
-          width: scaled_width,
-          height: scaled_height
-        });
-        Danbooru.Note.Box.resize_inner_border($note_box);
-      }
-    },
-
-    descale_all: function() {
-      $(".note-box").each(function(i, v) {
-        Danbooru.Note.Box.descale($(v));
       });
     },
 

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -82,7 +82,6 @@
 
   Danbooru.Post.initialize_post_image_resize_links = function() {
     $("#image-resize-link").click(function(e) {
-      Danbooru.Note.Box.descale_all();
       var $link = $(e.target);
       var $image = $("#image");
       $image.attr("src", $link.attr("href"));
@@ -98,8 +97,6 @@
   Danbooru.Post.initialize_post_image_resize_to_window_link = function() {
     $("#image-resize-to-window-link").click(function(e) {
       var $img = $("#image");
-
-      Danbooru.Note.Box.descale_all();
 
       if (($img.data("scale_factor") === 1) || ($img.data("scale_factor") === undefined)) {
         $img.data("original_width", $img.width());


### PR DESCRIPTION
Instead of note scaling relying on it's previous size, now it only relies on it's original size provided by the server.
Also, providing non-integer values to the css gives it better size and alignment if anyone happens to use the browser zoom feature
