### PR TITLE
Fix ugoira to work with notes.

### DIFF
--- a/app/views/posts/partials/show/_ugoira.html.erb
+++ b/app/views/posts/partials/show/_ugoira.html.erb
@@ -1,4 +1,20 @@
-<%= content_tag(:canvas, nil, :width => post.image_width, :height => post.image_height, :id => "ugoira-canvas") %>
+<%= content_tag(:canvas, nil,
+                :id => "image",
+                :width => post.image_width,
+                :height => post.image_height,
+                "data-original-width" => post.image_width,
+                "data-original-height" => post.image_height,
+                "data-large-width" => post.image_width,
+                "data-large-height" => post.image_height,
+                "data-tags" => post.tag_string,
+                "data-uploader" => post.uploader_name,
+                "data-rating" => post.rating,
+                "data-flags" => post.status_flags,
+                "data-parent-id" => post.parent_id,
+                "data-has-children" => post.has_children?,
+                "data-has-active-children" => post.has_active_children?,
+                "data-score" => post.score,
+                "data-fav-count" => post.fav_count) %>
 
 <div id="progressbar"></div>
 
@@ -21,7 +37,7 @@
         frames: <%= raw @post.pixiv_ugoira_frame_data.data.to_json %>
       };
       var options = {
-        canvas: document.getElementById("ugoira-canvas"),
+        canvas: document.getElementById("image"),
         source: "<%= @post.file_url %>",
         metadata: meta_data,
         chunkSize: 300000,


### PR DESCRIPTION
- Change the id of the canvas tag to 'image'. This is what the notes JS
  expects. It's also what the shift+e edit shortcut depends on.
- Add data-original-width/height attributes, which are what the notes JS
  needs to position notes properly.
- Add all the other data attributes that regular images have, because
  why not.
