### PR TITLE
Safer $.fn.selectEnd

### DIFF
--- a/app/assets/javascripts/utility.js
+++ b/app/assets/javascripts/utility.js
@@ -102,7 +102,9 @@
   };
 
   $.fn.selectEnd = function(){
-    this.selectRange(this.val().length, this.val().length);
+    if (this.length) {
+      this.selectRange(this.val().length, this.val().length);
+    }
     return this;
   }
 })();


### PR DESCRIPTION
When `this.length` is 0, `this.val().length` will become `undefined.length` and cause a TypeError.
