### PR TITLE
WebM support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'statistics2'
 gem 'capistrano'
 gem 'capistrano-ext'
 gem 'radix62', '~> 1.0.1'
+gem 'streamio-ffmpeg'
 
 # needed for looser jpeg header compat
 gem 'ruby-imagespec', :require => "image_spec", :git => "https://github.com/r888888888/ruby-imagespec.git", :branch => "exif-fixes"

--- a/app/models/amazon_backup.rb
+++ b/app/models/amazon_backup.rb
@@ -27,7 +27,7 @@ class AmazonBackup < ActiveRecord::Base
         AWS::S3::S3Object.store(File.basename(post.file_path), open(post.file_path, "rb"), Danbooru.config.amazon_s3_bucket_name, "Content-MD5" => base64_md5)
       end
 
-      if post.is_image? && File.exists?(post.preview_file_path)
+      if post.has_preview? && File.exists?(post.preview_file_path)
         AWS::S3::S3Object.store("preview/#{post.md5}.jpg", open(post.preview_file_path, "rb"), Danbooru.config.amazon_s3_bucket_name)
       end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -44,13 +44,13 @@ class Post < ActiveRecord::Base
   module FileMethods
     def distribute_files
       RemoteFileManager.new(file_path).distribute
-      RemoteFileManager.new(preview_file_path).distribute if is_image?
+      RemoteFileManager.new(preview_file_path).distribute if has_preview?
       RemoteFileManager.new(large_file_path).distribute if has_large?
     end
 
     def delete_remote_files
       RemoteFileManager.new(file_path).delete
-      RemoteFileManager.new(preview_file_path).delete if is_image?
+      RemoteFileManager.new(preview_file_path).delete if has_preview?
       RemoteFileManager.new(large_file_path).delete if has_large?
     end
 
@@ -93,7 +93,7 @@ class Post < ActiveRecord::Base
     end
 
     def preview_file_url
-      if !is_image?
+      if !has_preview?
         return "/images/download-preview.png"
       end
 
@@ -126,6 +126,18 @@ class Post < ActiveRecord::Base
 
     def is_flash?
       file_ext =~ /swf/i
+    end
+
+    def is_video?
+      file_ext =~ /webm/i
+    end
+
+    def has_preview?
+      is_image? || is_video?
+    end
+
+    def has_dimensions?
+      is_image? || is_flash? || is_video?
     end
   end
 

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -155,6 +155,8 @@ class PostPresenter < Presenter
 
     if @post.is_flash?
       template.render("posts/partials/show/flash", :post => @post)
+    elsif @post.is_video?
+      template.render("posts/partials/show/video", :post => @post)
     elsif !@post.is_image?
       template.render("posts/partials/show/download", :post => @post)
     elsif @post.is_image?

--- a/app/views/moderator/post/queues/show.html.erb
+++ b/app/views/moderator/post/queues/show.html.erb
@@ -38,7 +38,7 @@
               <li>
                 <strong>Size:</strong>
                 <%= number_to_human_size(post.file_size) %>
-                <% if post.is_image? %>
+                <% if post.has_dimensions? %>
                   (<%= post.image_width %>x<%= post.image_height %>)
                 <% end %>
               </li>

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <li>
     Size: <%= link_to_if post.visible?, number_to_human_size(post.file_size), post.file_url %>
-    <% if post.is_image? %>
+    <% if post.has_dimensions? %>
       (<%= post.image_width %>x<%= post.image_height %>)
     <% end %>
   </li>

--- a/app/views/posts/partials/show/_video.html.erb
+++ b/app/views/posts/partials/show/_video.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag(:video, nil, :width => post.image_width, :height => post.image_height, :autoplay => true, :loop => true, :src => post.file_url) %>
+
+<p><%= link_to "Save this video (right click and save)", post.file_url %></p>


### PR DESCRIPTION
Allow uploading webm files. Lately webm has been becoming popular as an animation format on various sites, since it has better quality than gif and better file size than gif or apng.

One thing it would be immediately useful for is as a way of uploading [pixiv ugoira format](https://github.com/r888888888/danbooru/issues/2212). Though webm is useful besides that as well.

Note: this implementation includes thumbnail generation for webms as well.
