### PR TITLE
Update HTML table column attributes

### DIFF
--- a/app/logical/table_builder.rb
+++ b/app/logical/table_builder.rb
@@ -2,8 +2,9 @@ class TableBuilder
   class Column
     attr_reader :attribute, :name, :block, :header_attributes, :body_attributes
 
-    def initialize(attribute = nil, th: {}, td: {}, width: nil, name: nil, &block)
+    def initialize(attribute = nil, column: nil, th: {}, td: {}, width: nil, name: nil, &block)
       @attribute = attribute
+      @column = column
       @header_attributes = { width: width, **th }
       @body_attributes = td
       @block = block
@@ -11,8 +12,12 @@ class TableBuilder
       @name = name || attribute
       @name = @name.to_s.titleize unless @name.is_a?(String)
 
-      if @name.present?
-        column_class = "#{@name.parameterize.dasherize}-column"
+      if @name.present? || @column.present?
+        if @column.present?
+          column_class = "#{@column}-column"
+        else
+          column_class = "#{@name.parameterize.dasherize}-column"
+        end
         @header_attributes[:class] = "#{column_class} #{@header_attributes[:class]}".strip
         @body_attributes[:class] = "#{column_class} #{@body_attributes[:class]}".strip
       end

--- a/app/views/artist_commentaries/index.html.erb
+++ b/app/views/artist_commentaries/index.html.erb
@@ -5,7 +5,7 @@
     <%= render "posts/partials/common/inline_blacklist" %>
 
     <%= table_for @commentaries, width: "100%" do |t| %>
-      <% t.column "Post", {width: "1%"} do |commentary| %>
+      <% t.column "Post", width: "1%" do |commentary| %>
         <%= PostPresenter.preview(commentary.post, :tags => "status:any") %>
       <% end %>
       <% t.column "Original" do |commentary| %>

--- a/app/views/artist_commentary_versions/_listing.html.erb
+++ b/app/views/artist_commentary_versions/_listing.html.erb
@@ -28,7 +28,7 @@
       <%= compact_time commentary_version.updated_at %>
     <% end %>
     <% if artist_commentary_versions_listing_type == :revert %>
-      <% t.column width: "7%" do |commentary_version| %>
+      <% t.column column: "control", width: "7%" do |commentary_version| %>
         <%= link_to "Revert to", revert_artist_commentary_path(commentary_version.post_id, :version_id => commentary_version.id), :remote => true, :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
       <% end %>
     <% end %>

--- a/app/views/artist_commentary_versions/_listing.html.erb
+++ b/app/views/artist_commentary_versions/_listing.html.erb
@@ -1,7 +1,7 @@
 <div id="p-<%= artist_commentary_versions_listing_type %>-listing">
 
   <%= table_for @commentary_versions, {class: "striped autofit", width: "100%"} do |t| %>
-    <% t.column "Post", {width: "5%"} do |commentary_version| %>
+    <% t.column "Post", width: "5%" do |commentary_version| %>
       <% if artist_commentary_versions_listing_type == :revert %>
         <%= link_to commentary_version.post_id, post_path(commentary_version.post_id) %>
       <% else %>
@@ -21,10 +21,10 @@
       <%= format_commentary_title(commentary_version.translated_title) %>
       <%= format_commentary_description(commentary_version.translated_description) %>
     <% end %>
-    <% t.column "Edited by", {width: "10%"} do |commentary_version| %>
+    <% t.column "Edited by", width: "10%" do |commentary_version| %>
       <%= link_to_user commentary_version.updater %>
     <% end %>
-    <% t.column "Date", {width: "10%"} do |commentary_version| %>
+    <% t.column "Date", width: "10%" do |commentary_version| %>
       <%= compact_time commentary_version.updated_at %>
     <% end %>
     <% if artist_commentary_versions_listing_type == :revert %>

--- a/app/views/artist_versions/_listing.html.erb
+++ b/app/views/artist_versions/_listing.html.erb
@@ -31,7 +31,7 @@
         </p>
       <% end %>
       <% if artist_versions_listing_type == :revert %>
-        <% t.column do |artist_version| %>
+        <% t.column column: "control" do |artist_version| %>
           <%= link_to "Revert to", revert_artist_path(artist_version.artist_id, version_id: artist_version.id), method: :put, "data-confirm": "Are you sure you want to revert to this version?" %>
         <% end %>
       <% end %>

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -27,7 +27,7 @@
       <% t.column "Updated" do |artist| %>
         <%= time_ago_in_words_tagged(artist.updated_at) %>
       <% end %>
-      <% t.column do |artist| %>
+      <% t.column column: "control" do |artist| %>
         <% if CurrentUser.is_member? %>
           <%= link_to "Edit", edit_artist_path(artist) %>
 

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -22,7 +22,7 @@
         <%= link_to "»", bans_path(search: { banner_name: ban.banner.name }) %>
         <div><%= time_ago_in_words_tagged(ban.created_at) %></div>
       <% end %>
-      <% t.column do |ban| %>
+      <% t.column column: "control" do |ban| %>
         <% if CurrentUser.is_moderator? %>
           <%= link_to "Edit", edit_ban_path(ban) %>
           | <%= link_to "Delete", ban_path(ban), :method => :delete, :remote => true %>

--- a/app/views/bulk_update_requests/_listing.html.erb
+++ b/app/views/bulk_update_requests/_listing.html.erb
@@ -27,7 +27,7 @@
     <%= link_to "»", bulk_update_requests_path(search: { user_name: request.user.name }) %>
     <div><%= time_ago_in_words_tagged(request.created_at) %></div>
   <% end %>
-  <% t.column do |request| %>
+  <% t.column column: "control" do |request| %>
     <%= link_to "Show", bulk_update_request_path(request) %> |
     <%= render "bulk_update_requests/bur_edit_links", bur: request %>
   <% end %>

--- a/app/views/comment_votes/index.html.erb
+++ b/app/views/comment_votes/index.html.erb
@@ -32,7 +32,7 @@
         <%= link_to "»", comment_votes_path(search: { user_name: vote.user.name }) %>
         <div><%= time_ago_in_words_tagged(vote.created_at) %></div>
       <% end %>
-      <% t.column do |vote| %>
+      <% t.column column: "control" do |vote| %>
         <% if vote.user == CurrentUser.user %>
           <%= link_to "unvote", comment_comment_votes_path(vote.comment), remote: true, method: :delete %>
         <% end %>

--- a/app/views/delayed_jobs/index.html.erb
+++ b/app/views/delayed_jobs/index.html.erb
@@ -23,7 +23,7 @@
       <% t.column "Run at" do |job| %>
         <%= time_ago_in_words_tagged(job.run_at) %>
       <% end %>
-      <% t.column do |job| %>
+      <% t.column column: "control" do |job| %>
         <% if CurrentUser.is_admin? %>
           <% if job.locked_at? %>
             Running

--- a/app/views/forum_post_votes/index.html.erb
+++ b/app/views/forum_post_votes/index.html.erb
@@ -31,7 +31,7 @@
         <%= link_to "»", forum_post_votes_path(search: { creator_name: forum_post_vote.creator.name }) %>
         <div><%= time_ago_in_words_tagged(forum_post_vote.created_at) %></div>
       <% end %>
-      <% t.column do |forum_post_vote| %>
+      <% t.column column: "control" do |forum_post_vote| %>
         <% if forum_post_vote.creator == CurrentUser.user %>
           <%= link_to "unvote", forum_post_vote_path(forum_post_vote, format: "js"), remote: true, method: :delete %>
         <% end %>

--- a/app/views/ip_addresses/_index.html.erb
+++ b/app/views/ip_addresses/_index.html.erb
@@ -16,7 +16,7 @@
   <% t.column "Date" do |ip| %>
     <%= time_ago_in_words_tagged ip.created_at %>
   <% end %>
-  <% t.column do |ip| %>
+  <% t.column column: "ip-info" do |ip| %>
     <%= link_to "IP info", "https://ipinfo.io/#{ip.ip_addr}" %>
   <% end %>
 <% end %>

--- a/app/views/ip_addresses/_index_by_ip_addr.html.erb
+++ b/app/views/ip_addresses/_index_by_ip_addr.html.erb
@@ -10,7 +10,7 @@
   <% t.column "Uses" do |ip| %>
     <%= link_to ip.count_all, ip_addresses_path(search: { ip_addr: ip.to_s }) %>
   <% end %>
-  <% t.column "" do |ip| %>
+  <% t.column column: "ip-info" do |ip| %>
     <%= link_to "IP info", "https://ipinfo.io/#{ip.ip_addr}" %>
   <% end %>
 <% end %>

--- a/app/views/ip_bans/index.html.erb
+++ b/app/views/ip_bans/index.html.erb
@@ -10,7 +10,7 @@
         <%= link_to_user ip_ban.creator %>
       <% end %>
       <% t.column :reason %>
-      <% t.column do |ip_ban| %>
+      <% t.column column: "control" do |ip_ban| %>
         <%= link_to "Unban", ip_ban_path(ip_ban), :remote => true, :method => :delete, :data => {:confirm => "Do your really want to unban #{ip_ban.ip_addr}?"} %>
       <% end %>
     <% end %>

--- a/app/views/news_updates/index.html.erb
+++ b/app/views/news_updates/index.html.erb
@@ -7,7 +7,7 @@
         <%= link_to_user news_update.creator %>
       <% end %>
       <% t.column :message %>
-      <% t.column do |news_update| %>
+      <% t.column column: "control" do |news_update| %>
         <%= link_to "Edit", edit_news_update_path(news_update) %>
         | <%= link_to "Delete", news_update_path(news_update), :method => :delete %>
       <% end %>

--- a/app/views/note_versions/_listing.html.erb
+++ b/app/views/note_versions/_listing.html.erb
@@ -1,7 +1,6 @@
 <div id="p-<%= note_versions_listing_type %>-listing">
 
     <%= table_for @note_versions, {class: "striped autofit", width: "100%"} do |t| %>
-      <% t.column column: "empty" %>
       <% t.column "Post", width: "5%" do |note_version| %>
         <%= link_to note_version.post_id, post_path(note_version.post_id) %>
         <% if params.dig(:search, :note_id).present? %>

--- a/app/views/note_versions/_listing.html.erb
+++ b/app/views/note_versions/_listing.html.erb
@@ -2,13 +2,13 @@
 
     <%= table_for @note_versions, {class: "striped autofit", width: "100%"} do |t| %>
       <% t.column column: "empty" %>
-      <% t.column "Post", {width: "5%"} do |note_version| %>
+      <% t.column "Post", width: "5%" do |note_version| %>
         <%= link_to note_version.post_id, post_path(note_version.post_id) %>
         <% if params.dig(:search, :note_id).present? %>
           <%= link_to "»", note_versions_path(search: {post_id: note_version.post_id}) %>
         <% end %>
       <% end %>
-      <% t.column "Note", {width: "5%"} do |note_version| %>
+      <% t.column "Note", width: "5%" do |note_version| %>
         <%= link_to "#{note_version.note_id}.#{note_version.version}", post_path(note_version.post_id, anchor: "note-#{note_version.note_id}") %>
         <% if params.dig(:search, :post_id).present? %>
           <%= link_to "»", note_versions_path(search: {note_id: note_version.note_id}) %>
@@ -21,13 +21,13 @@
         <% end %>
         <%= note_version_body_diff_info(note_version) %>
       <% end %>
-      <% t.column "Position", {width: "5%"} do |note_version| %>
+      <% t.column "Position", width: "5%" do |note_version| %>
         <%= note_version_position_diff(note_version) %>
       <% end %>
-      <% t.column "Edited By", {width: "10%"} do |note_version| %>
+      <% t.column "Edited By", width: "10%" do |note_version| %>
         <%= link_to_user note_version.updater %>
       <% end %>
-      <% t.column "Date", {width: "10%"} do |note_version| %>
+      <% t.column "Date", width: "10%" do |note_version| %>
         <%= compact_time note_version.updated_at %>
       <% end %>
       <% if note_versions_listing_type == :revert %>

--- a/app/views/note_versions/_listing.html.erb
+++ b/app/views/note_versions/_listing.html.erb
@@ -3,13 +3,13 @@
     <%= table_for @note_versions, {class: "striped autofit", width: "100%"} do |t| %>
       <% t.column "Post", width: "5%" do |note_version| %>
         <%= link_to note_version.post_id, post_path(note_version.post_id) %>
-        <% if params.dig(:search, :note_id).present? %>
+        <% if !params.dig(:search, :post_id).present? %>
           <%= link_to "»", note_versions_path(search: {post_id: note_version.post_id}) %>
         <% end %>
       <% end %>
       <% t.column "Note", width: "5%" do |note_version| %>
         <%= link_to "#{note_version.note_id}.#{note_version.version}", post_path(note_version.post_id, anchor: "note-#{note_version.note_id}") %>
-        <% if params.dig(:search, :post_id).present? %>
+        <% if !params.dig(:search, :note_id).present? %>
           <%= link_to "»", note_versions_path(search: {note_id: note_version.note_id}) %>
         <% end %>
       <% end %>

--- a/app/views/note_versions/_listing.html.erb
+++ b/app/views/note_versions/_listing.html.erb
@@ -1,7 +1,7 @@
 <div id="p-<%= note_versions_listing_type %>-listing">
 
     <%= table_for @note_versions, {class: "striped autofit", width: "100%"} do |t| %>
-      <% t.column %>
+      <% t.column column: "empty" %>
       <% t.column "Post", {width: "5%"} do |note_version| %>
         <%= link_to note_version.post_id, post_path(note_version.post_id) %>
         <% if params.dig(:search, :note_id).present? %>
@@ -31,7 +31,7 @@
         <%= compact_time note_version.updated_at %>
       <% end %>
       <% if note_versions_listing_type == :revert %>
-        <% t.column "", {width: "7%"} do |note_version| %>
+        <% t.column column: "control", width: "7%" do |note_version| %>
           <%= link_to "Revert to", revert_note_path(note_version.note_id, :version_id => note_version.id), :remote => true, :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
         <% end %>
       <% end %>

--- a/app/views/pool_versions/_listing.html.erb
+++ b/app/views/pool_versions/_listing.html.erb
@@ -1,7 +1,7 @@
 <div id="p-<%= pool_versions_listing_type %>-listing">
 
     <%= table_for @pool_versions, {class: "striped autofit", width: "100%"} do |t| %>
-      <% t.column th: {width: "3%"} do |pool_version| %>
+      <% t.column column: "diff", width: "3%" do |pool_version| %>
         <%= link_to_if pool_version.previous.present?, "diff", diff_pool_version_path(pool_version.id) %>
       <% end %>
       <% t.column "Pool" do |pool_version| %>
@@ -27,7 +27,7 @@
         <%= compact_time pool_version.updated_at %>
       <% end %>
       <% if pool_versions_listing_type == :revert %>
-        <% t.column do |pool_version| %>
+        <% t.column column: "control" do |pool_version| %>
           <%= link_to "Revert to", revert_pool_path(pool_version.pool_id, :version_id => pool_version.id), :method => :put, :remote => true %>
         <% end %>
       <% end %>

--- a/app/views/pools/index.html.erb
+++ b/app/views/pools/index.html.erb
@@ -3,7 +3,7 @@
     <%= render "search", :path => pools_path %>
 
     <%= table_for @pools, width: "100%" do |t| %>
-      <% t.column "Name", {width: "60%"} do |pool| %>
+      <% t.column "Name", width: "60%" do |pool| %>
         <span class="pool-category-<%= pool.category %>"><%= link_to pool.pretty_name, pool_path(pool) %></span>
         <% if pool.is_deleted? %>
           <span class="inactive">(deleted)</span>
@@ -12,7 +12,7 @@
           <%= link_to "page #{pool.last_page}", pool_path(pool, :page => pool.last_page), :class => "last-page" %>
         <% end %>
       <% end %>
-      <% t.column "Count", {width: "10%"} do |pool| %>
+      <% t.column "Count", width: "10%" do |pool| %>
         <%= pool.post_count %>
       <% end %>
     <% end %>

--- a/app/views/post_appeals/index.html.erb
+++ b/app/views/post_appeals/index.html.erb
@@ -5,7 +5,7 @@
     <%= render "posts/partials/common/inline_blacklist" %>
 
     <%= table_for @post_appeals, width: "100%" do |t| %>
-      <% t.column "Post", {width: "1%"} do |post_appeal| %>
+      <% t.column "Post", width: "1%" do |post_appeal| %>
         <%= PostPresenter.preview(post_appeal.post, :tags => "status:any") %>
       <% end %>
       <% t.column "Reason" do |post_appeal| %>
@@ -13,23 +13,23 @@
           <%= format_text post_appeal.reason, inline: true %>
         </span>
       <% end %>
-      <% t.column "Appeals", {width: "1%"} do |post_appeal| %>
+      <% t.column "Appeals", width: "1%" do |post_appeal| %>
         <%= link_to post_appeal.post.appeals.size, post_appeals_path(search: { post_id: post_appeal.post_id }) %>
       <% end %>
-      <% t.column "Resolved?", {width: "5%"} do |post_appeal| %>
+      <% t.column "Resolved?", width: "5%" do |post_appeal| %>
         <%= link_to post_appeal.is_resolved.to_s, post_appeals_path(search: params[:search].merge(is_resolved: post_appeal.is_resolved)) %>
       <% end %>
-      <% t.column "Uploaded", {width: "15%"} do |post_appeal| %>
+      <% t.column "Uploaded", width: "15%" do |post_appeal| %>
         <%= compact_time post_appeal.post.created_at %>
         <br> by <%= link_to_user post_appeal.post.uploader %>
         <%= link_to "»", post_appeals_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} user:#{post_appeal.post.uploader.name}".strip)) %>
       <% end %>
-      <% t.column "Appealed", {width: "15%"} do |post_appeal| %>
+      <% t.column "Appealed", width: "15%" do |post_appeal| %>
         <%= compact_time post_appeal.created_at %>
         <br> by <%= link_to_user post_appeal.creator %>
         <%= link_to "»", post_appeals_path(search: params[:search].merge(creator_name: post_appeal.creator.name)) %>
       <% end %>
-      <% t.column "Approver", {width: "15%"} do |post_appeal| %>
+      <% t.column "Approver", width: "15%" do |post_appeal| %>
         <% if post_appeal.post.approver %>
           <%= link_to_user post_appeal.post.approver %>
           <%= link_to "»", post_appeals_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:#{post_appeal.post.approver.name}".strip)) %>

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -10,10 +10,10 @@
     <% end %>
 
     <%= table_for @post_approvals, width: "100%" do |t| %>
-      <% t.column "Post", {width: "1%"} do |post_approval| %>
+      <% t.column "Post", width: "1%" do |post_approval| %>
         <%= PostPresenter.preview(post_approval.post, :tags => "status:any") %>
       <% end %>
-      <% t.column "Approver", {width: "15%"} do |post_approval| %>
+      <% t.column "Approver", width: "15%" do |post_approval| %>
         <%= link_to_user post_approval.user %>
         <%= link_to "»", post_approvals_path(search: params[:search].merge(user_name: post_approval.user.name)) %>
         <br><%= time_ago_in_words_tagged  post_approval.created_at %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -5,7 +5,7 @@
     <%= render "posts/partials/common/inline_blacklist" %>
 
     <%= table_for @post_flags, width: "100%" do |t| %>
-      <% t.column "Post", {width: "1%"} do |post_flag| %>
+      <% t.column "Post", width: "1%" do |post_flag| %>
         <%= PostPresenter.preview(post_flag.post, :tags => "status:any") %>
       <% end %>
       <% t.column "Reason" do |post_flag| %>
@@ -13,28 +13,28 @@
           <%= format_text post_flag.reason, inline: true %>
         </span>
       <% end %>
-      <% t.column "Flags", {width: "1%"} do |post_flag| %>
+      <% t.column "Flags", width: "1%" do |post_flag| %>
         <%= link_to post_flag.post.flags.size, post_flags_path(search: { post_id: post_flag.post_id }) %>
       <% end %>
-      <% t.column "Category", {width: "1%"} do |post_flag| %>
+      <% t.column "Category", width: "1%" do |post_flag| %>
         <%= link_to post_flag.category.to_s, post_flags_path(search: params[:search].merge(category: post_flag.category)) %>
       <% end %>
-      <% t.column "Resolved?", {width: "1%"} do |post_flag| %>
+      <% t.column "Resolved?", width: "1%" do |post_flag| %>
         <%= link_to post_flag.is_resolved?.to_s, post_flags_path(search: params[:search].merge(is_resolved: post_flag.is_resolved?)) %>
       <% end %>
-      <% t.column "Uploaded", {width: "15%"} do |post_flag| %>
+      <% t.column "Uploaded", width: "15%" do |post_flag| %>
         <%= compact_time post_flag.post.created_at %>
         <br> by <%= link_to_user post_flag.post.uploader %>
         <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} user:#{post_flag.post.uploader.name}".strip)) %>
       <% end %>
-      <% t.column "Flagged", {width: "15%"} do |post_flag| %>
+      <% t.column "Flagged", width: "15%" do |post_flag| %>
         <%= compact_time post_flag.created_at %>
         <% if CurrentUser.can_view_flagger_on_post?(post_flag) %>
           <br> by <%= link_to_user post_flag.creator %>
           <%= link_to "»", post_flags_path(search: params[:search].merge(creator_name: post_flag.creator.name)) %>
         <% end %>
       <% end %>
-      <% t.column "Approver", {width: "15%"} do |post_flag| %>
+      <% t.column "Approver", width: "15%" do |post_flag| %>
         <% if post_flag.post.approver %>
           <%= link_to_user post_flag.post.approver %>
           <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:#{post_flag.post.approver.name}".strip)) %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -11,7 +11,7 @@
     <% end %>
 
     <%= table_for @post_replacements, {class: "striped autofit", width: "100%"} do |t| %>
-      <% t.column "Post", {width: "1%"} do |post_replacement| %>
+      <% t.column "Post", width: "1%" do |post_replacement| %>
         <%= PostPresenter.preview(post_replacement.post, show_deleted: true) %>
       <% end %>
       <% t.column "Source" do |post_replacement| %>

--- a/app/views/post_versions/_listing.html.erb
+++ b/app/views/post_versions/_listing.html.erb
@@ -5,7 +5,7 @@
 
     <%= table_for @post_versions, {id: "post-versions-table", class: "striped autofit"} do |t| %>
       <% if CurrentUser.user.is_builder? %>
-        <% t.column tag.label(tag.input type: :checkbox, id: "post-version-select-all-checkbox", class: "post-version-select-checkbox"), th: { class: "post-version-select-column" }, td: { class: "post-version-select-column" } do |post_version| %>
+        <% t.column tag.label(tag.input type: :checkbox, id: "post-version-select-all-checkbox", class: "post-version-select-checkbox"), column: "post-version-select" do |post_version| %>
           <input type="checkbox" class="post-version-select-checkbox" <%= "disabled" unless post_version.can_undo?(CurrentUser.user) %>>
         <% end %>
       <% end %>

--- a/app/views/post_votes/index.html.erb
+++ b/app/views/post_votes/index.html.erb
@@ -28,7 +28,7 @@
         <%= link_to "»", post_votes_path(search: { user_name: vote.user.name }) %>
         <div><%= time_ago_in_words_tagged(vote.created_at) %></div>
       <% end %>
-      <% t.column do |vote| %>
+      <% t.column column: "control" do |vote| %>
         <% if vote.user == CurrentUser.user %>
           <%= link_to "unvote", post_post_votes_path(vote.post), remote: true, method: :delete %>
         <% end %>

--- a/app/views/tag_aliases/_listing.html.erb
+++ b/app/views/tag_aliases/_listing.html.erb
@@ -16,7 +16,7 @@
   <% t.column "Status", {width: "5%"} do |tag_alias| %>
     <span id="tag-alias-status-for-<%= tag_alias.id %>"><%= tag_alias.status %></span>
   <% end %>
-  <% t.column width: "15%" do |tag_alias| %>
+  <% t.column column: "control", width: "15%" do |tag_alias| %>
     <%= link_to "Show", tag_alias_path(tag_alias) %>
 
     <% if tag_alias.is_pending? && tag_alias.editable_by?(CurrentUser.user) %>

--- a/app/views/tag_aliases/_listing.html.erb
+++ b/app/views/tag_aliases/_listing.html.erb
@@ -1,19 +1,19 @@
 <%= table_for tag_aliases, width: "100%" do |t| %>
-  <% t.column "From", {width: "25%"} do |tag_alias| %>
+  <% t.column "From", width: "25%" do |tag_alias| %>
     <span class="category-<%= tag_alias.antecedent_tag.try(:category) %>"><%= link_to tag_alias.antecedent_name, posts_path(:tags => tag_alias.antecedent_name) %> <span class="count"><%= tag_alias.antecedent_tag.post_count rescue 0 %></span></span>
   <% end %>
-  <% t.column "To", {width: "25%"} do |tag_alias| %>
+  <% t.column "To", width: "25%" do |tag_alias| %>
     <span class="category-<%= tag_alias.consequent_tag.try(:category) %>"><%= link_to tag_alias.consequent_name, posts_path(:tags => tag_alias.consequent_name) %> <span class="count"><%= tag_alias.consequent_tag.post_count rescue 0 %></span></span>
   <% end %>
-  <% t.column "Reference", {width: "10%"} do |tag_alias| %>
+  <% t.column "Reference", width: "10%" do |tag_alias| %>
     <% if tag_alias.forum_topic_id %>
       <%= link_to tag_alias.forum_topic_id, forum_topic_path(tag_alias.forum_topic_id) %>
     <% end %>
   <% end %>
-  <% t.column "Approver", {width: "15%"} do |tag_alias| %>
+  <% t.column "Approver", width: "15%" do |tag_alias| %>
     <%= link_to_user(tag_alias.approver) if tag_alias.approver %>
   <% end %>
-  <% t.column "Status", {width: "5%"} do |tag_alias| %>
+  <% t.column "Status", width: "5%" do |tag_alias| %>
     <span id="tag-alias-status-for-<%= tag_alias.id %>"><%= tag_alias.status %></span>
   <% end %>
   <% t.column column: "control", width: "15%" do |tag_alias| %>

--- a/app/views/tag_implications/_listing.html.erb
+++ b/app/views/tag_implications/_listing.html.erb
@@ -1,19 +1,19 @@
 <%= table_for tag_implications, width: "100%" do |t| %>
-  <% t.column "From", {width: "25%"} do |tag_implication| %>
+  <% t.column "From", width: "25%" do |tag_implication| %>
     <span class="category-<%= tag_implication.antecedent_tag.try(:category) %>"><%= link_to tag_implication.antecedent_name, posts_path(:tags => tag_implication.antecedent_name) %> <span class="count"><%= tag_implication.antecedent_tag.post_count rescue 0 %></span></span>
   <% end %>
-  <% t.column "To", {width: "25%"} do |tag_implication| %>
+  <% t.column "To", width: "25%" do |tag_implication| %>
     <span class="category-<%= tag_implication.consequent_tag.try(:category) %>"><%= link_to tag_implication.consequent_name, posts_path(:tags => tag_implication.consequent_name) %> <span class="count"><%= tag_implication.consequent_tag.post_count rescue 0 %></span></span>
   <% end %>
-  <% t.column "Reference", {width: "10%"} do |tag_implication| %>
+  <% t.column "Reference", width: "10%" do |tag_implication| %>
     <% if tag_implication.forum_topic_id %>
       <%= link_to tag_implication.forum_topic_id, forum_topic_path(tag_implication.forum_topic_id) %>
     <% end %>
   <% end %>
-  <% t.column "Approver", {width: "15%"} do |tag_implication| %>
+  <% t.column "Approver", width: "15%" do |tag_implication| %>
     <%= link_to_user(tag_implication.approver) if tag_implication.approver %>
   <% end %>
-  <% t.column "Status", {width: "5%"} do |tag_implication| %>
+  <% t.column "Status", width: "5%" do |tag_implication| %>
     <span id="tag-implication-status-for-<%= tag_implication.id %>"><%= tag_implication.status %></span>
   <% end %>
   <% t.column column: "control", width: "15%" do |tag_implication| %>

--- a/app/views/tag_implications/_listing.html.erb
+++ b/app/views/tag_implications/_listing.html.erb
@@ -16,7 +16,7 @@
   <% t.column "Status", {width: "5%"} do |tag_implication| %>
     <span id="tag-implication-status-for-<%= tag_implication.id %>"><%= tag_implication.status %></span>
   <% end %>
-  <% t.column width: "15%" do |tag_implication| %>
+  <% t.column column: "control", width: "15%" do |tag_implication| %>
     <%= link_to "Show", tag_implication_path(tag_implication) %>
 
     <% if tag_implication.is_pending? && tag_implication.editable_by?(CurrentUser.user) %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -8,7 +8,7 @@
         <%= link_to_wiki "?", tag.name, class: "tag-type-#{tag.category}" %>
         <%= link_to tag.name, posts_path(tags: tag.name), class: "tag-type-#{tag.category}" %>
       <% end %>
-      <% t.column do |tag| %>
+      <% t.column column: "control" do |tag| %>
         <%= link_to_if tag.editable_by?(CurrentUser.user), "Edit", edit_tag_path(tag) %> |
         <%= link_to "History", post_versions_path(search: { changed_tags: tag.name }) %> |
         <%= link_to "Related", related_tag_path(search: { query: tag.name }) %> |

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -37,7 +37,7 @@
         <%= link_to "»", user_feedbacks_path(search: { creator_name: feedback.creator.name }) %>
         <div><%= time_ago_in_words_tagged(feedback.created_at) %></div>
       <% end %>
-      <% t.column do |feedback| %>
+      <% t.column column: "control" do |feedback| %>
         <% if feedback.editable_by?(CurrentUser.user) %>
           <%= link_to "edit", edit_user_feedback_path(feedback) %>
           <% if feedback.deletable_by?(CurrentUser.user) && !feedback.is_deleted? %>

--- a/app/views/user_name_change_requests/index.html.erb
+++ b/app/views/user_name_change_requests/index.html.erb
@@ -15,7 +15,7 @@
       <% t.column "Date" do |change_request| %>
         <%= compact_time change_request.created_at %>
       <% end %>
-      <% t.column do |change_request| %>
+      <% t.column column: "control" do |change_request| %>
         <%= link_to "view", user_name_change_request_path(change_request) %>
       <% end %>
     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
     <h1>Users</h1>
 
     <%= table_for @users, width: "100%" do |t| %>
-      <% t.column do |user| %>
+      <% t.column column: "control" do |user| %>
         <% if CurrentUser.is_admin? %>
           <%= link_to "Edit", edit_admin_user_path(user) %>
         <% end %>

--- a/app/views/wiki_page_versions/_listing.html.erb
+++ b/app/views/wiki_page_versions/_listing.html.erb
@@ -1,15 +1,15 @@
 <div id="p-<%= wiki_page_versions_listing_type %>-listing">
   <%= form_tag(diff_wiki_page_versions_path, :method => :get) do %>
     <%= table_for @wiki_page_versions, width: "100%" do |t| %>
-      <% t.column width: "3%" do |wiki_page_version, i| %>
+      <% t.column column: "diff", width: "3%" do |wiki_page_version, i| %>
         <%= link_to_if wiki_page_version.previous.present?, "diff", diff_wiki_page_versions_path(otherpage: wiki_page_version.previous.try(:id), thispage: wiki_page_version.id) %>
       <% end %>
 
       <% if wiki_page_versions_listing_type == :page %>
-        <% t.column width: "2%" do |wiki_page_version, i| %>
+        <% t.column column: "this-page", width: "2%" do |wiki_page_version, i| %>
           <%= radio_button_tag "thispage", wiki_page_version.id, (i == 1) %>
         <% end %>
-        <% t.column width: "2%" do |wiki_page_version, i| %>
+        <% t.column column: "other-page", width: "2%" do |wiki_page_version, i| %>
           <%= radio_button_tag "otherpage", wiki_page_version.id, (i == 0) %>
         <% end %>
       <% end %>

--- a/app/views/wiki_page_versions/_listing.html.erb
+++ b/app/views/wiki_page_versions/_listing.html.erb
@@ -21,10 +21,10 @@
           <%= link_to "»", wiki_page_versions_path(search: { wiki_page_id: wiki_page_version.wiki_page_id }) %>
         </span>
       <% end %>
-      <% t.column "Status", {width: "5%"} do |wiki_page_version| %>
+      <% t.column "Status", width: "5%" do |wiki_page_version| %>
         <%= wiki_page_version_status_diff(wiki_page_version) %>
       <% end %>
-      <% t.column "Last edited", {width: "26%"} do |wiki_page_version| %>
+      <% t.column "Last edited", width: "26%" do |wiki_page_version| %>
         <%= compact_time(wiki_page_version.updated_at) %>
         by
         <%= link_to_user wiki_page_version.updater %>


### PR DESCRIPTION
This primarily adds a column parameter for use on columns which have no header name. With this, the **th** and **td** parameters don't have to be used to set the column class. This also prevents extremely long class names from being created, e.g. on the post versions view: (`label-input-type-checkbox-id-post-version-select-all-checkbox-class-post-version-select-checkbox-label-column`). It then adds missing column classes for all applicable tables.

Next , it standardizes the use of the width parameter for the column parameters to not use surrounding curly braces.

Finally, it fixes up the note versions index to remove the unneeded empty column and fix the search by post ID and note ID links so that they appear whenever not searching by that parameter, which includes the vanilla index endpoint, where I had need for them myself but they weren't there.