### PR TITLE
Lock comments edited/deleted by moderators

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -124,7 +124,7 @@ class Comment < ApplicationRecord
   end
 
   def editable_by?(user)
-    creator_id == user.id || user.is_moderator?
+    updater_id == user.id || user.is_moderator?
   end
 
   def voted_by?(user)


### PR DESCRIPTION
Fixes #2728. Undeletion is now possible through the HTML interface by using the **is_deleted** search parameter. This fixes the other issue mentioned in #2728, namely that comments edited/deleted by moderators should not be editable/undeletable by users.