### PR TITLE
Add ability to use nested only parameter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,25 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def model_includes(params, model = nil)
+    if params[:only] && ["json", "xml"].include?(params[:format])
+      includes_array = ParameterBuilder.includes_parameters(params[:only], model_name)
+    elsif params[:action] == "index"
+      includes_array = default_includes(params)
+    else
+      includes_array = []
+    end
+    includes_array
+  end
+
+  def default_includes(*)
+    []
+  end
+
+  def model_name
+    controller_name.classify
+  end
+
   def redirect_to_show(items)
     redirect_to send("#{controller_path.singularize}_path", items.first, format: request.format.symbol)
   end

--- a/app/controllers/artist_commentaries_controller.rb
+++ b/app/controllers/artist_commentaries_controller.rb
@@ -3,7 +3,7 @@ class ArtistCommentariesController < ApplicationController
   before_action :member_only, only: [:create_or_update, :revert]
 
   def index
-    @commentaries = ArtistCommentary.paginated_search(params)
+    @commentaries = ArtistCommentary.paginated_search(params).includes(model_includes(params))
     respond_with(@commentaries)
   end
 
@@ -35,6 +35,14 @@ class ArtistCommentariesController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [{post: [:uploader]}]
+    end
+  end
 
   def commentary_params
     params.fetch(:artist_commentary, {}).except(:post_id).permit(%i[

--- a/app/controllers/artist_commentary_versions_controller.rb
+++ b/app/controllers/artist_commentary_versions_controller.rb
@@ -2,7 +2,7 @@ class ArtistCommentaryVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @commentary_versions = ArtistCommentaryVersion.paginated_search(params)
+    @commentary_versions = ArtistCommentaryVersion.paginated_search(params).includes(model_includes(params))
     respond_with(@commentary_versions)
   end
 
@@ -10,6 +10,16 @@ class ArtistCommentaryVersionsController < ApplicationController
     @commentary_version = ArtistCommentaryVersion.find(params[:id])
     respond_with(@commentary_version) do |format|
       format.html { redirect_to artist_commentary_versions_path(search: { post_id: @commentary_version.post_id }) }
+    end
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [{post: [:uploader]}, :updater]
     end
   end
 end

--- a/app/controllers/artist_urls_controller.rb
+++ b/app/controllers/artist_urls_controller.rb
@@ -3,10 +3,10 @@ class ArtistUrlsController < ApplicationController
   before_action :member_only, except: [:index]
 
   def index
-    @artist_urls = ArtistUrl.includes(:artist).paginated_search(params)
+    @artist_urls = ArtistUrl.paginated_search(params).includes(model_includes(params))
     respond_with(@artist_urls) do |format|
-      format.json { render json: @artist_urls.to_json(include: "artist") }
-      format.xml { render xml: @artist_urls.to_xml(include: "artist", root: "artist-urls") }
+      format.json { render json: @artist_urls.to_json(format_params) }
+      format.xml { render xml: @artist_urls.to_xml(format_params) }
     end
   end
 
@@ -17,6 +17,27 @@ class ArtistUrlsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [{artist: [:urls]}]
+    else
+      [:artist]
+    end
+  end
+
+  def format_params
+    param_hash = {}
+    if params[:only]
+      param_hash[:only] = params[:only]
+    else
+      param_hash[:include] = [:artist]
+    end
+    if request.format.symbol == :xml
+      param_hash[:root] = "artist-urls"
+    end
+    param_hash
+  end
 
   def artist_url_params
     permitted_params = %i[is_active]

--- a/app/controllers/artist_versions_controller.rb
+++ b/app/controllers/artist_versions_controller.rb
@@ -2,7 +2,7 @@ class ArtistVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @artist_versions = ArtistVersion.includes(:updater).paginated_search(params)
+    @artist_versions = ArtistVersion.paginated_search(params).includes(model_includes(params))
     respond_with(@artist_versions)
   end
 
@@ -10,6 +10,16 @@ class ArtistVersionsController < ApplicationController
     @artist_version = ArtistVersion.find(params[:id])
     respond_with(@artist_version) do |format|
       format.html { redirect_to artist_versions_path(search: { artist_id: @artist_version.artist_id }) }
+    end
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:updater, {artist: [:urls]}]
     end
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -31,10 +31,7 @@ class ArtistsController < ApplicationController
     # XXX
     params[:search][:name] = params.delete(:name) if params[:name]
 
-    @artists = Artist.includes(:urls).paginated_search(params)
-    @artists = @artists.includes(:tag) if request.format.html?
-    @artists = @artists.includes(:urls) if !request.format.html?
-
+    @artists = Artist.paginated_search(params).includes(model_includes(params))
     respond_with(@artists)
   end
 
@@ -80,6 +77,14 @@ class ArtistsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [:urls]
+    else
+      [:urls, :tag]
+    end
+  end
 
   def item_matches_params(artist)
     if params[:search][:any_name_or_url_matches]

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -12,10 +12,8 @@ class BansController < ApplicationController
   end
 
   def index
-    @bans = Ban.paginated_search(params, count_pages: true)
-    respond_with(@bans) do |fmt|
-      fmt.html { @bans = @bans.includes(:user, :banner) }
-    end
+    @bans = Ban.paginated_search(params, count_pages: true).includes(model_includes(params))
+    respond_with(@bans)
   end
 
   def show
@@ -49,6 +47,14 @@ class BansController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:user, :banner]
+    end
+  end
 
   def ban_params(context)
     permitted_params = %i[reason duration expires_at]

--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -15,7 +15,6 @@ class BulkUpdateRequestsController < ApplicationController
   end
 
   def show
-    @bulk_update_request = BulkUpdateRequest.find(params[:id])
     respond_with(@bulk_update_request)
   end
 

--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -42,11 +42,19 @@ class BulkUpdateRequestsController < ApplicationController
   end
 
   def index
-    @bulk_update_requests = BulkUpdateRequest.includes(:user, :approver, :forum_topic, forum_post: [:votes]).paginated_search(params, count_pages: true)
+    @bulk_update_requests = BulkUpdateRequest.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@bulk_update_requests)
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:user, :approver, :forum_topic, {forum_post: [:votes]}]
+    end
+  end
 
   def load_bulk_update_request
     @bulk_update_request = BulkUpdateRequest.find(params[:id])

--- a/app/controllers/comment_votes_controller.rb
+++ b/app/controllers/comment_votes_controller.rb
@@ -5,7 +5,7 @@ class CommentVotesController < ApplicationController
   rescue_with CommentVote::Error, ActiveRecord::RecordInvalid, status: 422
 
   def index
-    @comment_votes = CommentVote.includes(:user, comment: [:creator, :post]).paginated_search(params, count_pages: true)
+    @comment_votes = CommentVote.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@comment_votes)
   end
 
@@ -19,5 +19,15 @@ class CommentVotesController < ApplicationController
     @comment = Comment.find(params[:comment_id])
     @comment.unvote!
     respond_with(@comment)
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:user, {comment: [:creator, {post: [:uploader]}]}]
+    end
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  respond_to :html, :xml, :json
+  respond_to :html, :xml, :json, :atom
   respond_to :js, only: [:new, :destroy, :undelete]
   before_action :member_only, :except => [:index, :search, :show]
   skip_before_action :api_check
@@ -74,6 +74,18 @@ class CommentsController < ApplicationController
 
   private
 
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [:creator, :updater]
+    elsif params[:format] == "atom"
+      [:creator, :post]
+    else
+      includes_array = [:creator, :updater, {post: [:uploader]}]
+      includes_array << :votes if CurrentUser.is_member?
+      includes_array
+    end
+  end
+
   def index_for_post
     @post = Post.find(params[:post_id])
     @comments = @post.comments
@@ -90,12 +102,8 @@ class CommentsController < ApplicationController
   end
 
   def index_by_comment
-    @comments = Comment.includes(:creator, :updater).paginated_search(params)
-    respond_with(@comments) do |format|
-      format.atom do
-        @comments = @comments.includes(:post, :creator).load
-      end
-    end
+    @comments = Comment.paginated_search(params).includes(model_includes(params))
+    respond_with(@comments)
   end
 
   def check_privilege(comment)

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -15,7 +15,7 @@ class DmailsController < ApplicationController
   end
 
   def index
-    @dmails = Dmail.visible.paginated_search(params, defaults: { folder: "received" }, count_pages: true)
+    @dmails = Dmail.visible.paginated_search(params, defaults: { folder: "received" }, count_pages: true).includes(model_includes(params))
     respond_with(@dmails)
   end
 
@@ -50,6 +50,14 @@ class DmailsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:owner, :to, :from]
+    end
+  end
 
   def check_show_privilege(dmail)
     raise User::PrivilegeError unless dmail.visible_to?(CurrentUser.user, params[:key])

--- a/app/controllers/dtext_links_controller.rb
+++ b/app/controllers/dtext_links_controller.rb
@@ -2,7 +2,17 @@ class DtextLinksController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @dtext_links = DtextLink.includes(:model).paginated_search(params)
+    @dtext_links = DtextLink.paginated_search(params).includes(model_includes(params))
     respond_with(@dtext_links)
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:model]
+    end
   end
 end

--- a/app/controllers/favorite_groups_controller.rb
+++ b/app/controllers/favorite_groups_controller.rb
@@ -4,7 +4,7 @@ class FavoriteGroupsController < ApplicationController
 
   def index
     params[:search][:creator_id] ||= params[:user_id]
-    @favorite_groups = FavoriteGroup.paginated_search(params)
+    @favorite_groups = FavoriteGroup.paginated_search(params).includes(model_includes(params))
     respond_with(@favorite_groups)
   end
 
@@ -60,6 +60,14 @@ class FavoriteGroupsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:creator]
+    end
+  end
 
   def check_write_privilege(favgroup)
     raise User::PrivilegeError unless favgroup.editable_by?(CurrentUser.user)

--- a/app/controllers/forum_post_votes_controller.rb
+++ b/app/controllers/forum_post_votes_controller.rb
@@ -3,7 +3,7 @@ class ForumPostVotesController < ApplicationController
   before_action :member_only, only: [:create, :destroy]
 
   def index
-    @forum_post_votes = ForumPostVote.includes(creator: [], forum_post: [:topic]).paginated_search(params, count_pages: true)
+    @forum_post_votes = ForumPostVote.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@forum_post_votes)
   end
 
@@ -20,6 +20,14 @@ class ForumPostVotesController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:creator, {forum_post: [:topic]}]
+    end
+  end
 
   def forum_post_vote_params
     params.fetch(:forum_post_vote, {}).permit(:score)

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -24,7 +24,7 @@ class ForumPostsController < ApplicationController
   end
 
   def index
-    @forum_posts = ForumPost.paginated_search(params).includes(:topic)
+    @forum_posts = ForumPost.paginated_search(params).includes(model_includes(params))
     respond_with(@forum_posts)
   end
 
@@ -67,6 +67,14 @@ class ForumPostsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:topic, :creator]
+    end
+  end
 
   def load_post
     @forum_post = ForumPost.find(params[:id])

--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -23,10 +23,7 @@ class ForumTopicsController < ApplicationController
     params[:search][:order] ||= "sticky" if request.format == Mime::Type.lookup("text/html")
     params[:limit] ||= 40
 
-    @forum_topics = ForumTopic.paginated_search(params)
-
-    @forum_topics = @forum_topics.includes(:creator, :updater, :forum_topic_visit_by_current_user).load if request.format.html?
-    @forum_topics = @forum_topics.includes(:creator, :original_post).load if request.format.atom?
+    @forum_topics = ForumTopic.paginated_search(params).includes(model_includes(params))
 
     respond_with(@forum_topics)
   end
@@ -79,6 +76,16 @@ class ForumTopicsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    elsif params[:format] == "atom"
+      [:creator, :original_post]
+    else
+      [:creator, :updater, :forum_topic_visit_by_current_user]
+    end
+  end
 
   def normalize_search
     if params[:title_matches]

--- a/app/controllers/ip_addresses_controller.rb
+++ b/app/controllers/ip_addresses_controller.rb
@@ -3,16 +3,30 @@ class IpAddressesController < ApplicationController
   before_action :moderator_only
 
   def index
-    @ip_addresses = IpAddress.visible(CurrentUser.user).paginated_search(params)
+    @ip_addresses = IpAddress.visible(CurrentUser.user).paginated_search(params).includes(model_includes(params))
 
     if search_params[:group_by] == "ip_addr"
       @ip_addresses = @ip_addresses.group_by_ip_addr(search_params[:ipv4_masklen], search_params[:ipv6_masklen])
     elsif search_params[:group_by] == "user"
-      @ip_addresses = @ip_addresses.group_by_user.includes(:user)
-    else
-      @ip_addresses = @ip_addresses.includes(:user, :model)
+      @ip_addresses = @ip_addresses.group_by_user
     end
 
     respond_with(@ip_addresses)
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      if params[:search][:group_by] == "user"
+        [:user]
+      elsif params[:search][:group_by] == "ip_addr"
+        []
+      else
+        [:user, :model]
+      end
+    end
   end
 end

--- a/app/controllers/ip_bans_controller.rb
+++ b/app/controllers/ip_bans_controller.rb
@@ -12,7 +12,7 @@ class IpBansController < ApplicationController
   end
 
   def index
-    @ip_bans = IpBan.includes(:creator).paginated_search(params, count_pages: true)
+    @ip_bans = IpBan.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@ip_bans)
   end
 
@@ -23,6 +23,14 @@ class IpBansController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:creator]
+    end
+  end
 
   def ip_ban_params
     params.fetch(:ip_ban, {}).permit(%i[ip_addr reason])

--- a/app/controllers/legacy_controller.rb
+++ b/app/controllers/legacy_controller.rb
@@ -3,6 +3,7 @@ class LegacyController < ApplicationController
 
   def posts
     @post_set = PostSets::Post.new(tag_query, params[:page], params[:limit], format: "json")
+    @post_set.posts = @post_set.posts.includes(:uploader)
     @posts = @post_set.posts.map(&:legacy_attributes)
 
     respond_with(@posts) do |format|

--- a/app/controllers/mod_actions_controller.rb
+++ b/app/controllers/mod_actions_controller.rb
@@ -2,7 +2,7 @@ class ModActionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @mod_actions = ModAction.includes(:creator).paginated_search(params)
+    @mod_actions = ModAction.paginated_search(params).includes(model_includes(params))
     respond_with(@mod_actions)
   end
 
@@ -10,6 +10,16 @@ class ModActionsController < ApplicationController
     @mod_action = ModAction.find(params[:id])
     respond_with(@mod_action) do |fmt|
       fmt.html { redirect_to mod_actions_path(search: { id: @mod_action.id }) }
+    end
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:creator]
     end
   end
 end

--- a/app/controllers/moderation_reports_controller.rb
+++ b/app/controllers/moderation_reports_controller.rb
@@ -10,7 +10,7 @@ class ModerationReportsController < ApplicationController
   end
 
   def index
-    @moderation_reports = ModerationReport.paginated_search(params, count_pages: true).includes(:creator, :model)
+    @moderation_reports = ModerationReport.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@moderation_reports)
   end
 
@@ -28,6 +28,14 @@ class ModerationReportsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:creator, :model]
+    end
+  end
 
   def model_type
     params.fetch(:moderation_report, {}).fetch(:model_type)

--- a/app/controllers/moderator/post/disapprovals_controller.rb
+++ b/app/controllers/moderator/post/disapprovals_controller.rb
@@ -12,11 +12,23 @@ module Moderator
       end
 
       def index
-        @post_disapprovals = PostDisapproval.includes(:user).paginated_search(params)
+        @post_disapprovals = PostDisapproval.paginated_search(params).includes(model_includes(params))
         respond_with(@post_disapprovals)
       end
 
       private
+
+      def model_name
+        "PostDisapproval"
+      end
+
+      def default_includes(params)
+        if ["json", "xml"].include?(params[:format])
+          []
+        else
+          [:user]
+        end
+      end
 
       def post_disapproval_params
         params.require(:post_disapproval).permit(%i[post_id reason message])

--- a/app/controllers/note_versions_controller.rb
+++ b/app/controllers/note_versions_controller.rb
@@ -2,8 +2,7 @@ class NoteVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @note_versions = NoteVersion.paginated_search(params)
-    @note_versions = @note_versions.includes(:updater) if request.format.html?
+    @note_versions = NoteVersion.paginated_search(params).includes(model_includes(params))
     respond_with(@note_versions)
   end
 
@@ -11,6 +10,16 @@ class NoteVersionsController < ApplicationController
     @note_version = NoteVersion.find(params[:id])
     respond_with(@note_version) do |format|
       format.html { redirect_to note_versions_path(search: { note_id: @note_version.note_id }) }
+    end
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:updater]
     end
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,8 +6,7 @@ class NotesController < ApplicationController
   end
 
   def index
-    @notes = Note.includes(:creator).paginated_search(params)
-    @notes = @notes.includes(:creator) if request.format.html?
+    @notes = Note.paginated_search(params).includes(model_includes(params))
     respond_with(@notes)
   end
 
@@ -59,6 +58,14 @@ class NotesController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [:creator]
+    else
+      [:creator, :post]
+    end
+  end
 
   def note_params(context)
     permitted_params = %i[x y width height body]

--- a/app/controllers/pool_versions_controller.rb
+++ b/app/controllers/pool_versions_controller.rb
@@ -8,7 +8,7 @@ class PoolVersionsController < ApplicationController
       @pool = Pool.find(params[:search][:pool_id])
     end
 
-    @pool_versions = PoolArchive.paginated_search(params).includes(:updater, :pool)
+    @pool_versions = PoolArchive.paginated_search(params).includes(model_includes(params))
     respond_with(@pool_versions)
   end
 
@@ -26,6 +26,18 @@ class PoolVersionsController < ApplicationController
   end
 
   private
+
+  def model_name
+    "PoolArchive"
+  end
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:updater, :pool]
+    end
+  end
 
   def set_timeout
     PoolArchive.connection.execute("SET statement_timeout = #{CurrentUser.user.statement_timeout}")

--- a/app/controllers/pool_versions_controller.rb
+++ b/app/controllers/pool_versions_controller.rb
@@ -4,10 +4,6 @@ class PoolVersionsController < ApplicationController
   around_action :set_timeout
 
   def index
-    if params[:search] && params[:search][:pool_id].present?
-      @pool = Pool.find(params[:search][:pool_id])
-    end
-
     @pool_versions = PoolArchive.paginated_search(params).includes(model_includes(params))
     respond_with(@pool_versions)
   end

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -17,7 +17,7 @@ class PoolsController < ApplicationController
   end
 
   def index
-    @pools = Pool.includes(:creator).paginated_search(params, count_pages: true)
+    @pools = Pool.paginated_search(params, count_pages: true).includes(model_includes(params))
 
     respond_with(@pools)
   end
@@ -89,6 +89,10 @@ class PoolsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    [:creator]
+  end
 
   def item_matches_params(pool)
     if params[:search][:name_matches]

--- a/app/controllers/post_appeals_controller.rb
+++ b/app/controllers/post_appeals_controller.rb
@@ -8,7 +8,7 @@ class PostAppealsController < ApplicationController
   end
 
   def index
-    @post_appeals = PostAppeal.includes(:creator).paginated_search(params).includes(post: [:appeals, :uploader, :approver])
+    @post_appeals = PostAppeal.paginated_search(params).includes(model_includes(params))
     respond_with(@post_appeals)
   end
 
@@ -25,6 +25,14 @@ class PostAppealsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [:post]
+    else
+      [:creator, {post: [:appeals, :uploader, :approver]}]
+    end
+  end
 
   def post_appeal_params
     params.fetch(:post_appeal, {}).permit(%i[post_id reason])

--- a/app/controllers/post_approvals_controller.rb
+++ b/app/controllers/post_approvals_controller.rb
@@ -2,7 +2,17 @@ class PostApprovalsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @post_approvals = PostApproval.includes(:post, :user).paginated_search(params)
+    @post_approvals = PostApproval.paginated_search(params).includes(model_includes(params))
     respond_with(@post_approvals)
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:user, {post: [:uploader]}]
+    end
   end
 end

--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -8,7 +8,7 @@ class PostFlagsController < ApplicationController
   end
 
   def index
-    @post_flags = PostFlag.paginated_search(params).includes(:creator, post: [:flags, :uploader, :approver])
+    @post_flags = PostFlag.paginated_search(params).includes(model_includes(params))
     respond_with(@post_flags)
   end
 
@@ -25,6 +25,16 @@ class PostFlagsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [:post]
+    else
+      includes_array = [{post: [:flags, :uploader, :approver]}]
+      includes_array << :creator if CurrentUser.is_moderator?
+      includes_array
+    end
+  end
 
   def post_flag_params
     params.fetch(:post_flag, {}).permit(%i[post_id reason])

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -24,12 +24,20 @@ class PostReplacementsController < ApplicationController
 
   def index
     params[:search][:post_id] = params.delete(:post_id) if params.key?(:post_id)
-    @post_replacements = PostReplacement.paginated_search(params)
+    @post_replacements = PostReplacement.paginated_search(params).includes(model_includes(params))
 
     respond_with(@post_replacements)
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:creator, {post: [:uploader]}]
+    end
+  end
 
   def create_params
     params.require(:post_replacement).permit(:replacement_url, :replacement_file, :final_source, :tags)

--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -6,7 +6,7 @@ class PostVersionsController < ApplicationController
   respond_to :js, only: [:undo]
 
   def index
-    @post_versions = PostArchive.includes(:updater, post: [:versions]).paginated_search(params)
+    @post_versions = PostArchive.paginated_search(params).includes(model_includes(params))
     respond_with(@post_versions)
   end
 
@@ -21,6 +21,18 @@ class PostVersionsController < ApplicationController
   end
 
   private
+
+  def model_name
+    "PostArchive"
+  end
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [:updater, {post: [:versions]}]
+    else
+      [:updater, {post: [:uploader, :versions]}]
+    end
+  end
 
   def set_timeout
     PostArchive.connection.execute("SET statement_timeout = #{CurrentUser.user.statement_timeout}")

--- a/app/controllers/post_votes_controller.rb
+++ b/app/controllers/post_votes_controller.rb
@@ -5,7 +5,7 @@ class PostVotesController < ApplicationController
   rescue_with PostVote::Error, status: 422
 
   def index
-    @post_votes = PostVote.includes(:user, post: [:uploader]).paginated_search(params, count_pages: true)
+    @post_votes = PostVote.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@post_votes)
   end
 
@@ -21,5 +21,15 @@ class PostVotesController < ApplicationController
     @post.unvote!
 
     respond_with(@post)
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:user, {post: [:uploader]}]
+    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,7 +11,7 @@ class PostsController < ApplicationController
       end
     else
       @post_set = PostSets::Post.new(tag_query, params[:page], params[:limit], raw: params[:raw], random: params[:random], format: params[:format])
-      @posts = @post_set.posts
+      @posts = @post_set.posts = @post_set.posts.includes(model_includes(params)) if !@post_set.is_random?
       respond_with(@posts) do |format|
         format.atom
       end
@@ -95,6 +95,14 @@ class PostsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml", "atom"].include?(params[:format])
+      [:uploader]
+    else
+      (CurrentUser.user.is_moderator? ? [:uploader] : [])
+    end
+  end
 
   def tag_query
     params[:tags] || (params[:post] && params[:post][:tags])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,17 +21,19 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
 
-    @comments = @post.comments
-    @comments = @comments.includes(:creator)
-    @comments = @comments.includes(:votes) if CurrentUser.is_member?
-    @comments = @comments.visible(CurrentUser.user)
+    if request.format == Mime::Type.lookup("text/html")
+      @comments = @post.comments
+      @comments = @comments.includes(:creator)
+      @comments = @comments.includes(:votes) if CurrentUser.is_member?
+      @comments = @comments.visible(CurrentUser.user)
 
-    include_deleted = @post.is_deleted? || (@post.parent_id.present? && @post.parent.is_deleted?) || CurrentUser.user.show_deleted_children?
-    @sibling_posts = @post.parent.present? ? @post.parent.children : Post.none
-    @sibling_posts = @sibling_posts.undeleted unless include_deleted
+      include_deleted = @post.is_deleted? || (@post.parent_id.present? && @post.parent.is_deleted?) || CurrentUser.user.show_deleted_children?
+      @sibling_posts = @post.parent.present? ? @post.parent.children : Post.none
+      @sibling_posts = @sibling_posts.undeleted unless include_deleted
 
-    @child_posts = @post.children
-    @child_posts = @child_posts.undeleted unless include_deleted
+      @child_posts = @post.children
+      @child_posts = @child_posts.undeleted unless include_deleted
+    end
 
     respond_with(@post) do |format|
       format.html.tooltip { render layout: false }

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -2,7 +2,7 @@ class SavedSearchesController < ApplicationController
   respond_to :html, :xml, :json, :js
 
   def index
-    @saved_searches = saved_searches.paginated_search(params, count_pages: true)
+    @saved_searches = saved_searches.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@saved_searches)
   end
 

--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -22,7 +22,7 @@ class TagAliasesController < ApplicationController
   end
 
   def index
-    @tag_aliases = TagAlias.includes(:antecedent_tag, :consequent_tag, :approver).paginated_search(params, count_pages: true)
+    @tag_aliases = TagAlias.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@tag_aliases)
   end
 
@@ -41,6 +41,14 @@ class TagAliasesController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:antecedent_tag, :consequent_tag, :approver]
+    end
+  end
 
   def tag_alias_params
     params.require(:tag_alias).permit(%i[antecedent_name consequent_name forum_topic_id skip_secondary_validations])

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -22,7 +22,7 @@ class TagImplicationsController < ApplicationController
   end
 
   def index
-    @tag_implications = TagImplication.includes(:antecedent_tag, :consequent_tag, :approver).paginated_search(params, count_pages: true)
+    @tag_implications = TagImplication.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@tag_implications)
   end
 
@@ -41,6 +41,14 @@ class TagImplicationsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:antecedent_tag, :consequent_tag, :approver]
+    end
+  end
 
   def tag_implication_params
     params.require(:tag_implication).permit(%i[antecedent_name consequent_name forum_topic_id skip_secondary_validations])

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -9,7 +9,7 @@ class TagsController < ApplicationController
   end
 
   def index
-    @tags = Tag.paginated_search(params)
+    @tags = Tag.paginated_search(params).includes(model_includes(params))
     respond_with(@tags)
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -23,7 +23,7 @@ class UploadsController < ApplicationController
   end
 
   def index
-    @uploads = Upload.paginated_search(params, count_pages: true).includes(:post, :uploader)
+    @uploads = Upload.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@uploads)
   end
 
@@ -57,6 +57,14 @@ class UploadsController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      [:uploader]
+    else
+      [:uploader, {post: [:uploader]}]
+    end
+  end
 
   def upload_params
     permitted_params = %i[

--- a/app/controllers/user_feedbacks_controller.rb
+++ b/app/controllers/user_feedbacks_controller.rb
@@ -19,7 +19,7 @@ class UserFeedbacksController < ApplicationController
   end
 
   def index
-    @user_feedbacks = UserFeedback.includes(:user, :creator).paginated_search(params, count_pages: true)
+    @user_feedbacks = UserFeedback.paginated_search(params, count_pages: true).includes(model_includes(params))
     respond_with(@user_feedbacks)
   end
 
@@ -36,6 +36,14 @@ class UserFeedbacksController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:user, :creator]
+    end
+  end
 
   def check_privilege(user_feedback)
     raise User::PrivilegeError unless user_feedback.editable_by?(CurrentUser.user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,7 +31,7 @@ class UsersController < ApplicationController
       return
     end
 
-    @users = User.paginated_search(params)
+    @users = User.paginated_search(params).includes(model_includes(params))
     respond_with(@users)
   end
 
@@ -93,6 +93,14 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:inviter]
+    end
+  end
 
   def item_matches_params(user)
     if params[:search][:name_matches]

--- a/app/controllers/wiki_page_versions_controller.rb
+++ b/app/controllers/wiki_page_versions_controller.rb
@@ -3,7 +3,7 @@ class WikiPageVersionsController < ApplicationController
   layout "sidebar"
 
   def index
-    @wiki_page_versions = WikiPageVersion.paginated_search(params)
+    @wiki_page_versions = WikiPageVersion.paginated_search(params).includes(model_includes(params))
     respond_with(@wiki_page_versions)
   end
 
@@ -26,5 +26,15 @@ class WikiPageVersionsController < ApplicationController
     end
 
     respond_with([@thispage, @otherpage])
+  end
+
+  private
+
+  def default_includes(params)
+    if ["json", "xml"].include?(params[:format])
+      []
+    else
+      [:updater]
+    end
   end
 end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -15,7 +15,7 @@ class WikiPagesController < ApplicationController
   end
 
   def index
-    @wiki_pages = WikiPage.paginated_search(params)
+    @wiki_pages = WikiPage.paginated_search(params).includes(model_includes(params))
 
     respond_with(@wiki_pages)
   end

--- a/app/logical/application_responder.rb
+++ b/app/logical/application_responder.rb
@@ -17,7 +17,7 @@ class ApplicationResponder < ActionController::Responder
       options[:root] ||= resource.table_name.dasherize if resource.respond_to?(:table_name)
     end
 
-    options[:only] ||= params["only"].scan(/\w+/) if params["only"]
+    options[:only] ||= params["only"] if params["only"]
 
     super
   end

--- a/app/logical/parameter_builder.rb
+++ b/app/logical/parameter_builder.rb
@@ -1,0 +1,105 @@
+class ParameterBuilder
+  def self.serial_parameters(only_string, object)
+    only_array = split_only_string(only_string)
+    get_only_hash(only_array, object)
+  end
+
+  def self.get_only_hash(only_array, object, seen_objects = [])
+    return {} if object.nil?
+    is_root = seen_objects.length == 0
+    only_hash = {only: [], include: [], methods: []}
+    available_includes = object.available_includes
+    attributes, methods = object.api_attributes.partition { |attr| object.has_attribute?(attr) }
+    methods -= available_includes
+    # Attributes and/or methods may be included in the final pass, but not includes
+    seen_objects << object.class.name
+    only_array.each do |item|
+      match = item.match(/(\w+)\[(.+?)\]$/)
+      item = (match || [])[1] || item
+      item_sym = item.to_sym
+      was_seen = was_inclusion_seen(item, object.class, seen_objects)
+      if match && available_includes.include?(item_sym) && (!was_seen || is_root)
+        item_object = object.send(item_sym)
+        next if item_object.nil?
+        item_object = item_object[0] if item_object.is_a?(ActiveRecord::Relation)
+        item_array = split_only_string(match[2])
+        item_hash = get_only_hash(item_array, item_object, seen_objects.clone)
+        only_hash[:include] << Hash[item_sym, item_hash]
+      elsif available_includes.include?(item_sym) && (!was_seen || is_root)
+        only_hash[:include] << item_sym
+      elsif attributes.include?(item_sym)
+        only_hash[:only] << item_sym
+      elsif methods.include?(item_sym)
+        only_hash[:methods] << item_sym
+        only_hash[:only] << item_sym
+      end
+    end
+    only_hash.delete(:include) if only_hash[:include].empty?
+    only_hash.delete(:methods) if only_hash[:methods].empty?
+    only_hash
+  end
+
+  def self.includes_parameters(only_string, model_name)
+    only_array = split_only_string(only_string)
+    get_includes_array(only_array, model_name)
+  end
+
+  def self.get_includes_array(only_array, model_name, seen_objects = [])
+    is_root = seen_objects.length == 0
+    include_array = []
+    model = Kernel.const_get(model_name)
+    available_includes = model.available_includes
+    # Attributes and/or methods may be included in the final pass, but not includes
+    seen_objects << model_name
+    only_array.each do |item|
+      binding.pry
+      match = item.match(/(\w+)\[(.+?)\]$/)
+      item = (match || [])[1] || item
+      item_sym = item.to_sym
+      was_seen = was_inclusion_seen(item, model, seen_objects)
+      if match && available_includes.include?(item_sym) && (!was_seen || is_root)
+        item_array = split_only_string(match[2])
+        model.associated_models(item).each do |m|
+          item_array = get_includes_array(item_array, m, seen_objects.clone)
+          include_array << (item_array.empty? ? item_sym : Hash[item_sym, item_array])
+        end
+      elsif available_includes.include?(item_sym) && (!was_seen || is_root)
+        include_array << item_sym
+      end
+    end
+    include_array
+  end
+
+  def self.was_inclusion_seen(inclusion, class_object, seen_objects)
+    if class_object.reflections[inclusion]
+      inclusion_class = class_object.reflections[inclusion].class_name
+      max_seen = (class_object.multiple_includes.include?(inclusion.to_sym) ? 1 : 0)
+      seen_objects.count(inclusion_class) > max_seen
+    else
+      false
+    end
+  end
+
+  def self.split_only_string(only_string)
+    only_array = []
+    offset = 0
+    position = 0
+    level = 0
+    loop do
+      str = only_string[Range.new(position, -1)]
+      match = str.match(/[,\[\]]/)
+      break unless match
+      start_pos, end_pos = match.offset(0)
+      if match[0] == "," && level.zero?
+        only_array << only_string[Range.new(offset, position + start_pos - 1)]
+        offset = position + end_pos
+      elsif match[0] == "["
+        level += 1
+      elsif match[0] == "]"
+        level -= 1
+      end
+      position += end_pos
+    end
+    only_array << only_string[Range.new(offset, -1)]
+  end
+end

--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -109,13 +109,11 @@ module PostSets
         else
           temp = ::Post.tag_match(tag_string).where("true /* PostSets::Post#posts:2 */").paginate(page, :count => post_count, :limit => per_page)
         end
-
-        # HACK: uploader_name is needed in api responses and in data-uploader attribs (visible to mods only).
-        temp = temp.includes(:uploader) if !is_random? && (format.to_sym != :html || CurrentUser.is_moderator?)
-
-        temp.each # hack to force rails to eager load
-        temp
       end
+    end
+
+    def posts=(set_posts)
+      @posts = set_posts
     end
 
     def unknown_post_count?

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -508,4 +508,8 @@ class Artist < ApplicationRecord
       "Deleted"
     end
   end
+
+  def self.available_includes
+    [:creator, :members, :urls, :wiki_page, :tag_alias, :tag]
+  end
 end

--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -144,4 +144,8 @@ class ArtistCommentary < ApplicationRecord
 
   extend SearchMethods
   include VersionMethods
+
+  def self.available_includes
+    [:post]
+  end
 end

--- a/app/models/artist_commentary_version.rb
+++ b/app/models/artist_commentary_version.rb
@@ -27,4 +27,8 @@ class ArtistCommentaryVersion < ApplicationRecord
   def unchanged_empty?(field)
     self[field].strip.empty? && (previous.nil? || previous[field].strip.empty?)
   end
+
+  def self.available_includes
+    [:post, :updater]
+  end
 end

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -126,4 +126,8 @@ class ArtistUrl < ApplicationRecord
   rescue Addressable::URI::InvalidURIError => error
     errors[:url] << "'#{uri}' is malformed: #{error}"
   end
+
+  def self.available_includes
+    [:artist]
+  end
 end

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -66,4 +66,8 @@ class ArtistVersion < ApplicationRecord
   def was_unbanned
     !is_banned && previous.is_banned
   end
+
+  def self.available_includes
+    [:updater, :artist]
+  end
 end

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -115,4 +115,8 @@ class Ban < ApplicationRecord
   def create_unban_mod_action
     ModAction.log(%{Unbanned <@#{user_name}>}, :user_unban)
   end
+
+  def self.available_includes
+    [:user, :banner]
+  end
 end

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -216,4 +216,8 @@ class BulkUpdateRequest < ApplicationRecord
       forum_topic_id
     )
   end
+
+  def self.available_includes
+    [:user, :forum_topic, :forum_post, :approver]
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -174,4 +174,10 @@ class Comment < ApplicationRecord
   def quoted_response
     DText.quote(body, creator.name)
   end
+
+  def self.available_includes
+    includes_array = [:post, :creator, :updater]
+    includes_array << :moderation_reports if CurrentUser.is_moderator?
+    includes_array
+  end
 end

--- a/app/models/comment_vote.rb
+++ b/app/models/comment_vote.rb
@@ -51,4 +51,8 @@ class CommentVote < ApplicationRecord
   def initialize_user
     self.user_id = CurrentUser.user.id
   end
+
+  def self.available_includes
+    [:comment, :user]
+  end
 end

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -195,4 +195,10 @@ class Dmail < ApplicationRecord
   def dtext_shortlink(key: false, **options)
     key ? "dmail ##{id}/#{self.key}" : "dmail ##{id}"
   end
+
+  def self.available_includes
+    includes_array = [:owner, :to, :from]
+    includes_array << :moderation_reports if CurrentUser.is_moderator?
+    includes_array
+  end
 end

--- a/app/models/dtext_link.rb
+++ b/app/models/dtext_link.rb
@@ -8,6 +8,10 @@ class DtextLink < ApplicationRecord
   scope :wiki_page, -> { where(model_type: "WikiPage") }
   scope :forum_post, -> { where(model_type: "ForumPost") }
 
+  def self.model_types
+    %w[WikiPage ForumPost]
+  end
+
   def self.new_from_dtext(dtext)
     links = []
 
@@ -70,5 +74,9 @@ class DtextLink < ApplicationRecord
     # postgres will raise an error if the link is more than 2712 bytes long
     # because it can't index values that take up more than 1/3 of an 8kb page.
     self.link_target = self.link_target.truncate(2048, omission: "")
+  end
+
+  def self.available_includes
+    [:model]
   end
 end

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -168,4 +168,8 @@ class FavoriteGroup < ApplicationRecord
   def viewable_by?(user)
     creator_id == user.id || is_public
   end
+
+  def self.available_includes
+    [:creator]
+  end
 end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -223,4 +223,10 @@ class ForumPost < ApplicationRecord
   def dtext_shortlink
     "forum ##{id}"
   end
+
+  def self.available_includes
+    includes_array = [:creator, :updater, :topic, :dtext_links, :votes, :tag_alias, :tag_implication, :bulk_update_request]
+    includes_array << :moderation_reports if CurrentUser.is_moderator?
+    includes_array
+  end
 end

--- a/app/models/forum_post_vote.rb
+++ b/app/models/forum_post_vote.rb
@@ -53,4 +53,8 @@ class ForumPostVote < ApplicationRecord
       raise
     end
   end
+
+  def self.available_includes
+    [:creator]
+  end
 end

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -177,4 +177,10 @@ class ForumTopic < ApplicationRecord
   def update_orignal_post
     original_post&.update_columns(:updater_id => updater.id, :updated_at => Time.now)
   end
+
+  def self.available_includes
+    includes_array = [:creator, :updater, :original_post]
+    includes_array << :moderation_reports if CurrentUser.is_moderator?
+    includes_array
+  end
 end

--- a/app/models/ip_address.rb
+++ b/app/models/ip_address.rb
@@ -49,4 +49,8 @@ class IpAddress < ApplicationRecord
   def html_data_attributes
     super & attributes.keys.map(&:to_sym)
   end
+
+  def self.available_includes
+    [:user, :model]
+  end
 end

--- a/app/models/ip_ban.rb
+++ b/app/models/ip_ban.rb
@@ -42,4 +42,8 @@ class IpBan < ApplicationRecord
     str += "/" + ip_addr.prefix.to_s if has_subnet?
     str
   end
+
+  def self.available_includes
+    [:creator]
+  end
 end

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -83,4 +83,8 @@ class ModAction < ApplicationRecord
   def initialize_creator
     self.creator_id = CurrentUser.id
   end
+
+  def self.available_includes
+    [:creator]
+  end
 end

--- a/app/models/moderation_report.rb
+++ b/app/models/moderation_report.rb
@@ -19,6 +19,10 @@ class ModerationReport < ApplicationRecord
     !Rails.env.production?
   end
 
+  def self.model_types
+    %w[User Dmail Comment ForumPost]
+  end
+
   def forum_topic_title
     "Reports requiring moderation"
   end
@@ -82,5 +86,9 @@ class ModerationReport < ApplicationRecord
     q = q.search_attributes(params, :model_type, :model_id, :creator_id)
 
     q.apply_default_order(params)
+  end
+
+  def self.available_includes
+    [:creator, :model]
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -158,4 +158,8 @@ class Note < ApplicationRecord
       end
     end
   end
+
+  def self.available_includes
+    [:creator, :post]
+  end
 end

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -44,4 +44,8 @@ class NoteVersion < ApplicationRecord
   def was_undeleted
     is_active && !previous.is_active
   end
+
+  def self.available_includes
+    [:updater, :note, :post]
+  end
 end

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -312,4 +312,8 @@ class Pool < ApplicationRecord
       errors[:base] << "You cannot removes posts from pools within the first week of sign up"
     end
   end
+
+  def self.available_includes
+    [:creator]
+  end
 end

--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -148,4 +148,8 @@ class PoolArchive < ApplicationRecord
   def pretty_name
     name.tr("_", " ")
   end
+
+  def self.available_includes
+    [:updater, :pool]
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1787,4 +1787,11 @@ class Post < ApplicationRecord
 
     save
   end
+
+  def self.available_includes
+    includes_array = [:uploader, :updater, :approver, :parent, :upload, :artist_commentary, :flags, :appeals, :notes, :comments, :children, :approvals, :replacements]
+    includes_array << :moderation_reports if CurrentUser.is_moderator?
+    includes_array << :disapprovals if CurrentUser.user.is_approver?
+    includes_array
+  end
 end

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -62,4 +62,8 @@ class PostAppeal < ApplicationRecord
   def appeal_count_for_creator
     creator.post_appeals.recent.count
   end
+
+  def self.available_includes
+    [:creator, :post]
+  end
 end

--- a/app/models/post_approval.rb
+++ b/app/models/post_approval.rb
@@ -40,4 +40,8 @@ class PostApproval < ApplicationRecord
     q = q.search_attributes(params, :user, :post)
     q.apply_default_order(params)
   end
+
+  def self.available_includes
+    [:user, :post]
+  end
 end

--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -274,5 +274,9 @@ class PostArchive < ApplicationRecord
     super + [:obsolete_added_tags, :obsolete_removed_tags, :unchanged_tags, :updater_name]
   end
 
+  def self.available_includes
+    [:updater, :post]
+  end
+
   memoize :previous, :tag_array, :changes, :added_tags_with_fields, :removed_tags_with_fields, :obsolete_removed_tags, :obsolete_added_tags, :unchanged_tags
 end

--- a/app/models/post_disapproval.rb
+++ b/app/models/post_disapproval.rb
@@ -67,4 +67,8 @@ class PostDisapproval < ApplicationRecord
       end
     end
   end
+
+  def self.available_includes
+    [:user, :post]
+  end
 end

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -155,7 +155,7 @@ class PostFlag < ApplicationRecord
   end
 
   def uploader_id
-    @uploader_id ||= Post.find(post_id).uploader_id
+    post.uploader_id
   end
 
   def not_uploaded_by?(userid)

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -161,4 +161,10 @@ class PostFlag < ApplicationRecord
   def not_uploaded_by?(userid)
     uploader_id != userid
   end
+
+  def self.available_includes
+    includes_array = [:post]
+    includes_array << :creator if CurrentUser.user.is_moderator?
+    includes_array
+  end
 end

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -33,4 +33,8 @@ class PostReplacement < ApplicationRecord
     tags = tags.map { |tag| "-#{tag}" }
     tags.join(" ")
   end
+
+  def self.available_includes
+    [:creator, :post]
+  end
 end

--- a/app/models/post_vote.rb
+++ b/app/models/post_vote.rb
@@ -68,4 +68,8 @@ class PostVote < ApplicationRecord
       1
     end
   end
+
+  def self.available_includes
+    [:user, :post]
+  end
 end

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -171,4 +171,8 @@ class SavedSearch < ApplicationRecord
   def disable_labels=(value)
     CurrentUser.update(disable_categorized_saved_searches: true) if value.to_s.truthy?
   end
+
+  def self.available_includes
+    [:user]
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -918,6 +918,10 @@ class Tag < ApplicationRecord
     Post.tag_match(name)
   end
 
+  def self.available_includes
+    [:wiki_page, :artist, :antecedent_alias, :consequent_aliases, :antecedent_implications, :consequent_implications]
+  end
+
   include ApiMethods
   include CountMethods
   include CategoryMethods

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -219,6 +219,10 @@ class TagRelationship < ApplicationRecord
     )
   end
 
+  def self.available_includes
+    [:creator, :approver, :forum_post, :forum_topic, :antecedent_tag, :consequent_tag, :antecedent_wiki, :consequent_wiki]
+  end
+
   extend SearchMethods
   include MessageMethods
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -247,4 +247,8 @@ class Upload < ApplicationRecord
   def upload_as_pending?
     as_pending.to_s.truthy?
   end
+
+  def self.available_includes
+    [:uploader, :post]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -754,4 +754,8 @@ class User < ApplicationRecord
   def dtext_shortlink(**options)
     "<@#{name}>"
   end
+
+  def self.available_includes
+    [:inviter]
+  end
 end

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -85,4 +85,8 @@ class UserFeedback < ApplicationRecord
   def editable_by?(editor)
     (editor.is_moderator? && editor != user) || (creator == editor && !is_deleted?)
   end
+
+  def self.available_includes
+    [:creator, :user]
+  end
 end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -250,4 +250,8 @@ class WikiPage < ApplicationRecord
       title
     end
   end
+
+  def self.available_includes
+    [:tag, :artist, :dtext_links]
+  end
 end

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -54,4 +54,8 @@ class WikiPageVersion < ApplicationRecord
   def category_name
     Tag.category_for(title)
   end
+
+  def self.available_includes
+    [:updater, :wiki_page, :artist]
+  end
 end

--- a/app/views/favorite_groups/index.html.erb
+++ b/app/views/favorite_groups/index.html.erb
@@ -7,7 +7,7 @@
       <%= f.submit "Search" %>
     <% end %>
 
-    <%= table_for @favorite_groups.includes(:creator), width: "100%" do |t| %>
+    <%= table_for @favorite_groups, width: "100%" do |t| %>
       <% t.column "Name", {width: "60%"} do |favgroup| %>
         <%= link_to favgroup.pretty_name, favorite_group_path(favgroup) %>
         <% if favgroup.post_count > CurrentUser.user.per_page %>


### PR DESCRIPTION
The only string works much the same as before with its comma separation, though nested attributes are now indicated with square brackets. The following is an example of how it can be used.

`http://danbooru.donmai.us/artists.json?only=name,other_names,tag[post_count],urls[normalized_url]&limit=1`
```json
[
  {
    "name": "0_05kmgrn",
    "other_names": [
      "壱"
    ],
    "tag": {
      "post_count": 0
    },
    "urls": [
      {
        "normalized_url": "http://twitter.com/intent/user?user_id=1137791083331514369/"
      },
      {
        "normalized_url": "http://twitter.com/0_05kmgrn/"
      }
    ]
  }
]
```

As seen, the two nested terms are the values immediately preceding the square brackets, and the only parameters for those are the comma separated terms inside the square brackets.

No limit was placed on the depth of nesting, except for you can only include a model twice if and only if the model was the endpoint, after which no more nested terms are accepted. The reason for the double inclusion is an example from the artist URLs endpoint.

`http://danbooru.donmai.us/artist_urls.json?only=normalized_url,artist[name,other_names,tag[post_count],urls[normalized_url]]&limit=1`
```json
[
  {
    "normalized_url": "http://twitter.com/0_05kmgrn/",
    "artist": {
      "name": "0_05kmgrn",
      "other_names": [
        "壱"
      ],
      "tag": {
        "post_count": 0
      },
      "urls": [
        {
          "normalized_url": "http://twitter.com/intent/user?user_id=1137791083331514369/"
        },
        {
          "normalized_url": "http://twitter.com/0_05kmgrn/"
        }
      ]
    }
  }
]
```

In this case, the double inclusion allows a user to search for an artist URL, and get back all of the related artist URLs, while also specifying that it only wants the normalized URL and nothing else. This use case is an actual usage from the **Translate Pixiv Tags** userscript (https://github.com/evazion/translate-pixiv-tags).

The following is an example of a nested inclusion which exceeds the double inclusion, because the artist inclusion did not start out on the endpoint.

`http://danbooru.donmai.us/artist_urls.json?only=artist[urls[artist[id]]]&limit=1`
```json
[
  {
    "artist": {
      "urls": [
        {
          
        },
        {
          
        }
      ]
    }
  }
]
```

For forbidden items, these are the inclusions that should not be seen either because of their sensitivity (e.g. moderation reports), or because the number of associated items has the potential to be very large (e.g. forum posts). Comments for posts weren't included in this, as the number of comments for any one post wasn't thought to be high.

As a matter of adding this capability, all of the index inclusions were moved to the model. This also allows them to be used elsewhere if needed, and it also prevents inclusions from being added where they aren't needed, e.g. on specific formats.

Finally, this also fixes the issue for artist URLs where the only parameter was not working at all, due to the options generated by the base application record not being passed to the format block in the controller.