### PR TITLE
Convert notes to use percentages instead of exact coordinates

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -131,7 +131,7 @@ let Note = {
       $note_box.on(
         "mouseover.danbooru mouseout.danbooru",
         function(e) {
-          if (Note.dragging) {
+          if (Note.dragging || Utility.test_max_width(660)) {
             return;
           }
 
@@ -163,12 +163,21 @@ let Note = {
         "click.danbooru",
         function (event) {
           const note_id = $note_box.data("id");
-          $(".note-box").removeClass("movable");
-          if (note_id === Note.move_id) {
-            Note.move_id = null;
+          if (!Utility.test_max_width(660)) {
+            $(".note-box").removeClass("movable");
+            if (note_id === Note.move_id) {
+              Note.move_id = null;
+            } else {
+              Note.move_id = note_id;
+              $note_box.addClass("movable");
+            }
+          } else if ($note_box.hasClass("viewing")) {
+            Note.Body.hide(note_id);
+            $note_box.removeClass("viewing");
           } else {
-            Note.move_id = note_id;
-            $note_box.addClass("movable");
+            $(".note-box").removeClass("viewing");
+            Note.Body.show(note_id);
+            $note_box.addClass("viewing");
           }
         }
       );

--- a/app/javascript/src/javascripts/posts.js.erb
+++ b/app/javascript/src/javascripts/posts.js.erb
@@ -33,13 +33,8 @@ Post.initialize_all = function() {
     this.initialize_favlist();
     this.initialize_post_sections();
     this.initialize_post_image_resize_links();
-    this.initialize_post_image_resize_to_window_link();
     this.initialize_recommended();
     this.initialize_ugoira_player();
-
-    if (CurrentUser.data("always-resize-images") || (Utility.meta("viewport") && (window.screen.width <= 660))) {
-      $("#image-resize-to-window-link").click();
-    }
   }
 
   if ($("#c-posts #a-show, #c-uploads #a-new").length) {
@@ -325,7 +320,6 @@ Post.expand_image = function(e) {
   $notice.children().eq(0).hide();
   $notice.children().eq(1).show(); // Loading message
   Note.Box.scale_all();
-  $image.data("scale-factor", 1);
   e.preventDefault();
 }
 
@@ -355,45 +349,6 @@ Post.initialize_post_image_resize_links = function() {
       }
     });
   }
-}
-
-Post.resize_image_to_window = function($img) {
-  var sidebar_width = 0;
-  var client_width = 0;
-
-  if (($img.data("scale-factor") === 1) || ($img.data("scale-factor") === undefined)) {
-    if ($(window).width() > 660) {
-      sidebar_width = $("#sidebar").width() || 0;
-      client_width = $(window).width() - sidebar_width - 75;
-    } else {
-      client_width = $(window).width() - 2;
-    }
-
-    if ($img.width() > client_width) {
-      var isVideo = $img.prop("tagName") === "VIDEO";
-      var width = isVideo ? $img.prop("width") : $img.data("original-width");
-      var height = isVideo ? $img.prop("height") : $img.data("original-height");
-      var ratio = client_width / width;
-      $img.data("scale-factor", ratio);
-      $img.css("width", width * ratio);
-      $img.css("height", height * ratio);
-      Post.resize_ugoira_controls();
-    }
-  } else {
-    $img.data("scale-factor", 1);
-    $img.width($img.data("original-width"));
-    $img.height($img.data("original-height"));
-    Post.resize_ugoira_controls();
-  }
-
-  Note.Box.scale_all();
-}
-
-Post.initialize_post_image_resize_to_window_link = function() {
-  $("#image-resize-to-window-link").on("click.danbooru", function(e) {
-    Post.resize_image_to_window($("#image"));
-    e.preventDefault();
-  });
 }
 
 Post.initialize_excerpt = function() {
@@ -460,6 +415,7 @@ Post.initialize_ugoira_player = function() {
     let file_url = $("#image-container").data("file-url");
 
     Ugoira.create_player(content_type, frames, file_url);
+    $(window).on("resize.danbooru.ugoira_scale", Post.resize_ugoira_controls);
   }
 };
 

--- a/app/javascript/src/javascripts/posts.js.erb
+++ b/app/javascript/src/javascripts/posts.js.erb
@@ -302,7 +302,7 @@ Post.initialize_favlist = function() {
 
 Post.expand_image = function(e) {
   if (Utility.test_max_width(660)) {
-    // just do the default behavior
+    // Do the default behavior (navigate to image)
     return;
   }
 
@@ -316,6 +316,7 @@ Post.expand_image = function(e) {
   $image.on("load.danbooru", function() {
     $image.css("animation", "sharpen 0.5s forwards");
     $notice.hide();
+    $("#post-option-view-large").show();
   });
   $notice.children().eq(0).hide();
   $notice.children().eq(1).show(); // Loading message
@@ -323,29 +324,39 @@ Post.expand_image = function(e) {
   e.preventDefault();
 }
 
+Post.view_large = function(e) {
+  if (Utility.test_max_width(660)) {
+    // Do the default behavior (navigate to image)
+    return;
+  }
+
+  var $image = $("#image");
+  var $notice = $("#image-resize-notice");
+  $image.attr("src", $("#image-container").data("large-file-url"));
+  $image.css("filter", "blur(8px)");
+  $image.width($image.data("large-width"));
+  $image.height($image.data("large-height"));
+  $notice.children().eq(0).show();
+  $notice.children().eq(1).hide(); // Loading message
+  $image.on("load.danbooru", function() {
+    $image.css("animation", "sharpen 0.5s forwards");
+    $notice.show();
+    $("#post-option-view-large").hide();
+  });
+  Note.Box.scale_all();
+  e.preventDefault();
+}
+
 Post.initialize_post_image_resize_links = function() {
   $("#image-resize-link").on("click.danbooru", Post.expand_image);
+  $("#image-view-large-link").on("click.danbooru", Post.view_large);
 
   if ($("#image-resize-notice").length) {
     Utility.keydown("v", "resize", function(e) {
       if ($("#image-resize-notice").is(":visible")) {
         $("#image-resize-link").click();
       } else {
-        var $image = $("#image");
-        var $notice = $("#image-resize-notice");
-        $image.attr("src", $("#image-container").data("large-file-url"));
-        $image.css("filter", "blur(8px)");
-        $image.width($image.data("large-width"));
-        $image.height($image.data("large-height"));
-        $notice.children().eq(0).show();
-        $notice.children().eq(1).hide(); // Loading message
-        $image.on("load.danbooru", function() {
-          $image.css("animation", "sharpen 0.5s forwards");
-          $notice.show();
-        });
-        Note.Box.scale_all();
-        $image.data("scale-factor", 1);
-        e.preventDefault();
+        $("#image-view-large-link").click();
       }
     });
   }

--- a/app/javascript/src/styles/base/040_colors.css
+++ b/app/javascript/src/styles/base/040_colors.css
@@ -113,11 +113,10 @@
   --note-body-background: #FFE;
   --note-body-text-color: var(--text-color);
   --note-body-border: 1px solid black;
-  --note-box-border: 1px solid white;
-  --note-box-background: transparent;
-  --note-box-inner-border: 1px solid black;
-  --unsaved-note-box-inner-border: 1px solid red;
-  --movable-note-box-inner-border: 1px solid green;
+  --note-box-border: 1px solid black;
+  --note-box-shadow: 0 0 0 1px white;
+  --unsaved-note-box-border: 1px solid red;
+  --movable-note-box-border: 1px solid green;
   --note-preview-border: 1px solid red;
   --note-preview-background: white;
   --note-highlight-color: blue;

--- a/app/javascript/src/styles/specific/notes.scss
+++ b/app/javascript/src/styles/specific/notes.scss
@@ -1,6 +1,5 @@
 div#note-container {
   position: absolute;
-  z-index: 50;
 
   div.note-body {
     position: absolute;
@@ -71,6 +70,10 @@ div#note-container {
   }
 
   div.note-box {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
     position: absolute;
     border: var(--note-box-border);
     min-width: 5px;
@@ -78,24 +81,17 @@ div#note-container {
     width: 100px;
     height: 100px;
     cursor: move;
-    background: var(--note-box-background);
+    background: var(--note-body-background);
     line-height: 1.25;
     opacity: 0.5;
+    z-index: 100;
 
-    div.note-box-inner-border {
-      border: var(--note-box-inner-border);
-      background: var(--note-body-background);
-    }
-
-    div.note-box-inner-border.unsaved {
-      border: var(--unsaved-note-box-inner-border);
+    &.unsaved {
+      border: var(--unsaved-note-box-border);
     }
 
     &.movable {
-      div.note-box-inner-border,
-      div.note-box-inner-border.unsaved {
-        border: var(--movable-note-box-inner-border);
-      }
+      border: var(--movable-note-box-border);
     }
 
     &.embedded {
@@ -105,6 +101,7 @@ div#note-container {
 
       &.hovering {
         border: var(--note-box-border);
+        box-shadow: var(--note-box-shadow);
 
         &.editing,
         &.movable {
@@ -114,10 +111,6 @@ div#note-container {
         div.ui-resizable-handle {
           display: block;
         }
-
-        div.note-box-inner-border {
-          border: var(--note-box-inner-border);
-        }
       }
 
       &.editing,
@@ -125,28 +118,17 @@ div#note-container {
         opacity: 0.4;
       }
 
+      &.unsaved,
+      &.out-of-bounds {
+        border: var(--unsaved-note-box-border);
+      }
+
       &.movable {
-        div.note-box-inner-border,
-        div.note-box-inner-border.unsaved,
-        div.note-box-inner-border.out-of-bounds {
-          border: var(--movable-note-box-inner-border);
-        }
+        border: var(--movable-note-box-border);
       }
 
       div.ui-resizable-handle {
         display: none;
-      }
-
-      div.note-box-inner-border {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-        border: 1px solid transparent;
-      }
-
-      div.note-box-inner-border.unsaved,
-      div.note-box-inner-border.out-of-bounds {
-        border: var(--unsaved-note-box-inner-border);
       }
     }
 
@@ -162,6 +144,7 @@ div#note-preview {
   opacity: 0.6;
   display: none;
   background: var(--note-preview-background);
+  z-index: 100;
 }
 
 div.note-edit-dialog {

--- a/app/javascript/src/styles/specific/notes.scss
+++ b/app/javascript/src/styles/specific/notes.scss
@@ -16,7 +16,7 @@ div#note-container {
   }
 
   div.note-body, div.note-box.embedded div.note-box-inner-border {
-    h1, h2, h3, h4, h5, h6, a, span, div, blockquote, br, p, ul, li, ol, em, strong, small, big, b, i, font, u, s, code, center {
+    h1, h2, h3, h4, h5, h6, a, span, div, blockquote, p, ul, li, ol, em, strong, small, big, b, i, font, u, s, code, center {
       line-height: 1.25;
     }
 

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -341,6 +341,12 @@ div#c-posts {
       margin: 1em 0 0.5em;
     }
 
+    /* This ensures the image appears above the note container, but beneath any notes. */
+    #image {
+      position: relative;
+      z-index: 50;
+    }
+
     .pool-name, .search-name {
       word-wrap: break-word;
     }

--- a/app/javascript/src/styles/specific/z_responsive.scss
+++ b/app/javascript/src/styles/specific/z_responsive.scss
@@ -92,6 +92,11 @@
     }
   }
 
+  img#image {
+    max-width: 100%;
+    height: auto;
+  }
+
   .user-disable-cropped-false {
     article.post-preview {
       width: 33.3%;

--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -1,4 +1,9 @@
 <ul>
+  <% if post.visible? && post.has_large? && !post.is_ugoira? %>
+    <li id="post-option-view-large" style="<%= CurrentUser.default_image_size == "original" ? "" : "display: none;" %>">
+      <%= link_to "View large", post.tagged_large_file_url, id: "image-view-large-link" %>
+    </li>
+  <% end %>
   <li id="post-option-find-similar">
     <%= link_to "Find similar", iqdb_queries_path(post_id: post.id) %>
   </li>

--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -1,7 +1,4 @@
 <ul>
-  <li id="post-option-resize-to-window">
-    <%= link_to "Resize to window", "#", id: "image-resize-to-window-link" %>
-  </li>
   <li id="post-option-find-similar">
     <%= link_to "Find similar", iqdb_queries_path(post_id: post.id) %>
   </li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -52,7 +52,6 @@
         </div>
 
         <%= f.input :style_usernames, :as => :select, :label => "Colored usernames", :hint => "Color users according to their user level", :include_blank => false, :collection => [["Yes", "true"], ["No", "false"]] %>
-        <%= f.input :always_resize_images, :as => :select, :include_blank => false, :label => "Fit images to window", :hint => "Make images fit screen width by default", :collection => [["Yes", "true"], ["No", "false"]] %>
         <%= f.input :enable_post_navigation, :as => :select, :include_blank => false, :label => "Enable keyboard shortcuts", :hint => "Enable keyboard shortcuts", :collection => [["Yes", "true"], ["No", "false"]] %>
         <%= f.input :enable_sequential_post_navigation, :as => :select, :label => "Enable post navigation", :hint => "Show prev/next links when viewing a post", :include_blank => false, :collection => [["Yes", "true"], ["No", "false"]] %>
         <%= f.input :new_post_navigation_layout, :as => :select, :label => "Navigation bar position", :include_blank => false, :collection => [["Below", "true"], ["Above", "false"]], :hint => "When browsing pools or posts, place navigation links above or below the image" %>


### PR DESCRIPTION
Created this PR based on prior discussions on Discord with @evazion about the reversion of a commit with 4b9a297. Basically, the note boxes were converted from using exact coordinates into using percentages instead. This facilitates a much easier resizing of the note boxes, and allows for much of the Javascript resizing code to be removed. The only resizing required now is on the note container itself, needing its size updated to match the underlying image, as well as updating the font size based on the size ratio.

To accomplish this, several style elements had to be changed or removed. All style elements were removed from the inner box, both to unify all style elements on the note box itself, but also because any height or width styles set on the inner box heavily conflicted with getting the notes to work correctly. Now the inner note box just acts as a container for the note body of HTML code. The display of `table-cell` was also changed to `flex` for similar reasons as well, and so the centering styles were also changed to match that new display style. Since the note container now has a size, it had its z-index removed and a z-index added to the note boxes and images. This allows the note boxes to still be seen while still facilitating the user being able to right click or directly interact with the underlying image itself.

The image now automatically resizes to fill the width of the screen in responsive mode. Due to this, the "Always resize image" option and links were removed, since it's no longer needed for responsive mode, and the regular mode already has mechanisms in place to swap between the large and original images. The value was left in place though in the model so that the bit position can be reused in the future.

Previously, it was only possible to switch between the large and original image sizes using the keyboard hotkey. To fix this, a "View large" link was placed in the post **Options** section (so that it doesn't conflict with the image when in full size), and it performs the opposite function that the "View original" link does. The link is also capable of downloading the large size of image if needed.

Finally, this PR fixes an issue on Firefox with the `<br>` elements in the note body in which the **line-height** of the outer elements was made useless by the use of any `<br>` elements or carriage returns (which are converted to `<br>` elements). Currently, the only way to overcome this is to apply a **line-height** style to every single one of the `<br>` elements, which is very laborious plus it adds clutter to the note body.