### PR TITLE
Add cosplay related tags for other wikis

### DIFF
--- a/app/logical/related_tag_query.rb
+++ b/app/logical/related_tag_query.rb
@@ -46,10 +46,29 @@ class RelatedTagQuery
   end
 
   def other_wiki_pages
-    return [] unless Tag.category_for(query) == Tag.categories.copyright
+    if Tag.category_for(query) == Tag.categories.copyright
+      copyright_other_wiki_pages
+    elsif Tag.category_for(query) == Tag.categories.general
+      general_other_wiki_pages
+    else
+      []
+    end
+  end
 
-    other_wikis = DText.parse_wiki_titles(wiki_page&.body&.to_s).grep(/\Alist_of_/i)
-    other_wikis = other_wikis.map { |name| WikiPage.titled(name).first }
+  def copyright_other_wiki_pages
+    list_of_wikis = DText.parse_wiki_titles(wiki_page&.body&.to_s).grep(/\Alist_of_/i)
+    map_tags_to_wikis(list_of_wikis)
+  end
+
+  def general_other_wiki_pages
+    match = query.match(/(.+?)_\(cosplay\)/)
+    return [] unless match
+    map_tags_to_wikis([match[1]])
+  end
+
+  def map_tags_to_wikis(other_tags)
+    other_wikis = other_tags.map { |name| WikiPage.titled(name).first }
+    other_wikis = other_wikis.reject { |wiki| wiki.nil? }
     other_wikis = other_wikis.select { |wiki| wiki.tags.present? }
     other_wikis
   end


### PR DESCRIPTION
This queries the base tag when any `*_(cosplay) ` tag gets queried. Beforehand, if a user wanted to get the tags of the base tag (such as the costume), the user had to type out the base tag in addition to the `*_(cosplay)` tag. This is extra work for the user, plus it also wastes the current auto-implication capability where it automatically adds the base tag when the cosplay tag gets added.

Besides the above, it also fixes an existing issue when selecting other wikis, since if the `list_of_*` wiki does not actually exist, then the queried tag will generate an exception and not deliver any results.