### PR TITLE
Fix missing post HTML attributes

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1481,10 +1481,6 @@ class Post < ApplicationRecord
       hash
     end
 
-    def html_data_attributes
-      [:uploader_id, :approver_id]
-    end
-
     def status
       if is_pending?
         "pending"


### PR DESCRIPTION
I noticed the other day that the post model only had `uploader_id` and `approver_id`. That's because the post model was missed when all of the other models were converted over. I did a directory search and didn't find any other ones that didn't get done.