### PR TITLE
Async the application script loading in page heads;

### DIFF
--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -23,7 +23,7 @@
   <% if CurrentUser.user.custom_style.present? %>
     <%= stylesheet_link_tag custom_style_users_path, :media => "screen" %>
   <% end %>
-  <%= javascript_include_tag "application" %>
+  <%= javascript_include_tag "application", :async => true %>
   <%= raw Danbooru.config.custom_html_header_content %>
   <%= yield :html_header %>
 </head>


### PR DESCRIPTION
Since we don't manipulate the DOM until document ready, we can load our main script asynchronously to increase page-load performance.
