### PR TITLE
Fixes to note rendering

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -139,10 +139,6 @@ Danbooru.Note = {
         top: $note_box.position().top + $note_box.height() + 5,
         left: $note_box.position().left
       });
-      if (!$note_body.data('resized')) {
-        Danbooru.Note.Body.resize($note_body);
-        $note_body.data('resized', 'true');
-      }
       Danbooru.Note.Body.bound_position($note_body);
     },
 
@@ -173,8 +169,12 @@ Danbooru.Note = {
       Danbooru.Note.Body.hide_all();
       Danbooru.Note.clear_timeouts();
       var $note_body = Danbooru.Note.Body.find(id);
-      Danbooru.Note.Body.initialize($note_body);
+      if (!$note_body.data('resized')) {
+        Danbooru.Note.Body.resize($note_body);
+        $note_body.data('resized', 'true');
+      }
       $note_body.show();
+      Danbooru.Note.Body.initialize($note_body);
     },
 
     find: function(id) {


### PR DESCRIPTION
Some fixes to speed up note rendering. Related to issue #879.

The two main speedups are from loading notes to a document fragment and adding them all at once, and from avoiding an element query in scale() by storing the original size in the note box.

The call to resize() is delayed until the note body is first displayed.

With these fixes, [post #1335615](https://danbooru.donmai.us/posts/1335615) loads in about 6 seconds for me in Opera.

I did some quick and dirty profiling to find out where the remaining time is spent.
From a call to load_all in Opera:
- total 5542
- Note.add 5121
  - Note.Box.create 2593
    - $().draggable 522
    - $().resizable 1315
    - Note.Box.bind_events 262
  - Note.Body.create 1190
    - Note.Body.bind_events 975
  - Note.Box.scale 853
    - Note.Box.resize_inner_border 369
  - Note.Body.display_text 121
- $().css 397
- $().data 704
- $().html 72
