### PR TITLE
Fix renaming artists

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -49,6 +49,9 @@ class ArtistsController < ApplicationController
   end
 
   def update
+    if params[:artist][:wiki_page_attributes] && params[:artist][:wiki_page_attributes][:id] && params[:artist][:name] && params[:artist][:name] != @artist.name
+      params[:artist] = params[:artist].except(:wiki_page_attributes)
+    end
     @artist.update(artist_params)
     flash[:notice] = @artist.valid? ? "Artist updated" : @artist.errors.full_messages.join("; ")
     respond_with(@artist)

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -50,6 +50,10 @@ class ArtistsController < ApplicationController
 
   def update
     if params[:artist][:wiki_page_attributes] && params[:artist][:wiki_page_attributes][:id] && params[:artist][:name] && params[:artist][:name] != @artist.name
+      if params[:artist][:rename_wiki].to_s.truthy?
+        @wiki_page = WikiPage.find(params[:artist][:wiki_page_attributes][:id])
+        @wiki_page.update(wiki_params)
+      end
       params[:artist] = params[:artist].except(:wiki_page_attributes)
     end
     @artist.update(artist_params)
@@ -97,10 +101,18 @@ class ArtistsController < ApplicationController
   end
 
   def artist_params(context = nil)
+    params[:artist] = params[:artist].except(:rename_wiki)
     permitted_params = %i[name other_names other_names_string group_name url_string notes is_deleted]
     permitted_params << { wiki_page_attributes: %i[id body] }
     permitted_params << :source if context == :new
 
     params.fetch(:artist, {}).permit(permitted_params)
+  end
+
+  def wiki_params
+    permitted_params = %i[title body]
+    sub_params = params[:artist][:wiki_page_attributes].except(:id)
+    sub_params[:title] = params[:artist][:name]
+    sub_params.permit(permitted_params)
   end
 end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -29,6 +29,8 @@ class WikiPagesController < ApplicationController
     if request.format.html? && @wiki_page.blank? && found_by == :title
       @wiki_page = WikiPage.new(title: params[:id])
       respond_with @wiki_page, status: 404
+    elsif request.format.html? && @wiki_page.present? && @wiki_page.artist.present?
+      redirect_to(artist_path(@wiki_page.artist))
     elsif request.format.html? && @wiki_page.present? && found_by == :id
       redirect_to @wiki_page
     elsif @wiki_page.blank?

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -2,7 +2,7 @@ class Artist < ApplicationRecord
   extend Memoist
   class RevertError < StandardError; end
 
-  attr_accessor :url_string_changed
+  attr_accessor :url_string_changed, :rename_wiki
   array_attribute :other_names
   deletable
 

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -9,5 +9,15 @@
     <%= fw.input :body, label: "Wiki", input_html: { size: "50x15" } %>
   <% end %>
 
+  <% if @artist.wiki_page.id.present? %>
+    <div class="input">
+      <label class="checkbox optional" for="artist_rename_wiki">
+        <%= check_box "artist", "rename_wiki" %>
+        Rename wiki
+      </label>
+      <p class="hint">Check when renaming the artist to also rename the wiki.</p>
+    </div>
+  <% end %>
+
   <%= f.button :submit, "Submit" %>
 <% end %>

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -14,7 +14,13 @@
     <% if CurrentUser.is_member? %>
       <%= subnav_link_to "Edit", edit_artist_path(@artist), :"data-shortcut" => "e" %>
     <% end %>
-    <%= subnav_link_to "History", artist_versions_path(:search => {:artist_id => @artist.id}) %>
+    <%= tag.li(tag.span("History (", style: "font-weight:bold")) %>
+    <%= subnav_link_to "Artist", artist_versions_path(:search => {:artist_id => @artist.id}) %>
+    <% if @artist.wiki_page.present? && @artist.wiki_page.id.present? %>
+      <%= tag.li("|") %>
+      <%= subnav_link_to "Wiki", wiki_page_versions_path(:search => {:wiki_page_id => @artist.wiki_page.id}) %>
+    <% end %>
+    <%= tag.li(tag.span(")", style: "font-weight:bold")) %>
     <% if CurrentUser.is_member? %>
       <% if @artist.is_deleted? %>
         <%= subnav_link_to "Undelete", artist_path(@artist, format: "js"), method: :put, data: {confirm: "Are you sure you want to undelete this artist?", params: "artist[is_deleted]=false"}, remote: true %>

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -9,8 +9,6 @@
       <div class="prose">
         <%= format_text(@artist.wiki_page.body, :disable_mentions => true) %>
       </div>
-
-      <p><%= link_to "View wiki page", @artist.wiki_page %></p>
     <% end %>
 
     <%= yield %>

--- a/app/views/posts/partials/index/_excerpt.html.erb
+++ b/app/views/posts/partials/index/_excerpt.html.erb
@@ -14,7 +14,6 @@
         <%= render "tag_relationships/alias_and_implication_list", tag: artist.tag %>
 
         <p class="links">
-          <%= link_to "View wiki", artist.wiki_page %> |
           <%= link_to "View artist", artist_path(artist.id) %>
         </p>
       </div>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -28,10 +28,6 @@
       <%= format_text(@wiki_page.body) %>
     <% end %>
 
-    <% if @wiki_page.artist %>
-      <p><%= link_to "View artist", @wiki_page.artist %></p>
-    <% end %>
-
     <%= render "tag_relationships/alias_and_implication_list", tag: @wiki_page.tag %>
   </div>
 


### PR DESCRIPTION
Fixes #4303. 

It also provides a method to rename the wiki page along with the artist. It currently starts out as unchecked since I wasn't sure that renaming the wiki should be the default.

Besides the above, it now redirects the artist wiki page to the artist when it exists. This is because there is now no reason to show the artist wiki pages separately in a different view, since everything is accessible from the artist page. This also goes along with how DText wiki links are rendered, in that they are changed to artist links when the tag is of type artist.