### PR TITLE
Update blacklist controls

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -118,23 +118,27 @@ Blacklist.apply = function() {
   var count = 0
 
   $.each(this.posts(), function(i, post) {
-    var post_count = 0;
-    $.each(Blacklist.entries, function(j, entry) {
-      if (Blacklist.post_match(post, entry)) {
-        entry.hits += 1;
-        count += 1;
-        post_count += 1;
-      }
-    });
-    if (post_count > 0) {
-      Blacklist.post_hide(post);
-    } else {
-      Blacklist.post_unhide(post);
-    }
+    count += Blacklist.apply_post(post);
   });
 
   return count;
 }
+
+Blacklist.apply_post = function(post) {
+  var post_count = 0;
+  $.each(Blacklist.entries, function(j, entry) {
+    if (Blacklist.post_match(post, entry)) {
+      entry.hits += 1;
+      post_count += 1;
+    }
+  });
+  if (post_count > 0) {
+    Blacklist.post_hide(post);
+  } else {
+    Blacklist.post_unhide(post);
+  }
+  return post_count;
+};
 
 Blacklist.posts = function() {
   return $(".post-preview, #image-container, #c-comments .post, .mod-queue-preview.post-preview");

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -15,8 +15,7 @@ Blacklist.parse_entry = function(string) {
     "hits": 0,
     "min_score": null
   };
-  var matches = string.match(/\S+/g) || [];
-  $.each(matches, function(i, tag) {
+  Utility.regexp_split(string).forEach(function(tag) {
     if (tag.charAt(0) === '-') {
       entry.exclude.push(tag.slice(1));
     } else if (tag.charAt(0) === '~') {
@@ -169,11 +168,11 @@ Blacklist.post_match = function(post, entry) {
   var score = parseInt($post.attr("data-score"));
   var score_test = entry.min_score === null || score < entry.min_score;
 
-  var tags = String($post.attr("data-tags")).match(/\S+/g) || [];
-  tags = tags.concat(String($post.attr("data-pools")).match(/\S+/g) || []);
+  var tags = Utility.regexp_split($post.attr("data-tags"));
+  tags.push(...Utility.regexp_split($post.attr("data-pools")));
   tags.push("rating:" + $post.data("rating"));
   tags.push("uploaderid:" + $post.attr("data-uploader-id"));
-  $.each(String($post.data("flags")).match(/\S+/g) || [], function(i, v) {
+  Utility.regexp_split($post.data("flags")).forEach(function(v) {
     tags.push("status:" + v);
   });
 

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -84,28 +84,44 @@ Blacklist.update_sidebar = function() {
   $("#blacklist-box").show();
 }
 
+Blacklist.disable_all = function() {
+  Blacklist.entries.forEach(function(entry) {
+    entry.disabled = true;
+  });
+  // There is no need to process the blacklist when disabling
+  Blacklist.posts().removeClass("blacklisted-active");
+  $("#disable-all-blacklists").hide();
+  $("#re-enable-all-blacklists").show();
+  $("#blacklist-list a").addClass("blacklisted-inactive");
+}
+
+Blacklist.enable_all = function() {
+  Blacklist.entries.forEach(function(entry) {
+    entry.disabled = false;
+  });
+  Blacklist.apply();
+  $("#disable-all-blacklists").show();
+  $("#re-enable-all-blacklists").hide();
+  $("#blacklist-list a").removeClass("blacklisted-inactive");
+}
+
 Blacklist.initialize_disable_all_blacklists = function() {
   if (Cookie.get("dab") === "1") {
-    $("#re-enable-all-blacklists").show();
-    $("#blacklist-list a:not(.blacklisted-active)").click();
-    Blacklist.apply();
+    Blacklist.disable_all();
   } else {
+    // The blacklist has already been processed by this point
     $("#disable-all-blacklists").show()
   }
 
   $("#disable-all-blacklists").on("click.danbooru", function(e) {
-    $("#disable-all-blacklists").hide();
-    $("#re-enable-all-blacklists").show();
     Cookie.put("dab", "1");
-    $("#blacklist-list a:not(.blacklisted-active)").click();
+    Blacklist.disable_all();
     e.preventDefault();
   });
 
   $("#re-enable-all-blacklists").on("click.danbooru", function(e) {
-    $("#disable-all-blacklists").show();
-    $("#re-enable-all-blacklists").hide();
     Cookie.put("dab", "0");
-    $("#blacklist-list a.blacklisted-active").click();
+    Blacklist.enable_all();
     e.preventDefault();
   });
 }

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -41,16 +41,17 @@ Blacklist.parse_entries = function() {
 }
 
 Blacklist.toggle_entry = function(e) {
-  var tags = $(e.target).text();
+  var $link = $(e.target);
+  var tags = $link.text();
   var match = $.grep(Blacklist.entries, function(entry, i) {
     return entry.tags === tags;
   })[0];
   if (match) {
     match.disabled = !match.disabled;
     if (match.disabled) {
-      Blacklist.post_hide(e.target);
+      $link.addClass("blacklisted-inactive");
     } else {
-      Blacklist.post_unhide(e.target);
+      $link.removeClass("blacklisted-inactive");
     }
   }
   Blacklist.apply();
@@ -183,7 +184,7 @@ Blacklist.post_match = function(post, entry) {
 
 Blacklist.post_hide = function(post) {
   var $post = $(post);
-  $post.addClass("blacklisted").addClass("blacklisted-active");
+  $post.addClass("blacklisted blacklisted-active");
 
   var $video = $post.find("video").get(0);
   if ($video) {

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -34,7 +34,7 @@ Blacklist.parse_entries = function() {
   var entries = (Utility.meta("blacklisted-tags") || "nozomiisthebestlovelive").replace(/(rating:[qes])\w+/ig, "$1").toLowerCase().split(/,/);
   entries = entries.filter(e => e.trim() !== "");
 
-  $.each(entries, function(i, tags) {
+  entries.forEach(function(tags) {
     var entry = Blacklist.parse_entry(tags);
     Blacklist.entries.push(entry);
   });
@@ -59,7 +59,7 @@ Blacklist.toggle_entry = function(e) {
 }
 
 Blacklist.update_sidebar = function() {
-  $.each(this.entries, function(i, entry) {
+  Blacklist.entries.forEach(function(entry) {
     if (entry.hits === 0) {
       return;
     }
@@ -127,13 +127,13 @@ Blacklist.initialize_disable_all_blacklists = function() {
 }
 
 Blacklist.apply = function() {
-  $.each(this.entries, function(i, entry) {
+  Blacklist.entries.forEach(function(entry) {
     entry.hits = 0;
   });
 
   var count = 0
 
-  $.each(this.posts(), function(i, post) {
+  Blacklist.posts().each(function(i, post) {
     count += Blacklist.apply_post(post);
   });
 
@@ -142,7 +142,7 @@ Blacklist.apply = function() {
 
 Blacklist.apply_post = function(post) {
   var post_count = 0;
-  $.each(Blacklist.entries, function(j, entry) {
+  Blacklist.entries.forEach(function(entry) {
     if (Blacklist.post_match(post, entry)) {
       entry.hits += 1;
       post_count += 1;

--- a/app/javascript/src/javascripts/posts.js.erb
+++ b/app/javascript/src/javascripts/posts.js.erb
@@ -550,8 +550,8 @@ Post.update_tag_count = function(event) {
   let count = 0;
 
   if (event) {
-    let tags = [...new Set($(event.target).val().match(/\S+/g))];
-    if (tags) {
+    let tags = Utility.regexp_split($(event.target).val());
+    if (tags.length) {
       count = tags.length;
       string = (count === 1) ? (count + " tag") : (count + " tags")
     }

--- a/app/javascript/src/javascripts/related_tag.js
+++ b/app/javascript/src/javascripts/related_tag.js
@@ -89,27 +89,25 @@ RelatedTag.current_tag = function() {
 }
 
 RelatedTag.update_selected = function(e) {
-  var current_tags = $("#upload_tag_string,#post_tag_string").val().toLowerCase().match(/\S+/g) || [];
+  var current_tags = RelatedTag.current_tags();
   var $all_tags = $(".related-tags a.search-tag");
   $all_tags.removeClass("selected");
-
   $all_tags.each(function(i, tag) {
-    if (current_tags.indexOf(tag.textContent.replace(/ /g, "_")) > -1) {
+    if (current_tags.includes(tag.textContent.replace(/ /g, "_"))) {
       $(tag).addClass("selected");
     }
   });
 }
 
-RelatedTag.tags_include = function(name) {
-  var current = $("#upload_tag_string,#post_tag_string").val().toLowerCase().match(/\S+/g) || [];
-  return $.inArray(name.toLowerCase(), current) > -1;
+RelatedTag.current_tags = function() {
+  return Utility.regexp_split($("#upload_tag_string,#post_tag_string").val().toLowerCase());
 }
 
 RelatedTag.toggle_tag = function(e) {
   var $field = $("#upload_tag_string,#post_tag_string");
   var tag = $(e.target).html().replace(/ /g, "_").replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&");
 
-  if (RelatedTag.tags_include(tag)) {
+  if (RelatedTag.current_tags().includes(tag)) {
     var escaped_tag = Utility.regexp_escape(tag);
     $field.val($field.val().replace(new RegExp("(^|\\s)" + escaped_tag + "($|\\s)", "gi"), "$1$2"));
   } else {

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -108,6 +108,10 @@ Utility.regexp_escape = function(string) {
   return string.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
 }
 
+Utility.regexp_split = function(string) {
+  return [...new Set(String(string === null || string === undefined ? "" : string).match(/\S+/g))];
+}
+
 $.fn.selectEnd = function() {
   return this.each(function() {
     this.focus();

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -11,7 +11,7 @@
       vertical-align: bottom;
     }
 
-    a.blacklisted-active {
+    a.blacklisted-inactive {
       text-decoration: line-through;
     }
   }

--- a/app/views/posts/update.js.erb
+++ b/app/views/posts/update.js.erb
@@ -1,14 +1,16 @@
-var post_id = <%= @post.id %>;
-var $post = $(`#post_${post_id}`);
-
 <% if @post.valid? %>
-  $post.replaceWith("<%= j PostPresenter.preview(@post, show_deleted: true) %>");
+  var $post = $("#post_<%= @post.id %>");
+  <% if !CurrentUser.disable_post_tooltips %>
+    $post.find("img").qtip("destroy", true);
+  <% end %>
+  var $new_post = $("<%= j PostPresenter.preview(@post, show_deleted: true) %>");
+  Danbooru.Blacklist.apply_post($new_post.get(0));
+  $("#post_<%= @post.id %>").replaceWith($new_post);
+  <% if params[:mode] == "quick-edit" %>
+    Danbooru.PostModeMenu.close_edit_form();
+  <% end %>
 <% else %>
-  Danbooru.error(`Post #${post_id}: <%= j @post.errors.full_messages.join("; ") %>`);
-<% end %>
-
-<% if @post.valid? && params[:mode] == "quick-edit" %>
-  Danbooru.PostModeMenu.close_edit_form();
+  Danbooru.error(`Post #<%= @post.id %>: <%= j @post.errors.full_messages.join("; ") %>`);
 <% end %>
 
 $(document).trigger("danbooru:post-preview-updated", <%= raw @post.to_json %>);


### PR DESCRIPTION
Fixes #4323. Besides that, it also adds several other improvements.

1. Fixed several issues with the post update JS render

2. Fixed multiple performance issues with the blacklist apply function being applied multiple times

3. Refactored regexp split used in several places into its own utility function

4. Adjust how classes get added and renamed the classes on the links to be more accurate

5. Used alternate iterators as `$.each` is a subpar performer

<hr>

One thing I realized doing this is that module functions/variables are referred to in a lot of places with **this** which is dangerous with the current standard format. Since most of the anonymous functions use the full function format instead of arrow functions, the **this** inside those refer to the anonymous function instead of the module. So for all of the modules, the anonymous functions should be replaced with arrow functions or all of the module usage of **this** should be converted to using the module name instead.