### PR TITLE
Facilitate autocomplete queries by tag category

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -19,11 +19,12 @@ class TagsController < ApplicationController
   end
 
   def autocomplete
+    category = (params[:search][:category].present? ? params[:search][:category] : -1)
     if CurrentUser.is_builder?
       # limit rollout
-      @tags = TagAutocomplete.search(params[:search][:name_matches])
+      @tags = TagAutocomplete.search(params[:search][:name_matches], category)
     else
-      @tags = Tag.names_matches_with_aliases(params[:search][:name_matches])
+      @tags = Tag.names_matches_with_aliases(params[:search][:name_matches], category)
     end
 
     expires_in params[:expiry].to_i.days if params[:expiry]

--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -91,13 +91,20 @@ Autocomplete.initialize_tag_autocomplete = function() {
       return false;
     },
     source: function(req, resp) {
+      var is_tag_edit = this.element.data('autocomplete') === "tag-edit";
+      var tag_category = -1;
       var query = Autocomplete.parse_query(req.term, this.element.get(0).selectionStart);
       var metatag = query.metatag;
       var term = query.term;
+      var is_category_prefix = metatag.slice(0,-1) in Danbooru.Autocomplete.TAG_CATEGORIES;
 
-      if (!metatag && !term) {
+      if (!term && (!metatag || is_category_prefix)) {
         this.close();
         return;
+      }
+
+      if(!is_tag_edit && is_category_prefix) {
+        tag_category = Danbooru.Autocomplete.TAG_CATEGORIES[metatag.slice(0,-1)];
       }
 
       switch (metatag) {
@@ -158,7 +165,7 @@ Autocomplete.initialize_tag_autocomplete = function() {
         Autocomplete.saved_search_source(term, resp);
         break;
       default:
-        Autocomplete.normal_source(term, resp);
+        Autocomplete.normal_source(term, resp, tag_category);
         break;
       }
     }
@@ -169,7 +176,7 @@ Autocomplete.initialize_tag_autocomplete = function() {
       $(this).data("ui-autocomplete").menu.bindings = $();
     },
     source: function(req, resp) {
-      Autocomplete.normal_source(req.term, resp);
+      Autocomplete.normal_source(req.term, resp, -1);
     }
   });
 }
@@ -247,11 +254,12 @@ Autocomplete.initialize_wiki_autocomplete = function($fields) {
   });
 };
 
-Autocomplete.normal_source = function(term, resp) {
+Autocomplete.normal_source = function(term, resp, tag_category) {
   return $.ajax({
     url: "/tags/autocomplete.json",
     data: {
       "search[name_matches]": term,
+      "search[category]": tag_category,
       "expiry": 7
     },
     method: "get",


### PR DESCRIPTION
Fixes #4062. As discussed on Discord with @evazion, when in a tag edit interface, it makes sense to not do a category search as the tag edit box can be used to change a tag's category.  As such, it fixes the post query so that tag category prefixes can now be used.

Additionally, it fixes an issue where queries with just the tag category prefix was sending blank queries. As part of the fix, it also now checks for valid tag category IDs when using the **Tag** ``search`` function.

