### PR TITLE
User: Use model counts instead of SQL queries

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -15,13 +15,13 @@
         <% end %>
       <% end %>
       <% t.column "Posts" do |user| %>
-        <%= link_to user.posts.count, posts_path(:tags => "user:#{user.name}") %>
+        <%= link_to user.post_upload_count, posts_path(:tags => "user:#{user.name}") %>
       <% end %>
       <% t.column "Deleted" do |user| %>
         <%= user.posts.deleted.count %>
       <% end %>
       <% t.column "Notes" do |user| %>
-        <%= link_to user.note_versions.count, note_versions_path(:search => {:updater_id => user.id}) %>
+        <%= link_to user.note_update_count, note_versions_path(:search => {:updater_id => user.id}) %>
       <% end %>
       <% t.column "Edits" do |user| %>
         <%= link_to user.post_update_count, post_versions_path(:search => {:updater_id => user.id}) %>


### PR DESCRIPTION
I noticed this the other day when working on the only parameter but didn't remember to include it in (plus it was unrelated to that PR).

I thought about how to get rid of the SQL queries for the deleted count, but there's really no good way to do it without adding another integer column on the **User** model, and it wouldn't be worth it because it's not really used anywhere else.