### PR TITLE
Disable comment submit button to prevent double posting.

### DIFF
--- a/app/views/comments/partials/new/_form.html.erb
+++ b/app/views/comments/partials/new/_form.html.erb
@@ -4,7 +4,7 @@
 <%= form_tag(comments_path, :class => "simple_form") do %>
   <%= hidden_field "comment", "post_id", :value => post.id %>
   <%= dtext_field "comment", "body", :input_id => "comment_response_for_#{post.id}", :preview_id => "dtext-preview-for-#{post.id}" %>
-  <%= submit_tag "Post" %>
+  <%= submit_tag "Post", :data => { :disable_with => "Submitting..." } %>
   <%= dtext_preview_button "comment", "body", :input_id => "comment_response_for_#{post.id}", :preview_id => "dtext-preview-for-#{post.id}" %>
   <%= check_box "comment", "do_not_bump_post", :id => "comment_do_not_bump_post_#{post.id}" %> <label for="comment_do_not_bump_post_<%= post.id %>">No bump</label>
 <% end %>


### PR DESCRIPTION
This is just a proof of concept partial fix for #2264. I've only tested this very briefly but it seems to work.
