### PR TITLE
Fix random VCR failures in Pixiv tests.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -101,4 +101,11 @@ VCR.configure do |c|
   c.cassette_library_dir = "test/fixtures/vcr_cassettes"
   c.hook_into :webmock
   # c.allow_http_connections_when_no_cassette = true
+
+  c.default_cassette_options = {
+    match_requests_on: [
+      :method,
+      VCR.request_matchers.uri_without_param(:PHPSESSID)
+    ]
+  }
 end


### PR DESCRIPTION
@r888888888: This _should_ fix the VCR failures during Pixiv tests I think you're running into. I ran into this problem a week ago but didn't get around to submitting a patch then. For me, VCR would randomly fail depending on the test seed that `rake` chose. See the commit message for the full explanation why.
