### PR TITLE
Fix title parameter checking

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -77,8 +77,8 @@ class WikiPagesController < ApplicationController
   private
 
   def item_matches_params(wiki_page)
-    if params[:search][:title]
-      wiki_page.title == WikiPage.normalize_title(params[:search][:title])
+    if params[:search][:title_normalize]
+      wiki_page.title == WikiPage.normalize_title(params[:search][:title_normalize])
     else
       true
     end


### PR DESCRIPTION
It was fixed on the quick search form with 217f5e6 but wasn't fixed on the parameter checking in the controller.