### PR TITLE
Ensure JSON API returns boolean for Post#has_large.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -172,7 +172,7 @@ class Post < ActiveRecord::Base
     end
 
     def has_large
-      has_large?
+      !!has_large?
     end
 
     def large_image_width


### PR DESCRIPTION
Currently the post JSON API returns null for false and 0 for true for the `has_large` attribute. Cast it so that it's a boolean like other attributes.
