### PR TITLE
fix leftover reference to Artist.notes

### DIFF
--- a/app/views/posts/partials/index/_excerpt.html.erb
+++ b/app/views/posts/partials/index/_excerpt.html.erb
@@ -3,9 +3,9 @@
 <div id="excerpt" style="display: none;">
   <% if post_set.artist.present? %>
     <% post_set.artist.tap do |artist| %>
-      <% unless artist.notes.blank? %>
+      <% unless artist.wiki_page.blank? %>
         <div class="prose">
-          <%= format_text(artist.notes) %>
+          <%= format_text(artist.wiki_page.body) %>
         </div>
       <% end %>
 


### PR DESCRIPTION
fixup ef3188a7fe33b300f322de91e635990d04b1ba7b

as it is now it complains about an "undefined method `notes' for #<Artist:0x0559f488>" when searching for an artist for me (on my instance of course)

similar change in original commit: https://github.com/danbooru/danbooru/commit/ef3188a7fe33b300f322de91e635990d04b1ba7b#diff-9f43d1c0ee59f857f7a54b37a798d7a4L8-R10

not sure if this is the correct way to fix this but at least it doesn't throw an error anymore

~~I can't guarantee I haven't somehow made a mistake again when copying into the web editor (easier this way)~~