### PR TITLE
Add BUR counters to forum topics index

### DIFF
--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -28,7 +28,7 @@ class ForumTopicsController < ApplicationController
     if request.format.atom?
       @forum_topics = @forum_topics.includes(:creator, :original_post)
     elsif request.format.html?
-      @forum_topics = @forum_topics.includes(:creator, :updater, :forum_topic_visit_by_current_user)
+      @forum_topics = @forum_topics.includes(:creator, :updater, :forum_topic_visit_by_current_user, :bulk_update_requests)
     end
 
     respond_with(@forum_topics)

--- a/app/helpers/forum_topics_helper.rb
+++ b/app/helpers/forum_topics_helper.rb
@@ -10,4 +10,12 @@ module ForumTopicsHelper
   def new_forum_topic?(topic, read_forum_topics)
     !read_forum_topics.map(&:id).include?(topic.id)
   end
+
+  def bulk_update_request_counts(topic)
+    requests = []
+    requests << %(<span class="topic-pending-burs">Pending: #{topic.pending_bur_count}</span>) if topic.pending_bur_count.positive?
+    requests << %(<span class="topic-approved-burs">Approved: #{topic.approved_bur_count}</span>) if topic.approved_bur_count.positive?
+    requests << %(<span class="topic-rejected-burs">Rejected: #{topic.rejected_bur_count}</span>) if topic.rejected_bur_count.positive?
+    requests.join(" | ").html_safe
+  end
 end

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -18,6 +18,7 @@ class ForumTopic < ApplicationRecord
   has_one :forum_topic_visit_by_current_user, -> { where(user_id: CurrentUser.id) }, class_name: "ForumTopicVisit"
   has_many :moderation_reports, through: :posts
   has_one :original_post, -> {order("forum_posts.id asc")}, class_name: "ForumPost", foreign_key: "topic_id", inverse_of: :topic
+  has_many :bulk_update_requests, :foreign_key => "forum_topic_id"
 
   before_validation :initialize_is_deleted, :on => :create
   validates_presence_of :title
@@ -174,6 +175,18 @@ class ForumTopic < ApplicationRecord
 
   def update_orignal_post
     original_post&.update_columns(:updater_id => updater.id, :updated_at => Time.now)
+  end
+
+  def pending_bur_count
+    bulk_update_requests.select {|request| request.status == "pending"}.size
+  end
+
+  def approved_bur_count
+    bulk_update_requests.select {|request| request.status == "approved"}.size
+  end
+
+  def rejected_bur_count
+    bulk_update_requests.select {|request| request.status == "rejected"}.size
   end
 
   def self.available_includes

--- a/app/views/forum_topics/_listing.html.erb
+++ b/app/views/forum_topics/_listing.html.erb
@@ -22,13 +22,16 @@
       <span class="level-topic">(<%= User.level_string(topic.min_level).downcase %> only)</span>
     <% end %>
   <% end %>
-  <% t.column "Creator" do |topic| %>
+  <% t.column "BURs", width: "20%" do |topic| %>
+    <%= bulk_update_request_counts(topic) %>
+  <% end %>
+  <% t.column "Creator", width: "8%" do |topic| %>
     <%= link_to_user topic.creator %>
   <% end %>
-  <% t.column "Updated by" do |topic| %>
+  <% t.column "Updated by", width: "8%" do |topic| %>
     <%= link_to_user topic.updater %>
   <% end %>
-  <% t.column "Updated at" do |topic| %>
+  <% t.column "Updated at", width: "8%" do |topic| %>
     <%= compact_time topic.updated_at %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Fixes #2751.

A class for each BUR status type is supplied so that the user can style the counters themselves if they want to. The widths percentages were fine-tuned using up to 3 digits for all 3 values, so there should be plenty of room for growth.

On a side note, with this BUR counter scheme, the **[Approved]** and other markers that currently get prepended onto topics could be done away with. If that's something that is desired, then more commits can be added onto this PR, or it can be done as a separate PR/commits.

If such is the case, should all of the old topics titles be cleaned up to strip out those markers if they exist as well with a fixup script? It's true that there's no indication for failure with the BUR counters, however a forum post indicating such is already being added. Additionally, once a topic gets modified with such a marker, that marker can never be updated so it's not very effective now as it is.