### PR TITLE
Add upload commentary enhancements

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -63,7 +63,9 @@ class UploadsController < ApplicationController
     permitted_params = %i[
       file source tag_string rating status parent_id artist_commentary_title
       artist_commentary_desc include_artist_commentary referer_url
-      md5_confirmation as_pending
+      md5_confirmation as_pending translated_commentary_title
+      translated_commentary_desc add_commentary_tag add_commentary_request_tag
+      add_commentary_check_tag add_partial_commentary_tag
     ]
 
     params.require(:upload).permit(permitted_params)

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -64,8 +64,7 @@ class UploadsController < ApplicationController
       file source tag_string rating status parent_id artist_commentary_title
       artist_commentary_desc include_artist_commentary referer_url
       md5_confirmation as_pending translated_commentary_title
-      translated_commentary_desc add_commentary_tag add_commentary_request_tag
-      add_commentary_check_tag add_partial_commentary_tag
+      translated_commentary_desc
     ]
 
     params.require(:upload).permit(permitted_params)

--- a/app/javascript/src/javascripts/uploads.js.erb
+++ b/app/javascript/src/javascripts/uploads.js.erb
@@ -37,6 +37,11 @@ Upload.initialize_all = function() {
       Upload.toggle_commentary();
       e.preventDefault();
     });
+
+    $("#toggle-commentary-translation").on("click.danbooru", function(e) {
+      Upload.toggle_translation();
+      e.preventDefault();
+    });
   }
 
   if ($("#c-uploads #a-new").length) {
@@ -136,6 +141,17 @@ Upload.toggle_commentary = function() {
   }
 
   $(".artist-commentary").slideToggle();
+  $(".upload_commentary_translation_container").slideToggle();
+};
+
+Upload.toggle_translation = function() {
+  if ($(".commentary-translation").is(":visible")) {
+    $("#toggle-commentary-translation").text("show »");
+  } else {
+    $("#toggle-commentary-translation").text("« hide");
+  }
+
+  $(".commentary-translation").slideToggle();
 };
 
 Upload.initialize_dropzone = function() {

--- a/app/javascript/src/styles/specific/uploads.scss
+++ b/app/javascript/src/styles/specific/uploads.scss
@@ -4,6 +4,10 @@ div#c-uploads {
       margin-top: 1em;
     }
 
+    .commentary-translation {
+      margin-top: 1em;
+    }
+
     div#upload-guide-notice {
       margin-bottom: 2em;
     }

--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -111,11 +111,6 @@ class UploadService
       if !upload.uploader.can_upload_free? || upload.upload_as_pending?
         p.is_pending = true
       end
-
-      p.add_tag("commentary") if upload.add_commentary_tag
-      p.add_tag("commentary_request") if upload.add_commentary_request_tag
-      p.add_tag("commentary_check") if upload.add_commentary_check_tag
-      p.add_tag("partial_commentary") if upload.add_partial_commentary_tag
     end
   end
 end

--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -65,10 +65,6 @@ class UploadService
     return @post.warnings.full_messages
   end
 
-  def include_artist_commentary?
-    params[:include_artist_commentary].to_s.truthy?
-  end
-
   def create_post_from_upload(upload)
     @post = convert_to_post(upload)
     @post.save!
@@ -81,10 +77,12 @@ class UploadService
       )
     end
 
-    if include_artist_commentary?
+    if upload.include_artist_commentary
       @post.create_artist_commentary(
-        :original_title => params[:artist_commentary_title],
-        :original_description => params[:artist_commentary_desc]
+        :original_title => upload.artist_commentary_title,
+        :original_description => upload.artist_commentary_desc,
+        :translated_title => upload.translated_commentary_title,
+        :translated_description => upload.translated_commentary_desc
       )
     end
 
@@ -113,6 +111,11 @@ class UploadService
       if !upload.uploader.can_upload_free? || upload.upload_as_pending?
         p.is_pending = true
       end
+
+      p.add_tag("commentary") if upload.add_commentary_tag
+      p.add_tag("commentary_request") if upload.add_commentary_request_tag
+      p.add_tag("commentary_check") if upload.add_commentary_check_tag
+      p.add_tag("partial_commentary") if upload.add_partial_commentary_tag
     end
   end
 end

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -49,8 +49,6 @@
             <%= f.input :artist_commentary_title, as: :string, label: "Original Title", input_html: { size: 60, value: params[:artist_commentary_title] } %>
             <%= f.input :artist_commentary_desc, as: :text, label: "Original Description", input_html: { size: "60x5", value: params[:artist_commentary_desc] } %>
             <%= f.input :include_artist_commentary, as: :boolean, label: "Include Commentary", input_html: { checked: params[:include_artist_commentary].present? } %>
-            <%= f.input :add_commentary_tag, as: :boolean, label: "Add commentary tag", input_html: { checked: params[:add_commentary_tag].present? } %>
-            <%= f.input :add_commentary_request_tag, as: :boolean, label: "Add commentary request tag", input_html: { checked: params[:add_commentary_request_tag].present? } %>
           </div>
         </div>
 
@@ -61,8 +59,6 @@
           <div class="commentary-translation" style="display: none;">
             <%= f.input :translated_commentary_title, as: :string, label: "Translated Title", input_html: { size: 60, value: params[:translated_commentary_title] } %>
             <%= f.input :translated_commentary_desc, as: :text, label: "Translated Description", input_html: { size: "60x5", value: params[:translated_commentary_desc] } %>
-            <%= f.input :add_commentary_check_tag, as: :boolean, label: "Add commentary check tag", input_html: { checked: params[:add_commentary_check_tag].present? } %>
-            <%= f.input :add_partial_commentary_tag, as: :boolean, label: "Add partial commentary tag", input_html: { checked: params[:add_partial_commentary_tag].present? } %>
           </div>
         </div>
 

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -46,9 +46,23 @@
           <a href="#" id="toggle-artist-commentary">show »</a>
 
           <div class="artist-commentary" style="display: none;">
-            <%= f.input :artist_commentary_title, as: :string, label: "Title", input_html: { size: 60, value: params[:artist_commentary_title] } %>
-            <%= f.input :artist_commentary_desc, as: :text, label: "Description", input_html: { size: "60x5", value: params[:artist_commentary_desc] } %>
+            <%= f.input :artist_commentary_title, as: :string, label: "Original Title", input_html: { size: 60, value: params[:artist_commentary_title] } %>
+            <%= f.input :artist_commentary_desc, as: :text, label: "Original Description", input_html: { size: "60x5", value: params[:artist_commentary_desc] } %>
             <%= f.input :include_artist_commentary, as: :boolean, label: "Include Commentary", input_html: { checked: params[:include_artist_commentary].present? } %>
+            <%= f.input :add_commentary_tag, as: :boolean, label: "Add commentary tag", input_html: { checked: params[:add_commentary_tag].present? } %>
+            <%= f.input :add_commentary_request_tag, as: :boolean, label: "Add commentary request tag", input_html: { checked: params[:add_commentary_request_tag].present? } %>
+          </div>
+        </div>
+
+        <div class="input upload_commentary_translation_container" style="display: none;">
+          <strong>Translation</strong>
+          <a href="#" id="toggle-commentary-translation">show »</a>
+
+          <div class="commentary-translation" style="display: none;">
+            <%= f.input :translated_commentary_title, as: :string, label: "Translated Title", input_html: { size: 60, value: params[:translated_commentary_title] } %>
+            <%= f.input :translated_commentary_desc, as: :text, label: "Translated Description", input_html: { size: "60x5", value: params[:translated_commentary_desc] } %>
+            <%= f.input :add_commentary_check_tag, as: :boolean, label: "Add commentary check tag", input_html: { checked: params[:add_commentary_check_tag].present? } %>
+            <%= f.input :add_partial_commentary_tag, as: :boolean, label: "Add partial commentary tag", input_html: { checked: params[:add_partial_commentary_tag].present? } %>
           </div>
         </div>
 

--- a/db/migrate/20200114204550_add_more_commentary_to_uploads.rb
+++ b/db/migrate/20200114204550_add_more_commentary_to_uploads.rb
@@ -1,0 +1,10 @@
+class AddMoreCommentaryToUploads < ActiveRecord::Migration[6.0]
+  def change
+    add_column :uploads, :translated_commentary_title, :text
+    add_column :uploads, :translated_commentary_desc, :text
+    add_column :uploads, :add_commentary_tag, :boolean
+    add_column :uploads, :add_commentary_request_tag, :boolean
+    add_column :uploads, :add_commentary_check_tag, :boolean
+    add_column :uploads, :add_partial_commentary_tag, :boolean
+  end
+end

--- a/db/migrate/20200114204550_add_more_commentary_to_uploads.rb
+++ b/db/migrate/20200114204550_add_more_commentary_to_uploads.rb
@@ -1,10 +1,6 @@
 class AddMoreCommentaryToUploads < ActiveRecord::Migration[6.0]
   def change
-    add_column :uploads, :translated_commentary_title, :text
-    add_column :uploads, :translated_commentary_desc, :text
-    add_column :uploads, :add_commentary_tag, :boolean
-    add_column :uploads, :add_commentary_request_tag, :boolean
-    add_column :uploads, :add_commentary_check_tag, :boolean
-    add_column :uploads, :add_partial_commentary_tag, :boolean
+    add_column :uploads, :translated_commentary_title, :text, null: false, default: ""
+    add_column :uploads, :translated_commentary_desc, :text, null: false, default: ""
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3021,7 +3021,13 @@ CREATE TABLE public.uploads (
     artist_commentary_title text,
     include_artist_commentary boolean,
     context text,
-    referer_url text
+    referer_url text,
+    translated_commentary_title text,
+    translated_commentary_desc text,
+    add_commentary_tag boolean,
+    add_commentary_request_tag boolean,
+    add_commentary_check_tag boolean,
+    add_partial_commentary_tag boolean
 );
 
 
@@ -7397,6 +7403,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191117081229'),
 ('20191117200404'),
 ('20191119061018'),
-('20191223032633');
+('20191223032633'),
+('20200114204550');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3022,12 +3022,8 @@ CREATE TABLE public.uploads (
     include_artist_commentary boolean,
     context text,
     referer_url text,
-    translated_commentary_title text,
-    translated_commentary_desc text,
-    add_commentary_tag boolean,
-    add_commentary_request_tag boolean,
-    add_commentary_check_tag boolean,
-    add_partial_commentary_tag boolean
+    translated_commentary_title text DEFAULT ''::text NOT NULL,
+    translated_commentary_desc text DEFAULT ''::text NOT NULL
 );
 
 


### PR DESCRIPTION
Fixes #2794. In addition to the request from that issue, several other enhancements were made to the upload interface for artist commentaries.

1. Can now translate commentary from the upload page

    Sometimes the translator is the one uploading. This facilitates adding the translation in one step instead of having the multiple step process of submitting the upload, waiting for the post to be created with a page reload, then adding the commentary with another page reload.

    The translated section starts out hidden by default, and the control to show the translated section is only shown if the commentary section itself is shown.

2. Can now add commentary tags with a checkbox

    The checkbox names are the same as those on the add commentary dialogue. The tags involved with just the original section of commentary are included in that section, namely **commentary** and **commentary_request**. The tags involved with the translated section of the commentary are included in that section, namely **commentary_check** and **partial_commentary**.

### Notes

Since the other commentary fields were being saved in the upload record, the new input fields were added to the upload record as well. Also, those upload fields were used instead of the **params** parameter in several places since the upload record already has those fields and it doesn't require converting to a string and then a boolean.