### PR TITLE
Show pool excerpt for ordpool:1234 searches.

### DIFF
--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -43,7 +43,7 @@ module PostSets
     end
 
     def pool_name
-      tag_string.match(/^pool:(\S+)$/i).try(:[], 1)
+      tag_string.match(/^(?:ord)?pool:(\S+)$/i).try(:[], 1)
     end
 
     def has_pool?


### PR DESCRIPTION
Normally when searching `pool:1234`, an excerpt tab that has the Pool description appears above the search results. This tab doesn't appear when doing `ordpool:1234` searches.
