### PR TITLE
Add ability to search for multiple name values on the same field

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -174,6 +174,12 @@ class ApplicationRecord < ActiveRecord::Base
           where_regex(attr, params[:"#{attr}_regex"])
         elsif params[:"#{attr}_not_regex"].present?
           where_not_regex(attr, params[:"#{attr}_not_regex"])
+        elsif params[:"#{attr}_array"].present?
+          where(attr => params[:"#{attr}_array"])
+        elsif params[:"#{attr}_comma"].present?
+          where(attr => params[:"#{attr}_comma"].split(','))
+        elsif params[:"#{attr}_space"].present?
+          where(attr => params[:"#{attr}_space"].split(' '))
         else
           all
         end
@@ -218,6 +224,10 @@ class ApplicationRecord < ActiveRecord::Base
           items = items.map(&:to_i) if type == :integer
 
           relation = relation.where_array_includes_all(name, items)
+        elsif params[:"#{name}_include_any_array"]
+          relation = relation.where_array_includes_any(name, params[:"#{name}_include_any_array"])
+        elsif params[:"#{name}_include_all_array"]
+          relation = relation.where_array_includes_all(name, params[:"#{name}_include_all_array"])
         end
 
         if params[:"#{name.to_s.singularize}_count"]

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -478,7 +478,7 @@ class Artist < ApplicationRecord
     def search(params)
       q = super
 
-      q = q.search_attributes(params, :is_active, :is_banned, :creator, :name, :group_name)
+      q = q.search_attributes(params, :is_active, :is_banned, :creator, :name, :group_name, :other_names)
 
       if params[:any_other_name_like]
         q = q.any_other_name_like(params[:any_other_name_like])

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -816,7 +816,7 @@ class Tag < ApplicationRecord
     def search(params)
       q = super
 
-      q = q.search_attributes(params, :is_locked, :category, :post_count)
+      q = q.search_attributes(params, :is_locked, :category, :post_count, :name)
 
       if params[:fuzzy_name_matches].present?
         q = q.fuzzy_name_matches(params[:fuzzy_name_matches])
@@ -826,8 +826,8 @@ class Tag < ApplicationRecord
         q = q.name_matches(params[:name_matches])
       end
 
-      if params[:name].present?
-        q = q.where("tags.name": normalize_name(params[:name]).split(","))
+      if params[:name_normalize].present?
+        q = q.where("tags.name": normalize_name(params[:name_normalize]).split(","))
       end
 
       if params[:hide_empty].blank? || params[:hide_empty].to_s.truthy?

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -119,18 +119,10 @@ class TagRelationship < ApplicationRecord
 
     def search(params)
       q = super
-      q = q.search_attributes(params, :creator, :approver, :forum_topic_id, :forum_post_id)
+      q = q.search_attributes(params, :creator, :approver, :forum_topic_id, :forum_post_id, :antecedent_name, :consequent_name)
 
       if params[:name_matches].present?
         q = q.name_matches(params[:name_matches])
-      end
-
-      if params[:antecedent_name].present?
-        q = q.where(antecedent_name: params[:antecedent_name].split)
-      end
-
-      if params[:consequent_name].present?
-        q = q.where(consequent_name: params[:consequent_name].split)
       end
 
       if params[:status].present?

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -72,11 +72,11 @@ class WikiPage < ApplicationRecord
     def search(params = {})
       q = super
 
-      q = q.search_attributes(params, :is_locked, :is_deleted, :body)
+      q = q.search_attributes(params, :is_locked, :is_deleted, :body, :title, :other_names)
       q = q.text_attribute_matches(:body, params[:body_matches], index_column: :body_index, ts_config: "danbooru")
 
-      if params[:title].present?
-        q = q.where_like(:title, normalize_title(params[:title]))
+      if params[:title_normalize].present?
+        q = q.where_like(:title, normalize_title(params[:title_normalize]))
       end
 
       if params[:other_names_match].present?


### PR DESCRIPTION
Fixes #4227. It basically adds in support for URL array parameters for both text and array fields. Besides that it also adds in different string splitters for text fields, since that may be shorter and work better under many conditions.

This is a slightly breaking change since a parameters had to be renamed, or are now covered under one of the new parameter name formats. However, this now makes the base name parameter more standardized across models.