### PR TITLE
Fixes for bulleted list rendering (#1803)

### DIFF
--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -86,15 +86,22 @@ class DText
 
   def self.parse_list(str, options = {})
     html = ""
+    current_item = ""
     layout = []
     nest = 0
 
     str.split(/\n/).each do |line|
       if line =~ /^\s*(\*+) (.+)/
+        if nest > 0
+          html += "<li>#{current_item}</li>"
+        elsif not current_item.strip.empty?
+          html += "<p>#{current_item}</p>"
+        end
+
         nest = $1.size
-        content = parse_inline($2)
+        current_item = parse_inline($2)
       else
-        content = parse_inline(line)
+        current_item += parse_inline(line)
       end
 
       if nest > layout.size
@@ -108,13 +115,9 @@ class DText
           html += "</#{elist}>"
         end
       end
-
-      if nest > 0
-        html += "<li>#{content}</li>"
-      else
-        html += "<p>#{content}</p>"
-      end
     end
+
+    html += "<li>#{current_item}</li>"
 
     while layout.any?
       elist = layout.pop

--- a/test/unit/dtext_test.rb
+++ b/test/unit/dtext_test.rb
@@ -126,7 +126,11 @@ class DTextTest < ActiveSupport::TestCase
   end
 
   def test_lists_not_preceded_by_newline
-    assert_equal('<p>a</p><ul><li>b</li><li>c</li></ul>', p("a\n* b\n* c").gsub(/\n/, ""))
+    assert_equal('<p>ab</p><ul><li>c</li><li>d</li></ul>', p("a\nb\n* c\n* d").gsub(/\n/, ""))
+  end
+
+  def test_lists_with_multiline_items
+    assert_equal('<p>a</p><ul><li>bc</li><li>de</li></ul>', p("a\n* b\nc\n* d\ne").gsub(/\n/, ""))
   end
 
   def test_inline_tags


### PR DESCRIPTION
Changes:
- Fixes the specific case @ToksT mentions in #1803, where non-bulleted lines immediately preceding lists are themselves erroneously output as list items.
- Turns other lines not starting with a bullet into continuations of whatever list item precedes them, instead of separate list items as they were previously.

Making this a pull request for review before merging.
