### PR TITLE
Restrict note container resizing to embedded notes

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -174,9 +174,11 @@ let Note = {
       if (was_visible) {
         container.style.display = 'block';
       }
-      const $image = $("#image");
-      const percentage = 100 * ($image.width() / parseFloat($image.data('large-width')));
-      $(container).css('font-size', percentage + '%');
+      if (Note.embed) {
+        const $image = $("#image");
+        const percentage = 100 * ($image.width() / parseFloat($image.data('large-width')));
+        $(container).css('font-size', percentage + '%');
+      }
     },
 
     toggle_all: function() {


### PR DESCRIPTION
As mentioned by **Arcana55** on Danbooru ([forum #1234](https://danbooru.donmai.us/forum_posts/163316)), the note resizing is also affecting non-embedded-notes. This is because there was a missing embedded check in the scale all function.