### PR TITLE
Add universal index redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,28 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  private
+
+  def respond_with(*options, &block)
+    if params[:action] == "index" && is_redirect?(options[0])
+      redirect_to_show(options[0])
+    else
+      super(*options, &block)
+    end
+  end
+
+  def redirect_to_show(items)
+    redirect_to send("#{controller_path.singularize}_path", items.first, format: request.format.symbol)
+  end
+
+  def is_redirect?(items)
+    action_methods.include?("show") && params[:redirect].to_s.truthy? && items.one? && item_matches_params(items.first)
+  end
+
+  def item_matches_params(*)
+    true
+  end
+
   protected
 
   def enable_cors

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -35,11 +35,7 @@ class ArtistsController < ApplicationController
     @artists = @artists.includes(:tag) if request.format.html?
     @artists = @artists.includes(:urls) if !request.format.html?
 
-    if params[:redirect].to_s.truthy? && @artists.one? && @artists.first.name == Artist.normalize_name(params[:search][:any_name_or_url_matches])
-      redirect_to @artists.first
-    else
-      respond_with @artists
-    end
+    respond_with(@artists)
   end
 
   def show
@@ -84,6 +80,14 @@ class ArtistsController < ApplicationController
   end
 
   private
+
+  def item_matches_params(artist)
+    if params[:search][:any_name_or_url_matches]
+      artist.name == Artist.normalize_name(params[:search][:any_name_or_url_matches])
+    else
+      true
+    end
+  end
 
   def load_artist
     @artist = Artist.find(params[:id])

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -19,11 +19,7 @@ class PoolsController < ApplicationController
   def index
     @pools = Pool.includes(:creator).paginated_search(params, count_pages: true)
 
-    if params[:redirect].to_s.truthy? && @pools.one? && Pool.normalize_name_for_search(@pools.first.name) == Pool.normalize_name_for_search(params[:search][:name_matches])
-      redirect_to @pools.first
-    else
-      respond_with @pools
-    end
+    respond_with(@pools)
   end
 
   def gallery
@@ -93,6 +89,14 @@ class PoolsController < ApplicationController
   end
 
   private
+
+  def item_matches_params(pool)
+    if params[:search][:name_matches]
+      Pool.normalize_name_for_search(pool.name) == Pool.normalize_name_for_search(params[:search][:name_matches])
+    else
+      true
+    end
+  end
 
   def pool_params
     permitted_params = %i[name description category post_ids post_ids_string]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,11 +32,7 @@ class UsersController < ApplicationController
     end
 
     @users = User.paginated_search(params)
-    if params[:redirect].to_s.truthy? && @users.one? && User.normalize_name(@users.first.name) == User.normalize_name(params[:search][:name_matches])
-      redirect_to @users.first
-    else
-      respond_with @users
-    end
+    respond_with(@users)
   end
 
   def search
@@ -97,6 +93,14 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def item_matches_params(user)
+    if params[:search][:name_matches]
+      User.normalize_name(user.name) == User.normalize_name(params[:search][:name_matches])
+    else
+      true
+    end
+  end
 
   def check_privilege(user)
     raise User::PrivilegeError unless user.id == CurrentUser.id || CurrentUser.is_admin?

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -17,11 +17,7 @@ class WikiPagesController < ApplicationController
   def index
     @wiki_pages = WikiPage.paginated_search(params)
 
-    if params[:redirect].to_s.truthy? && @wiki_pages.one? && @wiki_pages.first.title == WikiPage.normalize_title(params[:search][:title])
-      redirect_to @wiki_pages.first
-    else
-      respond_with(@wiki_pages)
-    end
+    respond_with(@wiki_pages)
   end
 
   def search
@@ -79,6 +75,14 @@ class WikiPagesController < ApplicationController
   end
 
   private
+
+  def item_matches_params(wiki_page)
+    if params[:search][:title]
+      wiki_page.title == WikiPage.normalize_title(params[:search][:title])
+    else
+      true
+    end
+  end
 
   def normalize_search_params
     if params[:title]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -179,11 +179,11 @@ module ApplicationHelper
     tag.input value: "Preview", type: "button", class: "dtext-preview-button", "data-input-id": input_id, "data-preview-id": preview_id
   end
 
-  def quick_search_form_for(attribute, url, name, autocomplete: nil, &block)
+  def quick_search_form_for(attribute, url, name, autocomplete: nil, redirect: false, &block)
     tag.li do
       search_form_for(url, classes: "quick-search-form one-line-form") do |f|
         out  = f.input attribute, label: false, placeholder: "Search #{name}", input_html: { id: nil, "data-autocomplete": autocomplete }
-        out += tag.input type: :hidden, name: :redirect, value: 1
+        out += tag.input type: :hidden, name: :redirect, value: redirect
         out += capture { yield f } if block_given?
         out
       end

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:secondary_links) do %>
-  <%= quick_search_form_for(:any_name_or_url_matches, artists_path, "artists", autocomplete: "artist") %>
+  <%= quick_search_form_for(:any_name_or_url_matches, artists_path, "artists", autocomplete: "artist", redirect: true) %>
   <%= subnav_link_to "Listing", artists_path %>
   <%= subnav_link_to "Banned", artists_path(search: { is_banned: "true", order: "updated_at" }) %>
   <% if CurrentUser.is_member? %>

--- a/app/views/pools/_secondary_links.html.erb
+++ b/app/views/pools/_secondary_links.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:secondary_links) do %>
-  <%= quick_search_form_for(:name_matches, pools_path, "pools", autocomplete: "pool") %>
+  <%= quick_search_form_for(:name_matches, pools_path, "pools", autocomplete: "pool", redirect: true) %>
   <%= subnav_link_to "Gallery", gallery_pools_path %>
   <%= subnav_link_to "Listing", pools_path %>
   <%= subnav_link_to "New", new_pool_path %>

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:secondary_links) do %>
-  <%= quick_search_form_for(:name_matches, users_path, "users", autocomplete: "user") %>
+  <%= quick_search_form_for(:name_matches, users_path, "users", autocomplete: "user", redirect: true) %>
   <%= subnav_link_to "Listing", users_path %>
   <%= subnav_link_to "Search", search_users_path %>
 

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:secondary_links) do %>
-  <%= quick_search_form_for(:title, wiki_pages_path, "wiki pages", autocomplete: "wiki-page") %>
+  <%= quick_search_form_for(:title_normalize, wiki_pages_path, "wiki pages", autocomplete: "wiki-page", redirect: true) %>
   <%= subnav_link_to "Listing", wiki_pages_path %>
   <%= subnav_link_to "Search", search_wiki_pages_path %>
   <% if CurrentUser.is_member? %>


### PR DESCRIPTION
Fixes #4204. This is a more comprehensive version of 6e5e070. 
- It allows users to redirect to the show page on all controllers that have index and show actions.
- It also fixes the quick search forms so that the redirect parameter is accurate to the intended purpose of the search
    - I.e. whether it will redirect or not if only one match is found.
- Only the search parameters for the quick search forms are being handled specially in the controller.
    - The use of any other search parameters will redirect as long as only one result is returned when the redirect parameter is true.
    - This should be fine as long as users are aware of that.
- All of the controllers with index actions had their render functions replaced even if they didn't have a show action
    - This is just in case a show action is ever added to that controller in the future.
- It also fixes a bug in the wiki page autocomplete caused by 3436827

I already have a use for this functionality myself, as I can add it to my IndexedAutocomplete script for the forum topic search, and perhaps add it to several other autocomplete fields. Besides that, I also have several other uses in mind.