### PR TITLE
Restrict post-login redirection targets to local URLs

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,8 @@ class SessionsController < ApplicationController
     session_creator = SessionCreator.new(session, cookies, params[:name], params[:password], params[:remember])
 
     if session_creator.authenticate
-      redirect_to(params[:url] || session[:previous_uri] || posts_path, :notice => "You are now logged in.")
+      url = params[:url] if params[:url].start_with? '/'
+      redirect_to(url || session[:previous_uri] || posts_path, :notice => "You are now logged in.")
     else
       redirect_to(new_session_path, :notice => "Password was incorrect.")
     end


### PR DESCRIPTION
The login page doesn't check that the `url` parameter is a local URL before redirecting to it; e.g. https://danbooru.donmai.us/session/new?url=http://www.example.com/ will happily take you to http://www.example.com/, leaving users open to phishing attacks if the target is a malicious site. This pull request only accepts `params[:url]` as a redirect target if it begins with a `/`, closing this vulnerability.
