### PR TITLE
Add parameters for searching attributes by array with case insensitivity

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -72,6 +72,14 @@ class ApplicationRecord < ActiveRecord::Base
         where("#{qualified_column_for(attr)} @> ARRAY[?]", values)
       end
 
+      def where_array_includes_any_lower(attr, values)
+        where("lower(#{qualified_column_for(attr)}::text)::text[] && ARRAY[?]", values)
+      end
+
+      def where_array_includes_all_lower(attr, values)
+        where("lower(#{qualified_column_for(attr)}::text)::text[] @> ARRAY[?]", values)
+      end
+
       def where_array_count(attr, value)
         relation = all
         qualified_column = "cardinality(#{qualified_column_for(attr)})"
@@ -232,6 +240,20 @@ class ApplicationRecord < ActiveRecord::Base
           relation = relation.where_array_includes_any(name, params[:"#{name}_include_any_array"])
         elsif params[:"#{name}_include_all_array"]
           relation = relation.where_array_includes_all(name, params[:"#{name}_include_all_array"])
+        elsif params[:"#{name}_include_any_lower"]
+          items = params[:"#{name}_include_any_lower"].to_s.scan(/[^[:space:]]+/)
+          items = items.map(&:to_i) if type == :integer
+
+          relation = relation.where_array_includes_any_lower(name, items)
+        elsif params[:"#{name}_include_all_lower"]
+          items = params[:"#{name}_include_all_lower"].to_s.scan(/[^[:space:]]+/)
+          items = items.map(&:to_i) if type == :integer
+
+          relation = relation.where_array_includes_all_lower(name, items)
+        elsif params[:"#{name}_include_any_lower_array"]
+          relation = relation.where_array_includes_any_lower(name, params[:"#{name}_include_any_lower_array"])
+        elsif params[:"#{name}_include_all_lower_array"]
+          relation = relation.where_array_includes_all_lower(name, params[:"#{name}_include_all_lower_array"])
         end
 
         if params[:"#{name.to_s.singularize}_count"]

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -80,6 +80,10 @@ class ApplicationRecord < ActiveRecord::Base
         where("lower(#{qualified_column_for(attr)}::text)::text[] @> ARRAY[?]", values)
       end
 
+      def where_text_includes_lower(attr, values)
+        where("lower(#{qualified_column_for(attr)}) IN (?)", values)
+      end
+
       def where_array_count(attr, value)
         relation = all
         qualified_column = "cardinality(#{qualified_column_for(attr)})"
@@ -192,6 +196,12 @@ class ApplicationRecord < ActiveRecord::Base
           where(attr => params[:"#{attr}_comma"].split(','))
         elsif params[:"#{attr}_space"].present?
           where(attr => params[:"#{attr}_space"].split(' '))
+        elsif params[:"#{attr}_lower_array"].present?
+          where_text_includes_lower(attr, params[:"#{attr}_lower_array"])
+        elsif params[:"#{attr}_lower_comma"].present?
+          where_text_includes_lower(attr, params[:"#{attr}_lower_comma"].split(','))
+        elsif params[:"#{attr}_lower_space"].present?
+          where_text_includes_lower(attr, params[:"#{attr}_lower_space"].split(' '))
         else
           all
         end


### PR DESCRIPTION
It does the by performing a lowercase on the text, so the user of these params must also do a lowercase on their end before sending the query.

### Edit:

This has the immediate use case of searching batches of wiki page other names, as is a need with [Translate Pixiv Tags](https://github.com/evazion/translate-pixiv-tags).