### PR TITLE
Show the same post results through HTML and the API

### DIFF
--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -7,7 +7,7 @@ class PostPresenter < Presenter
       return "<em>none</em>".html_safe
     end
 
-    if !options[:show_deleted] && post.is_deleted? && options[:tags] !~ /status:(?:all|any|deleted|banned)/ && !options[:raw]
+    if CurrentUser.hide_deleted_posts && !options[:show_deleted] && post.is_deleted? && options[:tags] !~ /status:(?:all|any|deleted|banned)/ && !options[:raw]
       return ""
     end
 

--- a/app/presenters/post_set_presenters/base.rb
+++ b/app/presenters/post_set_presenters/base.rb
@@ -19,7 +19,7 @@ module PostSetPresenters
     end
 
     def not_shown(post, options)
-      !options[:show_deleted] && post.is_deleted? && @post_set.tag_string !~ /status:(?:all|any|deleted|banned)/ && !@post_set.raw
+      CurrentUser.hide_deleted_posts && !options[:show_deleted] && post.is_deleted? && @post_set.tag_string !~ /status:(?:all|any|deleted|banned)/ && !@post_set.raw
     end
 
     def none_shown(options)


### PR DESCRIPTION
Fixes #4195.

- It also makes the hide deleted posts setting work as it is described in the settings menu.
    - "Remove deleted posts from search results"
    - I.e. deleted posts should only be removed when the deleted posts filter is on.
- Even with the deleted posts filter on, it can still be overridden with the **show_deleted** parameter.