### PR TITLE
Add embedded notes improvements

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -601,7 +601,7 @@ let Note = {
       }
 
       let $dialog = $('<div></div>');
-      let note_title = (id === 'x' ? 'Creating new note' : 'Editing note #' + id);
+      let note_title = (typeof id === 'string' && id.startsWith('x') ? 'Creating new note' : 'Editing note #' + id);
       $dialog.append('<span><b>' + note_title + ' (<a href="/wiki_pages/help:notes">view help</a>)</b></span>');
       $dialog.append($textarea);
       $dialog.data("id", id);

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -168,6 +168,44 @@ let Note = {
       event.preventDefault();
     },
 
+    key_resize: function (event) {
+      if (!Note.move_id) {
+        return;
+      }
+      const $note_box = Note.Box.find(Note.move_id);
+      if ($note_box.length === 0) {
+        return;
+      }
+      let current_height = $note_box.height();
+      let current_width = $note_box.width();
+      switch (event.originalEvent.key) {
+      case "ArrowUp":
+        current_height--;
+        break;
+      case "ArrowDown":
+        current_height++;
+        break;
+      case "ArrowLeft":
+        current_width--;
+        break;
+      case "ArrowRight":
+        current_width++;
+        break;
+      default:
+        // do nothing
+      }
+      const position = Note.Box.get_min_max_position($note_box, null, null, current_height, current_width);
+      $note_box.css({
+        top: position.top,
+        left: position.left,
+        height: current_height,
+        width: current_width,
+      });
+      Note.Box.resize_inner_border($note_box);
+      $note_box.find(".note-box-inner-border").addClass("unsaved");
+      event.preventDefault();
+    },
+
     get_min_max_position: function($note_box, current_top = null, current_left = null, current_height = null, current_width = null) {
       const computed_style = window.getComputedStyle($note_box[0]);
       current_top = (current_top === null ? parseFloat(computed_style.top) : current_top);
@@ -864,6 +902,7 @@ let Note = {
     this.initialize_highlight();
     $(document).on("hashchange.danbooru.note", this.initialize_highlight);
     Utility.keydown("up down left right", "nudge_note", Note.Box.key_nudge);
+    Utility.keydown("shift+up shift+down shift+left shift+right", "resize_note", Note.Box.key_resize);
   },
 
   initialize_shortcuts: function() {

--- a/app/javascript/src/javascripts/posts.js.erb
+++ b/app/javascript/src/javascripts/posts.js.erb
@@ -361,6 +361,9 @@ Post.resize_image_to_window = function($img) {
   var sidebar_width = 0;
   var client_width = 0;
 
+  var isVideo = $img.prop("tagName") === "VIDEO";
+  var width = isVideo ? $img.prop("width") : $img.prop('naturalWidth');
+  var height = isVideo ? $img.prop("height") : $img.prop('naturalHeight');
   if (($img.data("scale-factor") === 1) || ($img.data("scale-factor") === undefined)) {
     if ($(window).width() > 660) {
       sidebar_width = $("#sidebar").width() || 0;
@@ -370,9 +373,6 @@ Post.resize_image_to_window = function($img) {
     }
 
     if ($img.width() > client_width) {
-      var isVideo = $img.prop("tagName") === "VIDEO";
-      var width = isVideo ? $img.prop("width") : $img.data("original-width");
-      var height = isVideo ? $img.prop("height") : $img.data("original-height");
       var ratio = client_width / width;
       $img.data("scale-factor", ratio);
       $img.css("width", width * ratio);
@@ -381,8 +381,8 @@ Post.resize_image_to_window = function($img) {
     }
   } else {
     $img.data("scale-factor", 1);
-    $img.width($img.data("original-width"));
-    $img.height($img.data("original-height"));
+    $img.width(width);
+    $img.height(height);
     Post.resize_ugoira_controls();
   }
 

--- a/app/javascript/src/styles/base/040_colors.css
+++ b/app/javascript/src/styles/base/040_colors.css
@@ -117,6 +117,7 @@
   --note-box-background: transparent;
   --note-box-inner-border: 1px solid black;
   --unsaved-note-box-inner-border: 1px solid red;
+  --movable-note-box-inner-border: 1px solid green;
   --note-preview-border: 1px solid red;
   --note-preview-background: white;
   --note-highlight-color: blue;

--- a/app/javascript/src/styles/specific/notes.scss
+++ b/app/javascript/src/styles/specific/notes.scss
@@ -91,6 +91,13 @@ div#note-container {
       border: var(--unsaved-note-box-inner-border);
     }
 
+    &.movable {
+      div.note-box-inner-border,
+      div.note-box-inner-border.unsaved {
+        border: var(--movable-note-box-inner-border);
+      }
+    }
+
     &.embedded {
       color: var(--note-body-text-color);
       border: 1px solid transparent;
@@ -120,7 +127,8 @@ div#note-container {
 
       &.movable {
         div.note-box-inner-border,
-        div.note-box-inner-border.unsaved {
+        div.note-box-inner-border.unsaved,
+        div.note-box-inner-border.out-of-bounds {
           border: var(--movable-note-box-inner-border);
         }
       }
@@ -136,7 +144,8 @@ div#note-container {
         border: 1px solid transparent;
       }
 
-      div.note-box-inner-border.unsaved {
+      div.note-box-inner-border.unsaved,
+      div.note-box-inner-border.out-of-bounds {
         border: var(--unsaved-note-box-inner-border);
       }
     }

--- a/app/javascript/src/styles/specific/notes.scss
+++ b/app/javascript/src/styles/specific/notes.scss
@@ -99,7 +99,8 @@ div#note-container {
       &.hovering {
         border: var(--note-box-border);
 
-        &.editing {
+        &.editing,
+        &.movable {
           opacity: 1;
         }
 
@@ -112,8 +113,16 @@ div#note-container {
         }
       }
 
-      &.editing {
+      &.editing,
+      &.movable {
         opacity: 0.4;
+      }
+
+      &.movable {
+        div.note-box-inner-border,
+        div.note-box-inner-border.unsaved {
+          border: var(--movable-note-box-inner-border);
+        }
       }
 
       div.ui-resizable-handle {
@@ -125,6 +134,10 @@ div#note-container {
         display: table-cell;
         vertical-align: middle;
         border: 1px solid transparent;
+      }
+
+      div.note-box-inner-border.unsaved {
+        border: var(--unsaved-note-box-inner-border);
       }
     }
 


### PR DESCRIPTION
Fixes #4235. In addition to the items there, it also adds the much needed key functions for nudge and resize. It also adds a few settable styles beyond background color on the note box itself, which facilitates having different shapes and orientations of the box. It does this by copying certain styles of the first element with the class of **note-box-attributes** that it finds in the note text if it exists.

Several style manipulations were converted to using classes instead of setting styles on the elements themselves, which allows for easier maintenance and setting of multiple styles at once. For the note preview function, the font-size of the parent inner box is set to the base font size (set at page load) so that the size calculations can be done correctly, and afterwards it clears that font size so that the note elements get scaled correctly according to the current font size of the note container. Finally, some of the dead embedded code was removed.