### PR TITLE
Bump rmagick to 2.13.3.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     raindrops (0.13.0)
     rake (10.3.2)
     ref (1.0.5)
-    rmagick (2.13.2)
+    rmagick (2.13.3)
     ruby-prof (0.14.2)
     safe_yaml (1.0.2)
     sanitize (2.1.0)


### PR DESCRIPTION
rmagick-2.13.2 is incompatible with versions of ImageMagick built with --enable-hdri. This includes the version of ImageMagick supplied with Arch Linux. This prevents rmagick, and consequently Danbooru,
from being installed on Arch Linux.

rmagick-2.13.3 fixed this issue (https://github.com/rmagick/rmagick/issues/18)
