### PR TITLE
Automatically add ugoira tag to ugoira posts.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -562,12 +562,16 @@ class Post < ActiveRecord::Base
         tags << "huge_filesize"
       end
 
-      if file_ext == "swf"
+      if is_flash?
         tags << "flash"
       end
 
-      if file_ext == "webm"
+      if is_video?
         tags << "webm"
+      end
+
+      if is_ugoira?
+        tags << "ugoira"
       end
 
       return tags

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -641,6 +641,42 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
+      context "with a .zip file extension" do
+        setup do
+          @post.file_ext = "zip"
+          @post.tag_string = ""
+          @post.save
+        end
+
+        should "have the appropriate file type tag added automatically" do
+          assert_match(/ugoira/, @post.tag_string)
+        end
+      end
+
+      context "with a .webm file extension" do
+        setup do
+          @post.file_ext = "webm"
+          @post.tag_string = ""
+          @post.save
+        end
+
+        should "have the appropriate file type tag added automatically" do
+          assert_match(/webm/, @post.tag_string)
+        end
+      end
+
+      context "with a .swf file extension" do
+        setup do
+          @post.file_ext = "swf"
+          @post.tag_string = ""
+          @post.save
+        end
+
+        should "have the appropriate file type tag added automatically" do
+          assert_match(/flash/, @post.tag_string)
+        end
+      end
+
       context "that has been updated" do
         should "create a new version if it's the first version" do
           assert_difference("PostVersion.count", 1) do


### PR DESCRIPTION
Note that this only adds the ugoira tag to .zip posts. Unlike the other filetype tags, it does not remove the ugoira tag from posts converted from ugoira, but that aren't true ugoira.

IMO ugoira conversions shouldn't be tagged as ugoira now that we're going to have true ugoira support, but I'll put that to the forum to decide.
