### PR TITLE
Related tag enhancements

### DIFF
--- a/app/controllers/related_tags_controller.rb
+++ b/app/controllers/related_tags_controller.rb
@@ -4,9 +4,10 @@ class RelatedTagsController < ApplicationController
   def show
     query = params[:query] || search_params[:query]
     category = params[:category] || search_params[:category]
+    type = params[:type] || search_params[:type]
     limit = params[:limit]
 
-    @query = RelatedTagQuery.new(query: query, category: category, user: CurrentUser.user, limit: limit)
+    @query = RelatedTagQuery.new(query: query, category: category, type: type, user: CurrentUser.user, limit: limit)
     respond_with(@query)
   end
 end

--- a/app/controllers/related_tags_controller.rb
+++ b/app/controllers/related_tags_controller.rb
@@ -4,8 +4,9 @@ class RelatedTagsController < ApplicationController
   def show
     query = params[:query] || search_params[:query]
     category = params[:category] || search_params[:category]
+    limit = params[:limit]
 
-    @query = RelatedTagQuery.new(query: query, category: category, user: CurrentUser.user)
+    @query = RelatedTagQuery.new(query: query, category: category, user: CurrentUser.user, limit: limit)
     respond_with(@query)
   end
 end

--- a/app/logical/related_tag_query.rb
+++ b/app/logical/related_tag_query.rb
@@ -26,6 +26,14 @@ class RelatedTagQuery
     end
   end
 
+  def tags_overlap
+    if query =~ /\*/
+      {}
+    else
+      tags.map { |v| [v.name, v.overlap_count] }.to_h
+    end
+  end
+
   # Returns the top 20 most frequently added tags within the last 20 edits made by the user in the last hour.
   def recent_tags(since: 1.hour.ago, max_edits: 20, max_tags: 20)
     return [] unless user.present? && PostVersion.enabled?
@@ -78,6 +86,7 @@ class RelatedTagQuery
       query: query,
       category: category,
       tags: tags_with_categories(tags.map(&:name)),
+      tags_overlap: tags_overlap,
       wiki_page_tags: tags_with_categories(wiki_page_tags),
       other_wikis: other_wiki_pages.map { |wiki| [wiki.title, tags_with_categories(wiki.tags)] }.to_h
     }

--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -71,6 +71,10 @@ class TagCategory
     def short_name_regex
       @@short_name_regex ||= short_name_list.join("|")
     end
+
+    def category_ids_regex
+      @@category_ids_regex ||= "[#{category_ids.join("")}]"
+    end
   end
 
   extend Mappings

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -87,7 +87,14 @@ class Tag < ApplicationRecord
     end
 
     def value_for(string)
-      TagCategory.mapping[string.to_s.downcase] || 0
+      norm_string = string.to_s.downcase
+      if norm_string =~ /#{TagCategory.category_ids_regex}/
+        norm_string.to_i
+      elsif TagCategory.mapping[string.to_s.downcase]
+        TagCategory.mapping[string.to_s.downcase]
+      else
+        0
+      end
     end
   end
 

--- a/test/unit/related_tag_calculator_test.rb
+++ b/test/unit/related_tag_calculator_test.rb
@@ -30,7 +30,7 @@ class RelatedTagCalculatorTest < ActiveSupport::TestCase
         create(:post, tag_string: "aaa bbb ccc")
         create(:post, tag_string: "aaa bbb")
 
-        assert_equal(%w[aaa bbb ccc ddd], RelatedTagCalculator.frequent_tags_for_search("aaa").pluck(:name))
+        assert_equal(%w[aaa bbb ccc ddd], RelatedTagCalculator.frequent_tags_for_search("aaa")[0].pluck(:name))
       end
 
       should "calculate the most frequent tags for a multiple tag search" do
@@ -38,7 +38,7 @@ class RelatedTagCalculatorTest < ActiveSupport::TestCase
         create(:post, tag_string: "aaa bbb ccc ddd")
         create(:post, tag_string: "aaa eee fff")
 
-        assert_equal(%w[aaa bbb ccc ddd], RelatedTagCalculator.frequent_tags_for_search("aaa bbb").pluck(:name))
+        assert_equal(%w[aaa bbb ccc ddd], RelatedTagCalculator.frequent_tags_for_search("aaa bbb")[0].pluck(:name))
       end
 
       should "calculate the most frequent tags with a category constraint" do
@@ -46,8 +46,8 @@ class RelatedTagCalculatorTest < ActiveSupport::TestCase
         create(:post, tag_string: "aaa bbb art:ccc")
         create(:post, tag_string: "aaa bbb")
 
-        assert_equal(%w[aaa bbb], RelatedTagCalculator.frequent_tags_for_search("aaa", category: Tag.categories.general).pluck(:name))
-        assert_equal(%w[ccc], RelatedTagCalculator.frequent_tags_for_search("aaa", category: Tag.categories.artist).pluck(:name))
+        assert_equal(%w[aaa bbb], RelatedTagCalculator.frequent_tags_for_search("aaa", category: Tag.categories.general)[0].pluck(:name))
+        assert_equal(%w[ccc], RelatedTagCalculator.frequent_tags_for_search("aaa", category: Tag.categories.artist)[0].pluck(:name))
       end
     end
 
@@ -57,9 +57,9 @@ class RelatedTagCalculatorTest < ActiveSupport::TestCase
         create(:post, tag_string: "1girl solo", rating: "q")
         create(:post, tag_string: "1girl 1boy", rating: "q")
 
-        assert_equal(%w[1girl solo 1boy], RelatedTagCalculator.similar_tags_for_search("1girl").pluck(:name))
-        assert_equal(%w[1girl 1boy solo], RelatedTagCalculator.similar_tags_for_search("rating:q").pluck(:name))
-        assert_equal(%w[solo 1girl], RelatedTagCalculator.similar_tags_for_search("solo").pluck(:name))
+        assert_equal(%w[1girl solo 1boy], RelatedTagCalculator.similar_tags_for_search("1girl")[0].pluck(:name))
+        assert_equal(%w[1girl 1boy solo], RelatedTagCalculator.similar_tags_for_search("rating:q")[0].pluck(:name))
+        assert_equal(%w[solo 1girl], RelatedTagCalculator.similar_tags_for_search("solo")[0].pluck(:name))
       end
 
       should "calculate the similar tags for an aliased tag" do
@@ -67,7 +67,7 @@ class RelatedTagCalculatorTest < ActiveSupport::TestCase
         create(:post, tag_string: "bunny dog")
         create(:post, tag_string: "bunny cat")
 
-        assert_equal(%w[bunny cat dog], RelatedTagCalculator.similar_tags_for_search("rabbit").pluck(:name))
+        assert_equal(%w[bunny cat dog], RelatedTagCalculator.similar_tags_for_search("rabbit")[0].pluck(:name))
       end
     end
   end


### PR DESCRIPTION
Fixes #4321. It also adds some other enhancements.

1. Included tag overlap
    
    This is a separate hash so that the values can be quickly looked up. There is no extra processing involved since the SQL queries already adds that information to the tag instances. There's no reason and no easy way to add those for pattern matching, so those types only return a blank hash.

2. Variable limit

    The default is still 25.

3. Settable type

   The user can now specify which type they want to use, regardless of the format of the query or whether a category is specified or not. It also fixes it where the category type wasn't settable for pattern matching.

4.  Included sample count

    This is the amount of samples that were actually used in the calculations. Since the sample size is not always the maximum, the query tag is not always included in the results, and the query term is not always a tag, it helps to know what the population size used was to help determine the percentage of the tag overlap.

5. Facilitate numerical category inputs

    So 0, 1 ,3, 4 and 5 can now be used as well as any of the string variants. Although currently only used by the related tag endpoint in such a way, it could potentially be used in a variety of other endpoints.