### PR TITLE
Refactor authorization logic to use Pundit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'scenic'
 gem 'ipaddress'
 gem 'http'
 gem 'activerecord-hierarchical_query'
+gem 'pundit'
 
 # needed for looser jpeg header compat
 gem 'ruby-imagespec', :require => "image_spec", :git => "https://github.com/r888888888/ruby-imagespec.git", :branch => "exif-fixes"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,8 @@ GEM
     public_suffix (4.0.3)
     puma (4.3.3)
       nio4r (~> 2.0)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.2.2)
     rack-contrib (2.1.0)
       rack (~> 2.0)
@@ -447,6 +449,7 @@ DEPENDENCIES
   pry-inline
   pry-rails
   puma
+  pundit
   rack-mini-profiler
   rails (~> 6.0)
   rake

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,13 +1,11 @@
 module Admin
   class UsersController < ApplicationController
-    before_action :moderator_only
-
     def edit
-      @user = User.find(params[:id])
+      @user = authorize User.find(params[:id]), :promote?
     end
 
     def update
-      @user = User.find(params[:id])
+      @user = authorize User.find(params[:id]), :promote?
       @user.promote_to!(params[:user][:level], params[:user])
       redirect_to edit_admin_user_path(@user), :notice => "User updated"
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,17 +165,6 @@ class ApplicationController < ActionController::Base
     raise User::PrivilegeError if !request.get? && IpBan.is_banned?(CurrentUser.ip_addr)
   end
 
-  def role_only!(role)
-    raise User::PrivilegeError if !CurrentUser.send("is_#{role}?")
-    raise User::PrivilegeError if !request.get? && CurrentUser.user.is_banned?
-  end
-
-  User::Roles.each do |role|
-    define_method("#{role}_only") do
-      role_only!(role)
-    end
-  end
-
   def pundit_user
     [CurrentUser.user, request]
   end

--- a/app/controllers/artist_commentaries_controller.rb
+++ b/app/controllers/artist_commentaries_controller.rb
@@ -1,9 +1,8 @@
 class ArtistCommentariesController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only, only: [:create_or_update, :revert]
 
   def index
-    @commentaries = ArtistCommentary.paginated_search(params)
+    @commentaries = authorize ArtistCommentary.paginated_search(params)
     @commentaries = @commentaries.includes(post: :uploader) if request.format.html?
 
     respond_with(@commentaries)
@@ -14,9 +13,9 @@ class ArtistCommentariesController < ApplicationController
 
   def show
     if params[:id]
-      @commentary = ArtistCommentary.find(params[:id])
+      @commentary = authorize ArtistCommentary.find(params[:id])
     else
-      @commentary = ArtistCommentary.find_by_post_id!(params[:post_id])
+      @commentary = authorize ArtistCommentary.find_by_post_id!(params[:post_id])
     end
 
     respond_with(@commentary) do |format|
@@ -25,24 +24,16 @@ class ArtistCommentariesController < ApplicationController
   end
 
   def create_or_update
-    @artist_commentary = ArtistCommentary.find_or_initialize_by(post_id: params.dig(:artist_commentary, :post_id))
-    @artist_commentary.update(commentary_params)
+    post_id = params[:artist_commentary].delete(:post_id)
+    @artist_commentary = authorize ArtistCommentary.find_or_initialize_by(post_id: post_id)
+    @artist_commentary.update(permitted_attributes(@artist_commentary))
     respond_with(@artist_commentary)
   end
 
   def revert
-    @artist_commentary = ArtistCommentary.find_by_post_id!(params[:id])
+    @artist_commentary = authorize ArtistCommentary.find_by_post_id!(params[:id])
     @version = @artist_commentary.versions.find(params[:version_id])
     @artist_commentary.revert_to!(@version)
-  end
-
-  private
-
-  def commentary_params
-    params.fetch(:artist_commentary, {}).except(:post_id).permit(%i[
-      original_description original_title translated_description translated_title
-      remove_commentary_tag remove_commentary_request_tag remove_commentary_check_tag remove_partial_commentary_tag
-      add_commentary_tag add_commentary_request_tag add_commentary_check_tag add_partial_commentary_tag
-    ])
+    respond_with(@artist_commentary)
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,16 +1,14 @@
 class ArtistsController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only, :except => [:index, :show, :show_or_new, :banned]
-  before_action :admin_only, :only => [:ban, :unban]
-  before_action :load_artist, :only => [:ban, :unban, :show, :edit, :update, :destroy, :undelete]
 
   def new
-    @artist = Artist.new_with_defaults(artist_params(:new))
+    @artist = authorize Artist.new_with_defaults(permitted_attributes(Artist))
     @artist.build_wiki_page if @artist.wiki_page.nil?
     respond_with(@artist)
   end
 
   def edit
+    @artist = authorize Artist.find(params[:id])
     @artist.build_wiki_page if @artist.wiki_page.nil?
     respond_with(@artist)
   end
@@ -20,11 +18,13 @@ class ArtistsController < ApplicationController
   end
 
   def ban
+    @artist = authorize Artist.find(params[:id])
     @artist.ban!(banner: CurrentUser.user)
     redirect_to(artist_path(@artist), :notice => "Artist was banned")
   end
 
   def unban
+    @artist = authorize Artist.find(params[:id])
     @artist.unban!
     redirect_to(artist_path(@artist), :notice => "Artist was unbanned")
   end
@@ -32,35 +32,38 @@ class ArtistsController < ApplicationController
   def index
     # XXX
     params[:search][:name] = params.delete(:name) if params[:name]
-    @artists = Artist.paginated_search(params)
+    @artists = authorize Artist.paginated_search(params)
     @artists = @artists.includes(:urls, :tag) if request.format.html?
 
     respond_with(@artists)
   end
 
   def show
-    @artist = Artist.find(params[:id])
+    @artist = authorize Artist.find(params[:id])
     respond_with(@artist)
   end
 
   def create
-    @artist = Artist.create(artist_params)
+    @artist = authorize Artist.new(permitted_attributes(Artist))
+    @artist.save
     respond_with(@artist)
   end
 
   def update
-    @artist.update(artist_params)
+    @artist = authorize Artist.find(params[:id])
+    @artist.update(permitted_attributes(@artist))
     flash[:notice] = @artist.valid? ? "Artist updated" : @artist.errors.full_messages.join("; ")
     respond_with(@artist)
   end
 
   def destroy
+    @artist = authorize Artist.find(params[:id])
     @artist.update_attribute(:is_deleted, true)
     redirect_to(artist_path(@artist), :notice => "Artist deleted")
   end
 
   def revert
-    @artist = Artist.find(params[:id])
+    @artist = authorize Artist.find(params[:id])
     @version = @artist.versions.find(params[:version_id])
     @artist.revert_to!(@version)
     respond_with(@artist)
@@ -87,17 +90,5 @@ class ArtistsController < ApplicationController
     else
       true
     end
-  end
-
-  def load_artist
-    @artist = Artist.find(params[:id])
-  end
-
-  def artist_params(context = nil)
-    permitted_params = %i[name other_names other_names_string group_name url_string notes is_deleted]
-    permitted_params << { wiki_page_attributes: %i[id body] }
-    permitted_params << :source if context == :new
-
-    params.fetch(:artist, {}).permit(permitted_params)
   end
 end

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -1,59 +1,44 @@
 class BansController < ApplicationController
-  before_action :moderator_only, :except => [:show, :index]
   respond_to :html, :xml, :json
   helper_method :search_params
 
   def new
-    @ban = Ban.new(ban_params(:create))
+    @ban = authorize Ban.new(permitted_attributes(Ban))
+    respond_with(@ban)
   end
 
   def edit
-    @ban = Ban.find(params[:id])
+    @ban = authorize Ban.find(params[:id])
+    respond_with(@ban)
   end
 
   def index
-    @bans = Ban.paginated_search(params, count_pages: true)
+    @bans = authorize Ban.paginated_search(params, count_pages: true)
     @bans = @bans.includes(:user, :banner) if request.format.html?
 
     respond_with(@bans)
   end
 
   def show
-    @ban = Ban.find(params[:id])
+    @ban = authorize Ban.find(params[:id])
     respond_with(@ban)
   end
 
   def create
-    @ban = Ban.create(banner: CurrentUser.user, **ban_params(:create))
-
-    if @ban.errors.any?
-      render :action => "new"
-    else
-      redirect_to ban_path(@ban), :notice => "Ban created"
-    end
+    @ban = authorize Ban.new(banner: CurrentUser.user, **permitted_attributes(Ban))
+    @ban.save
+    respond_with(@ban)
   end
 
   def update
-    @ban = Ban.find(params[:id])
-    if @ban.update(ban_params(:update))
-      redirect_to ban_path(@ban), :notice => "Ban updated"
-    else
-      render :action => "edit"
-    end
+    @ban = authorize Ban.find(params[:id])
+    @ban.update(permitted_attributes(@ban))
+    respond_with(@ban)
   end
 
   def destroy
-    @ban = Ban.find(params[:id])
+    @ban = authorize Ban.find(params[:id])
     @ban.destroy
-    redirect_to bans_path, :notice => "Ban destroyed"
-  end
-
-  private
-
-  def ban_params(context)
-    permitted_params = %i[reason duration expires_at]
-    permitted_params += %i[user_id user_name] if context == :create
-
-    params.fetch(:ban, {}).permit(permitted_params)
+    respond_with(@ban)
   end
 end

--- a/app/controllers/comment_votes_controller.rb
+++ b/app/controllers/comment_votes_controller.rb
@@ -1,23 +1,22 @@
 class CommentVotesController < ApplicationController
-  before_action :member_only, except: [:index]
   skip_before_action :api_check
   respond_to :js, :json, :xml, :html
   rescue_with CommentVote::Error, ActiveRecord::RecordInvalid, status: 422
 
   def index
-    @comment_votes = CommentVote.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    @comment_votes = authorize CommentVote.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @comment_votes = @comment_votes.includes(:user, comment: [:creator, post: [:uploader]]) if request.format.html?
     respond_with(@comment_votes)
   end
 
   def create
-    @comment = Comment.find(params[:comment_id])
+    @comment = authorize Comment.find(params[:comment_id])
     @comment_vote = @comment.vote!(params[:score])
     respond_with(@comment)
   end
 
   def destroy
-    @comment = Comment.find(params[:comment_id])
+    @comment = authorize Comment.find(params[:comment_id])
     @comment.unvote!
     respond_with(@comment)
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,6 @@
 class CommentsController < ApplicationController
   respond_to :html, :xml, :json, :atom
   respond_to :js, only: [:new, :destroy, :undelete]
-  before_action :member_only, :except => [:index, :search, :show]
   skip_before_action :api_check
 
   def index
@@ -20,20 +19,25 @@ class CommentsController < ApplicationController
   end
 
   def new
-    @comment = Comment.new(comment_params(:create))
-    @comment.body = Comment.find(params[:id]).quoted_response if params[:id]
+    if params[:id]
+      quoted_comment = Comment.find(params[:id])
+      @comment = authorize Comment.new(post_id: quoted_comment.post_id, body: quoted_comment.quoted_response)
+    else
+      @comment = authorize Comment.new(permitted_attributes(Comment))
+    end
+
     respond_with(@comment)
   end
 
   def update
-    @comment = Comment.find(params[:id])
-    check_privilege(@comment)
-    @comment.update(comment_params(:update))
+    @comment = authorize Comment.find(params[:id])
+    @comment.update(permitted_attributes(@comment))
     respond_with(@comment, :location => post_path(@comment.post_id))
   end
 
   def create
-    @comment = Comment.create(comment_params(:create).merge(creator: CurrentUser.user, creator_ip_addr: CurrentUser.ip_addr))
+    @comment = authorize Comment.new(creator: CurrentUser.user, creator_ip_addr: CurrentUser.ip_addr)
+    @comment.update(permitted_attributes(@comment))
     flash[:notice] = @comment.valid? ? "Comment posted" : @comment.errors.full_messages.join("; ")
     respond_with(@comment) do |format|
       format.html do
@@ -43,13 +47,12 @@ class CommentsController < ApplicationController
   end
 
   def edit
-    @comment = Comment.find(params[:id])
-    check_privilege(@comment)
+    @comment = authorize Comment.find(params[:id])
     respond_with(@comment)
   end
 
   def show
-    @comment = Comment.find(params[:id])
+    @comment = authorize Comment.find(params[:id])
 
     respond_with(@comment) do |format|
       format.html do
@@ -59,15 +62,13 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = Comment.find(params[:id])
-    check_privilege(@comment)
+    @comment = authorize Comment.find(params[:id])
     @comment.update(is_deleted: true)
     respond_with(@comment)
   end
 
   def undelete
-    @comment = Comment.find(params[:id])
-    check_privilege(@comment)
+    @comment = authorize Comment.find(params[:id])
     @comment.update(is_deleted: false)
     respond_with(@comment)
   end
@@ -102,20 +103,5 @@ class CommentsController < ApplicationController
     end
 
     respond_with(@comments)
-  end
-
-  def check_privilege(comment)
-    if !comment.editable_by?(CurrentUser.user)
-      raise User::PrivilegeError
-    end
-  end
-
-  def comment_params(context)
-    permitted_params = %i[body post_id]
-    permitted_params += %i[do_not_bump_post] if context == :create
-    permitted_params += %i[is_deleted] if context == :update
-    permitted_params += %i[is_sticky] if CurrentUser.is_moderator?
-
-    params.fetch(:comment, {}).permit(permitted_params)
   end
 end

--- a/app/controllers/delayed_jobs_controller.rb
+++ b/app/controllers/delayed_jobs_controller.rb
@@ -1,14 +1,13 @@
 class DelayedJobsController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :admin_only, except: [:index]
 
   def index
-    @delayed_jobs = Delayed::Job.order("run_at asc").extending(PaginationExtension).paginate(params[:page], :limit => params[:limit])
+    @delayed_jobs = authorize Delayed::Job.order("run_at asc").extending(PaginationExtension).paginate(params[:page], :limit => params[:limit]), policy_class: DelayedJobPolicy
     respond_with(@delayed_jobs)
   end
 
   def cancel
-    @job = Delayed::Job.find(params[:id])
+    @job = authorize Delayed::Job.find(params[:id]), policy_class: DelayedJobPolicy
     if !@job.locked_at?
       @job.fail!
     end
@@ -16,7 +15,7 @@ class DelayedJobsController < ApplicationController
   end
 
   def retry
-    @job = Delayed::Job.find(params[:id])
+    @job = authorize Delayed::Job.find(params[:id]), policy_class: DelayedJobPolicy
     if !@job.locked_at?
       @job.update(failed_at: nil, attempts: 0)
     end
@@ -24,7 +23,7 @@ class DelayedJobsController < ApplicationController
   end
 
   def run
-    @job = Delayed::Job.find(params[:id])
+    @job = authorize Delayed::Job.find(params[:id]), policy_class: DelayedJobPolicy
     if !@job.locked_at?
       @job.update(run_at: Time.now)
     end
@@ -32,7 +31,7 @@ class DelayedJobsController < ApplicationController
   end
 
   def destroy
-    @job = Delayed::Job.find(params[:id])
+    @job = authorize Delayed::Job.find(params[:id]), policy_class: DelayedJobPolicy
     if !@job.locked_at?
       @job.destroy
     end

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -1,24 +1,18 @@
 class EmailsController < ApplicationController
-  before_action :member_only
   respond_to :html, :xml, :json
 
   def show
-    @user = User.find(params[:user_id])
-    check_privilege(@user)
-
-    respond_with(@user.email_address)
+    @email_address = authorize EmailAddress.find_by_user_id!(params[:user_id])
+    respond_with(@email_address)
   end
 
   def edit
-    @user = User.find(params[:user_id])
-    check_privilege(@user)
-
+    @user = authorize User.find(params[:user_id]), policy_class: EmailAddressPolicy
     respond_with(@user)
   end
 
   def update
-    @user = User.find(params[:user_id])
-    check_privilege(@user)
+    @user = authorize User.find(params[:user_id]), policy_class: EmailAddressPolicy
 
     if User.authenticate(@user.name, params[:user][:password])
       @user.update(email_address_attributes: { address: params[:user][:email] })
@@ -37,17 +31,10 @@ class EmailsController < ApplicationController
   end
 
   def verify
-    email_id = Danbooru::MessageVerifier.new(:email_verification_key).verify(params[:email_verification_key])
-    @email_address = EmailAddress.find(email_id)
+    @email_address = authorize EmailAddress.find_by_user_id!(params[:user_id])
     @email_address.update!(is_verified: true)
 
     flash[:notice] = "Email address verified"
     redirect_to @email_address.user
-  end
-
-  private
-
-  def check_privilege(user)
-    raise User::PrivilegeError unless user.id == CurrentUser.id || CurrentUser.is_admin?
   end
 end

--- a/app/controllers/favorite_group_orders_controller.rb
+++ b/app/controllers/favorite_group_orders_controller.rb
@@ -1,9 +1,8 @@
 class FavoriteGroupOrdersController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only
 
   def edit
-    @favorite_group = FavoriteGroup.find(params[:favorite_group_id])
+    @favorite_group = authorize FavoriteGroup.find(params[:favorite_group_id])
     respond_with(@favorite_group)
   end
 end

--- a/app/controllers/favorite_groups_controller.rb
+++ b/app/controllers/favorite_groups_controller.rb
@@ -1,10 +1,9 @@
 class FavoriteGroupsController < ApplicationController
-  before_action :member_only, :except => [:index, :show]
   respond_to :html, :xml, :json, :js
 
   def index
     params[:search][:creator_id] ||= params[:user_id]
-    @favorite_groups = FavoriteGroup.visible(CurrentUser.user).paginated_search(params)
+    @favorite_groups = authorize FavoriteGroup.visible(CurrentUser.user).paginated_search(params)
     @favorite_groups = @favorite_groups.includes(:creator) if request.format.html?
 
     respond_with(@favorite_groups)
@@ -13,33 +12,31 @@ class FavoriteGroupsController < ApplicationController
   def show
     limit = params[:limit].presence || CurrentUser.user.per_page
 
-    @favorite_group = FavoriteGroup.find(params[:id])
-    check_read_privilege(@favorite_group)
+    @favorite_group = authorize FavoriteGroup.find(params[:id])
     @posts = @favorite_group.posts.paginate(params[:page], limit: limit, count: @favorite_group.post_count)
 
     respond_with(@favorite_group)
   end
 
   def new
-    @favorite_group = FavoriteGroup.new
+    @favorite_group = authorize FavoriteGroup.new
     respond_with(@favorite_group)
   end
 
   def create
-    @favorite_group = CurrentUser.favorite_groups.create(favgroup_params)
+    @favorite_group = authorize FavoriteGroup.new(creator: CurrentUser.user, **permitted_attributes(FavoriteGroup))
+    @favorite_group.save
     respond_with(@favorite_group)
   end
 
   def edit
-    @favorite_group = FavoriteGroup.find(params[:id])
-    check_write_privilege(@favorite_group)
+    @favorite_group = authorize FavoriteGroup.find(params[:id])
     respond_with(@favorite_group)
   end
 
   def update
-    @favorite_group = FavoriteGroup.find(params[:id])
-    check_write_privilege(@favorite_group)
-    @favorite_group.update(favgroup_params)
+    @favorite_group = authorize FavoriteGroup.find(params[:id])
+    @favorite_group.update(permitted_attributes(@favorite_group))
     unless @favorite_group.errors.any?
       flash[:notice] = "Favorite group updated"
     end
@@ -47,31 +44,15 @@ class FavoriteGroupsController < ApplicationController
   end
 
   def destroy
-    @favorite_group = FavoriteGroup.find(params[:id])
-    check_write_privilege(@favorite_group)
+    @favorite_group = authorize FavoriteGroup.find(params[:id])
     @favorite_group.destroy!
     flash[:notice] = "Favorite group deleted" if request.format.html?
     respond_with(@favorite_group, location: favorite_groups_path(search: { creator_name: CurrentUser.name }))
   end
 
   def add_post
-    @favorite_group = FavoriteGroup.find(params[:id])
-    check_write_privilege(@favorite_group)
+    @favorite_group = authorize FavoriteGroup.find(params[:id])
     @post = Post.find(params[:post_id])
     @favorite_group.add!(@post)
-  end
-
-  private
-
-  def check_write_privilege(favgroup)
-    raise User::PrivilegeError unless favgroup.editable_by?(CurrentUser.user)
-  end
-
-  def check_read_privilege(favgroup)
-    raise User::PrivilegeError unless favgroup.viewable_by?(CurrentUser.user)
-  end
-
-  def favgroup_params
-    params.fetch(:favorite_group, {}).permit(%i[name post_ids post_ids_string is_public], post_ids: [])
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,10 +1,10 @@
 class FavoritesController < ApplicationController
-  before_action :member_only, except: [:index]
   respond_to :html, :xml, :json, :js
   skip_before_action :api_check
   rescue_with Favorite::Error, status: 422
 
   def index
+    authorize Favorite
     if !request.format.html?
       @favorites = Favorite.visible(CurrentUser.user).paginated_search(params)
       respond_with(@favorites)
@@ -19,6 +19,7 @@ class FavoritesController < ApplicationController
   end
 
   def create
+    authorize Favorite
     @post = Post.find(params[:post_id])
     @post.add_favorite!(CurrentUser.user)
     flash.now[:notice] = "You have favorited this post"
@@ -27,6 +28,7 @@ class FavoritesController < ApplicationController
   end
 
   def destroy
+    authorize Favorite
     @post = Post.find_by_id(params[:id])
 
     if @post

--- a/app/controllers/forum_post_votes_controller.rb
+++ b/app/controllers/forum_post_votes_controller.rb
@@ -1,29 +1,23 @@
 class ForumPostVotesController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only, only: [:create, :destroy]
 
   def index
-    @forum_post_votes = ForumPostVote.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    @forum_post_votes = authorize ForumPostVote.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @forum_post_votes = @forum_post_votes.includes(:creator, forum_post: [:creator, :topic]) if request.format.html?
 
     respond_with(@forum_post_votes)
   end
 
   def create
-    @forum_post = ForumPost.visible(CurrentUser.user).find(params[:forum_post_id])
-    @forum_post_vote = @forum_post.votes.create(forum_post_vote_params.merge(creator: CurrentUser.user))
+    @forum_post = ForumPost.find(params[:forum_post_id])
+    @forum_post_vote = authorize ForumPostVote.new(creator: CurrentUser.user, forum_post: @forum_post, **permitted_attributes(ForumPostVote))
+    @forum_post_vote.save
     respond_with(@forum_post_vote)
   end
 
   def destroy
-    @forum_post_vote = CurrentUser.user.forum_post_votes.find(params[:id])
+    @forum_post_vote = authorize ForumPostVote.find(params[:id])
     @forum_post_vote.destroy
     respond_with(@forum_post_vote)
-  end
-
-  private
-
-  def forum_post_vote_params
-    params.fetch(:forum_post_vote, {}).permit(:score)
   end
 end

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -1,25 +1,14 @@
 class ForumPostsController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only, :except => [:index, :show, :search]
-  before_action :load_post, :only => [:edit, :show, :update, :destroy, :undelete]
-  before_action :check_min_level, :only => [:edit, :show, :update, :destroy, :undelete]
   skip_before_action :api_check
 
   def new
-    if params[:topic_id]
-      @forum_topic = ForumTopic.find(params[:topic_id])
-      raise User::PrivilegeError.new unless @forum_topic.visible?(CurrentUser.user)
-    end
-    if params[:post_id]
-      quoted_post = ForumPost.find(params[:post_id])
-      raise User::PrivilegeError.new unless quoted_post.topic.visible?(CurrentUser.user)
-    end
-    @forum_post = ForumPost.new_reply(params)
+    @forum_post = authorize ForumPost.new_reply(params)
     respond_with(@forum_post)
   end
 
   def edit
-    check_privilege(@forum_post)
+    @forum_post = authorize ForumPost.find(params[:id])
     respond_with(@forum_post)
   end
 
@@ -34,6 +23,8 @@ class ForumPostsController < ApplicationController
   end
 
   def show
+    @forum_post = authorize ForumPost.find(params[:id])
+
     respond_with(@forum_post) do |format|
       format.html do
         page = @forum_post.forum_topic_page
@@ -44,51 +35,29 @@ class ForumPostsController < ApplicationController
   end
 
   def create
-    @forum_post = ForumPost.create(forum_post_params(:create).merge(creator: CurrentUser.user))
+    @forum_post = authorize ForumPost.new(creator: CurrentUser.user, topic_id: params.dig(:forum_post, :topic_id))
+    @forum_post.update(permitted_attributes(@forum_post))
+
     page = @forum_post.topic.last_page if @forum_post.topic.last_page > 1
     respond_with(@forum_post, :location => forum_topic_path(@forum_post.topic, :page => page))
   end
 
   def update
-    check_privilege(@forum_post)
-    @forum_post.update(forum_post_params(:update))
+    @forum_post = authorize ForumPost.find(params[:id])
+    @forum_post.update(permitted_attributes(@forum_post))
     page = @forum_post.forum_topic_page if @forum_post.forum_topic_page > 1
     respond_with(@forum_post, :location => forum_topic_path(@forum_post.topic, :page => page, :anchor => "forum_post_#{@forum_post.id}"))
   end
 
   def destroy
-    check_privilege(@forum_post)
+    @forum_post = authorize ForumPost.find(params[:id])
     @forum_post.delete!
     respond_with(@forum_post)
   end
 
   def undelete
-    check_privilege(@forum_post)
+    @forum_post = authorize ForumPost.find(params[:id])
     @forum_post.undelete!
     respond_with(@forum_post)
-  end
-
-  private
-
-  def load_post
-    @forum_post = ForumPost.find(params[:id])
-    @forum_topic = @forum_post.topic
-  end
-
-  def check_min_level
-    raise User::PrivilegeError if CurrentUser.user.level < @forum_topic.min_level
-  end
-
-  def check_privilege(forum_post)
-    if !forum_post.editable_by?(CurrentUser.user)
-      raise User::PrivilegeError
-    end
-  end
-
-  def forum_post_params(context)
-    permitted_params = [:body]
-    permitted_params += [:topic_id] if context == :create
-
-    params.require(:forum_post).permit(permitted_params)
   end
 end

--- a/app/controllers/forum_topic_visits_controller.rb
+++ b/app/controllers/forum_topic_visits_controller.rb
@@ -1,6 +1,5 @@
 class ForumTopicVisitsController < ApplicationController
   respond_to :xml, :json
-  before_action :member_only
 
   def index
     @forum_topic_visits = ForumTopicVisit.where(user: CurrentUser.user).paginated_search(params)

--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -1,20 +1,17 @@
 class ForumTopicsController < ApplicationController
   respond_to :html, :xml, :json
   respond_to :atom, only: [:index, :show]
-  before_action :member_only, :except => [:index, :show]
   before_action :normalize_search, :only => :index
-  before_action :load_topic, :only => [:edit, :show, :update, :destroy, :undelete]
-  before_action :check_min_level, :only => [:show, :edit, :update, :destroy, :undelete]
   skip_before_action :api_check
 
   def new
-    @forum_topic = ForumTopic.new
+    @forum_topic = authorize ForumTopic.new
     @forum_topic.original_post = ForumPost.new
     respond_with(@forum_topic)
   end
 
   def edit
-    check_privilege(@forum_topic)
+    @forum_topic = authorize ForumTopic.find(params[:id])
     respond_with(@forum_topic)
   end
 
@@ -35,11 +32,13 @@ class ForumTopicsController < ApplicationController
   end
 
   def show
+    @forum_topic = authorize ForumTopic.find(params[:id])
+
     if request.format.html?
       @forum_topic.mark_as_read!(CurrentUser.user)
     end
 
-    @forum_posts = ForumPost.search(:topic_id => @forum_topic.id).reorder("forum_posts.id").paginate(params[:page])
+    @forum_posts = @forum_topic.forum_posts.order(id: :asc).paginate(params[:page], limit: params[:limit])
 
     if request.format.atom?
       @forum_posts = @forum_posts.reverse_order.load
@@ -51,7 +50,7 @@ class ForumTopicsController < ApplicationController
   end
 
   def create
-    @forum_topic = ForumTopic.new(forum_topic_params(:create))
+    @forum_topic = authorize ForumTopic.new(permitted_attributes(ForumTopic))
     @forum_topic.creator = CurrentUser.user
     @forum_topic.original_post.creator = CurrentUser.user
     @forum_topic.save
@@ -60,13 +59,13 @@ class ForumTopicsController < ApplicationController
   end
 
   def update
-    check_privilege(@forum_topic)
-    @forum_topic.update(forum_topic_params(:update))
+    @forum_topic = authorize ForumTopic.find(params[:id])
+    @forum_topic.update(permitted_attributes(@forum_topic))
     respond_with(@forum_topic)
   end
 
   def destroy
-    check_privilege(@forum_topic)
+    @forum_topic = authorize ForumTopic.find(params[:id])
     @forum_topic.update(is_deleted: true)
     @forum_topic.create_mod_action_for_delete
     flash[:notice] = "Topic deleted"
@@ -74,7 +73,7 @@ class ForumTopicsController < ApplicationController
   end
 
   def undelete
-    check_privilege(@forum_topic)
+    @forum_topic = authorize ForumTopic.find(params[:id])
     @forum_topic.update(is_deleted: false)
     @forum_topic.create_mod_action_for_undelete
     flash[:notice] = "Topic undeleted"
@@ -82,6 +81,7 @@ class ForumTopicsController < ApplicationController
   end
 
   def mark_all_as_read
+    authorize ForumTopic
     CurrentUser.user.update_attribute(:last_forum_read_at, Time.now)
     ForumTopicVisit.prune!(CurrentUser.user)
     redirect_to forum_topics_path, :notice => "All topics marked as read"
@@ -99,26 +99,5 @@ class ForumTopicsController < ApplicationController
       params[:search] ||= {}
       params[:search][:title] = params.delete(:title)
     end
-  end
-
-  def check_privilege(forum_topic)
-    if !forum_topic.editable_by?(CurrentUser.user)
-      raise User::PrivilegeError
-    end
-  end
-
-  def load_topic
-    @forum_topic = ForumTopic.find(params[:id])
-  end
-
-  def check_min_level
-    raise User::PrivilegeError if CurrentUser.user.level < @forum_topic.min_level
-  end
-
-  def forum_topic_params(context)
-    permitted_params = [:title, :category_id, { original_post_attributes: %i[id body] }]
-    permitted_params += %i[is_sticky is_locked min_level] if CurrentUser.is_moderator?
-
-    params.require(:forum_topic).permit(permitted_params)
   end
 end

--- a/app/controllers/ip_addresses_controller.rb
+++ b/app/controllers/ip_addresses_controller.rb
@@ -1,9 +1,8 @@
 class IpAddressesController < ApplicationController
   respond_to :html, :xml, :json
-  before_action :moderator_only
 
   def index
-    @ip_addresses = IpAddress.visible(CurrentUser.user).paginated_search(params)
+    @ip_addresses = authorize IpAddress.visible(CurrentUser.user).paginated_search(params)
 
     if search_params[:group_by] == "ip_addr"
       @ip_addresses = @ip_addresses.group_by_ip_addr(search_params[:ipv4_masklen], search_params[:ipv6_masklen])

--- a/app/controllers/ip_bans_controller.rb
+++ b/app/controllers/ip_bans_controller.rb
@@ -1,34 +1,31 @@
 class IpBansController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :moderator_only
 
   def new
-    @ip_ban = IpBan.new
+    @ip_ban = authorize IpBan.new(permitted_attributes(IpBan))
+    respond_with(@ip_ban)
   end
 
   def create
-    @ip_ban = CurrentUser.ip_bans.create(ip_ban_params)
+    @ip_ban = authorize IpBan.new(creator: CurrentUser.user, **permitted_attributes(IpBan))
+    @ip_ban.save
     respond_with(@ip_ban, :location => ip_bans_path)
   end
 
   def index
-    @ip_bans = IpBan.paginated_search(params, count_pages: true)
+    @ip_bans = authorize IpBan.paginated_search(params, count_pages: true)
     @ip_bans = @ip_bans.includes(:creator) if request.format.html?
 
     respond_with(@ip_bans)
   end
 
   def destroy
-    @ip_ban = IpBan.find(params[:id])
+    @ip_ban = authorize IpBan.find(params[:id])
     @ip_ban.destroy
     respond_with(@ip_ban)
   end
 
   private
-
-  def ip_ban_params
-    params.fetch(:ip_ban, {}).permit(%i[ip_addr reason])
-  end
 
   def search_params
     params.fetch(:search, {}).permit(%i[ip_addr order])

--- a/app/controllers/maintenance/user/count_fixes_controller.rb
+++ b/app/controllers/maintenance/user/count_fixes_controller.rb
@@ -1,12 +1,12 @@
 module Maintenance
   module User
     class CountFixesController < ApplicationController
-      before_action :member_only
-
       def new
+        @user = authorize CurrentUser.user, :fix_counts?
       end
 
       def create
+        @user = authorize CurrentUser.user, :fix_counts?
         CurrentUser.user.refresh_counts!
         flash[:notice] = "Counts have been refreshed"
         redirect_to profile_path

--- a/app/controllers/moderation_reports_controller.rb
+++ b/app/controllers/moderation_reports_controller.rb
@@ -1,49 +1,28 @@
 class ModerationReportsController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only, only: [:new, :create]
-  before_action :moderator_only, only: [:index]
 
   def new
-    @moderation_report = ModerationReport.new(moderation_report_params)
-    check_privilege(@moderation_report)
+    @moderation_report = authorize ModerationReport.new(permitted_attributes(ModerationReport))
     respond_with(@moderation_report)
   end
 
   def index
-    @moderation_reports = ModerationReport.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    @moderation_reports = authorize ModerationReport.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @moderation_reports = @moderation_reports.includes(:creator, :model) if request.format.html?
 
     respond_with(@moderation_reports)
   end
 
   def show
+    authorize ModerationReport
     redirect_to moderation_reports_path(search: { id: params[:id] })
   end
 
   def create
-    @moderation_report = ModerationReport.new(moderation_report_params.merge(creator: CurrentUser.user))
-    check_privilege(@moderation_report)
+    @moderation_report = authorize ModerationReport.new(creator: CurrentUser.user, **permitted_attributes(ModerationReport))
     @moderation_report.save
 
     flash.now[:notice] = @moderation_report.valid? ? "Report submitted" : @moderation_report.errors.full_messages.join("; ")
     respond_with(@moderation_report)
-  end
-
-  private
-
-  def model_type
-    params.fetch(:moderation_report, {}).fetch(:model_type)
-  end
-
-  def model_id
-    params.fetch(:moderation_report, {}).fetch(:model_id)
-  end
-
-  def check_privilege(moderation_report)
-    raise User::PrivilegeError unless moderation_report.model.reportable_by?(CurrentUser.user)
-  end
-
-  def moderation_report_params
-    params.fetch(:moderation_report, {}).permit(%i[model_type model_id reason])
   end
 end

--- a/app/controllers/moderator/dashboards_controller.rb
+++ b/app/controllers/moderator/dashboards_controller.rb
@@ -1,7 +1,5 @@
 module Moderator
   class DashboardsController < ApplicationController
-    before_action :member_only
-
     def show
       @dashboard = Moderator::Dashboard::Report.new(**search_params.to_h.symbolize_keys)
     end

--- a/app/controllers/moderator/ip_addrs_controller.rb
+++ b/app/controllers/moderator/ip_addrs_controller.rb
@@ -1,9 +1,9 @@
 module Moderator
   class IpAddrsController < ApplicationController
-    before_action :moderator_only
     respond_to :html, :json
 
     def index
+      authorize IpAddress
       @search = IpAddrSearch.new(params[:search])
       @results = @search.execute
       respond_with(@results)

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -1,10 +1,7 @@
 module Moderator
   module Post
     class PostsController < ApplicationController
-      before_action :approver_only, :only => [:delete, :move_favorites, :ban, :unban, :confirm_delete, :confirm_move_favorites]
-      before_action :admin_only, :only => [:expunge]
       skip_before_action :api_check
-
       respond_to :html, :json, :xml, :js
 
       def confirm_delete
@@ -12,7 +9,7 @@ module Moderator
       end
 
       def delete
-        @post = ::Post.find(params[:id])
+        @post = authorize ::Post.find(params[:id])
         if params[:commit] == "Delete"
           @post.delete!(params[:reason], :move_favorites => params[:move_favorites].present?)
         end
@@ -24,7 +21,7 @@ module Moderator
       end
 
       def move_favorites
-        @post = ::Post.find(params[:id])
+        @post = authorize ::Post.find(params[:id])
         if params[:commit] == "Submit"
           @post.give_favorites_to_parent
         end
@@ -32,12 +29,12 @@ module Moderator
       end
 
       def expunge
-        @post = ::Post.find(params[:id])
+        @post = authorize ::Post.find(params[:id])
         @post.expunge!
       end
 
       def ban
-        @post = ::Post.find(params[:id])
+        @post = authorize ::Post.find(params[:id])
         @post.ban!
         flash[:notice] = "Post was banned"
 
@@ -45,7 +42,7 @@ module Moderator
       end
 
       def unban
-        @post = ::Post.find(params[:id])
+        @post = authorize ::Post.find(params[:id])
         @post.unban!
         flash[:notice] = "Post was banned"
 

--- a/app/controllers/modqueue_controller.rb
+++ b/app/controllers/modqueue_controller.rb
@@ -1,9 +1,9 @@
 class ModqueueController < ApplicationController
   respond_to :html, :json, :xml
-  before_action :approver_only
   layout "sidebar"
 
   def index
+    authorize :modqueue
     @posts = Post.includes(:appeals, :disapprovals, :uploader, flags: [:creator]).pending_or_flagged.available_for_moderation(search_params[:hidden])
     @posts = @posts.paginated_search(params, order: "modqueue", count_pages: true)
 

--- a/app/controllers/news_updates_controller.rb
+++ b/app/controllers/news_updates_controller.rb
@@ -1,44 +1,39 @@
 class NewsUpdatesController < ApplicationController
-  before_action :admin_only
   respond_to :html
 
   def index
+    authorize NewsUpdate
     @news_updates = NewsUpdate.order("id desc").paginate(params[:page], :limit => params[:limit])
     respond_with(@news_updates)
   end
 
   def edit
-    @news_update = NewsUpdate.find(params[:id])
+    @news_update = authorize NewsUpdate.find(params[:id])
     respond_with(@news_update)
   end
 
   def update
-    @news_update = NewsUpdate.find(params[:id])
-    @news_update.update(news_update_params)
+    @news_update = authorize NewsUpdate.find(params[:id])
+    @news_update.update(permitted_attributes(@news_update))
     respond_with(@news_update, :location => news_updates_path)
   end
 
   def new
-    @news_update = NewsUpdate.new
+    @news_update = authorize NewsUpdate.new
     respond_with(@news_update)
   end
 
   def create
-    @news_update = NewsUpdate.create(news_update_params.merge(creator: CurrentUser.user))
+    @news_update = authorize NewsUpdate.new(creator: CurrentUser.user, **permitted_attributes(NewsUpdate))
+    @news_update.save
     respond_with(@news_update, :location => news_updates_path)
   end
 
   def destroy
-    @news_update = NewsUpdate.find(params[:id])
+    @news_update = authorize NewsUpdate.find(params[:id])
     @news_update.destroy
     respond_with(@news_update) do |format|
       format.js
     end
-  end
-
-  private
-
-  def news_update_params
-    params.require(:news_update).permit([:message])
   end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,31 +1,20 @@
 class PasswordsController < ApplicationController
-  before_action :member_only
   respond_to :html, :xml, :json
 
   def edit
-    @user = User.find(params[:user_id])
-    check_privilege(@user)
-
+    @user = authorize User.find(params[:user_id]), policy_class: PasswordPolicy
     respond_with(@user)
   end
 
   def update
-    @user = User.find(params[:user_id])
-    check_privilege(@user)
-
+    @user = authorize User.find(params[:user_id]), policy_class: PasswordPolicy
     @user.update(user_params)
     flash[:notice] = @user.errors.none? ? "Password updated" : @user.errors.full_messages.join("; ")
 
     respond_with(@user, location: @user)
   end
 
-  private
-
-  def check_privilege(user)
-    raise User::PrivilegeError unless user.id == CurrentUser.id || CurrentUser.is_admin?
-  end
-
   def user_params
-    params.require(:user).permit(%i[signed_user_id old_password password password_confirmation])
+    params.fetch(:user, {}).permit(policy(:password).permitted_attributes)
   end
 end

--- a/app/controllers/pool_elements_controller.rb
+++ b/app/controllers/pool_elements_controller.rb
@@ -1,15 +1,13 @@
 class PoolElementsController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only
 
   def create
     @pool = Pool.find_by_name(params[:pool_name]) || Pool.find_by_id(params[:pool_id])
+    raise ActiveRecord::RecordNotFound if @pool.nil?
+    authorize(@pool, :update?)
 
-    if @pool.present? && !@pool.is_deleted?
-      @post = Post.find(params[:post_id])
-      @pool.add!(@post)
-    else
-      @error = "That pool does not exist"
-    end
+    @post = Post.find(params[:post_id])
+    @pool.add!(@post)
+    respond_with(@pool)
   end
 end

--- a/app/controllers/pool_orders_controller.rb
+++ b/app/controllers/pool_orders_controller.rb
@@ -1,9 +1,8 @@
 class PoolOrdersController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only
 
   def edit
-    @pool = Pool.find(params[:pool_id])
+    @pool = authorize Pool.find(params[:pool_id])
     respond_with(@pool)
   end
 end

--- a/app/controllers/post_appeals_controller.rb
+++ b/app/controllers/post_appeals_controller.rb
@@ -1,14 +1,13 @@
 class PostAppealsController < ApplicationController
-  before_action :member_only, :except => [:index, :show]
   respond_to :html, :xml, :json, :js
 
   def new
-    @post_appeal = PostAppeal.new(post_appeal_params)
+    @post_appeal = authorize PostAppeal.new(permitted_attributes(PostAppeal))
     respond_with(@post_appeal)
   end
 
   def index
-    @post_appeals = PostAppeal.paginated_search(params)
+    @post_appeals = authorize PostAppeal.paginated_search(params)
 
     if request.format.html?
       @post_appeals = @post_appeals.includes(:creator, post: [:appeals, :uploader, :approver])
@@ -20,21 +19,16 @@ class PostAppealsController < ApplicationController
   end
 
   def create
-    @post_appeal = PostAppeal.create(post_appeal_params.merge(creator: CurrentUser.user))
+    @post_appeal = authorize PostAppeal.new(creator: CurrentUser.user, **permitted_attributes(PostAppeal))
+    @post_appeal.save
     flash[:notice] = @post_appeal.errors.none? ? "Post appealed" : @post_appeal.errors.full_messages.join("; ")
     respond_with(@post_appeal)
   end
 
   def show
-    @post_appeal = PostAppeal.find(params[:id])
+    @post_appeal = authorize PostAppeal.find(params[:id])
     respond_with(@post_appeal) do |fmt|
       fmt.html { redirect_to post_appeals_path(search: { id: @post_appeal.id }) }
     end
-  end
-
-  private
-
-  def post_appeal_params
-    params.fetch(:post_appeal, {}).permit(%i[post_id reason])
   end
 end

--- a/app/controllers/post_approvals_controller.rb
+++ b/app/controllers/post_approvals_controller.rb
@@ -1,15 +1,14 @@
 class PostApprovalsController < ApplicationController
-  before_action :approver_only, only: [:create]
   respond_to :html, :xml, :json, :js
 
   def create
-    post = Post.find(params[:post_id])
-    @approval = post.approve!
+    @approval = authorize PostApproval.new(user: CurrentUser.user, post_id: params[:post_id])
+    @approval.save
     respond_with(@approval)
   end
 
   def index
-    @post_approvals = PostApproval.paginated_search(params)
+    @post_approvals = authorize PostApproval.paginated_search(params)
     @post_approvals = @post_approvals.includes(:user, post: :uploader) if request.format.html?
 
     respond_with(@post_approvals)

--- a/app/controllers/post_disapprovals_controller.rb
+++ b/app/controllers/post_disapprovals_controller.rb
@@ -1,23 +1,17 @@
 class PostDisapprovalsController < ApplicationController
-  before_action :approver_only, only: [:create]
   skip_before_action :api_check
   respond_to :js, :html, :json, :xml
 
   def create
-    @post_disapproval = PostDisapproval.create(user: CurrentUser.user, **post_disapproval_params)
+    @post_disapproval = authorize PostDisapproval.new(user: CurrentUser.user, **permitted_attributes(PostDisapproval))
+    @post_disapproval.save
     respond_with(@post_disapproval)
   end
 
   def index
-    @post_disapprovals = PostDisapproval.paginated_search(params)
+    @post_disapprovals = authorize PostDisapproval.paginated_search(params)
     @post_disapprovals = @post_disapprovals.includes(:user) if request.format.html?
 
     respond_with(@post_disapprovals)
-  end
-
-  private
-
-  def post_disapproval_params
-    params.require(:post_disapproval).permit(%i[post_id reason message])
   end
 end

--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -1,14 +1,13 @@
 class PostFlagsController < ApplicationController
-  before_action :member_only, :except => [:index, :show]
   respond_to :html, :xml, :json, :js
 
   def new
-    @post_flag = PostFlag.new(post_flag_params)
+    @post_flag = authorize PostFlag.new(permitted_attributes(PostFlag))
     respond_with(@post_flag)
   end
 
   def index
-    @post_flags = PostFlag.paginated_search(params)
+    @post_flags = authorize PostFlag.paginated_search(params)
 
     if request.format.html?
       @post_flags = @post_flags.includes(:creator, post: [:flags, :uploader, :approver])
@@ -20,21 +19,16 @@ class PostFlagsController < ApplicationController
   end
 
   def create
-    @post_flag = PostFlag.create(post_flag_params.merge(creator: CurrentUser.user))
+    @post_flag = authorize PostFlag.new(creator: CurrentUser.user, **permitted_attributes(PostFlag))
+    @post_flag.save
     flash[:notice] = @post_flag.errors.none? ? "Post flagged" : @post_flag.errors.full_messages.join("; ")
     respond_with(@post_flag)
   end
 
   def show
-    @post_flag = PostFlag.find(params[:id])
+    @post_flag = authorize PostFlag.find(params[:id])
     respond_with(@post_flag) do |fmt|
       fmt.html { redirect_to post_flags_path(search: { id: @post_flag.id }) }
     end
-  end
-
-  private
-
-  def post_flag_params
-    params.fetch(:post_flag, {}).permit(%i[post_id reason])
   end
 end

--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -1,5 +1,4 @@
 class PostVersionsController < ApplicationController
-  before_action :member_only, except: [:index, :search]
   before_action :check_availabililty
   around_action :set_timeout
   respond_to :html, :xml, :json
@@ -7,7 +6,7 @@ class PostVersionsController < ApplicationController
 
   def index
     set_version_comparison
-    @post_versions = PostVersion.paginated_search(params)
+    @post_versions = authorize PostVersion.paginated_search(params)
 
     if request.format.html?
       @post_versions = @post_versions.includes(:updater, post: [:uploader, :versions])
@@ -22,7 +21,7 @@ class PostVersionsController < ApplicationController
   end
 
   def undo
-    @post_version = PostVersion.find(params[:id])
+    @post_version = authorize PostVersion.find(params[:id])
     @post_version.undo!
 
     respond_with(@post_version)

--- a/app/controllers/post_votes_controller.rb
+++ b/app/controllers/post_votes_controller.rb
@@ -1,25 +1,24 @@
 class PostVotesController < ApplicationController
-  before_action :voter_only
   skip_before_action :api_check
   respond_to :js, :json, :xml, :html
   rescue_with PostVote::Error, status: 422
 
   def index
-    @post_votes = PostVote.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    @post_votes = authorize PostVote.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @post_votes = @post_votes.includes(:user, post: :uploader) if request.format.html?
 
     respond_with(@post_votes)
   end
 
   def create
-    @post = Post.find(params[:post_id])
+    @post = authorize Post.find(params[:post_id]), policy_class: PostVotePolicy
     @post.vote!(params[:score])
 
     respond_with(@post)
   end
 
   def destroy
-    @post = Post.find(params[:post_id])
+    @post = authorize Post.find(params[:post_id]), policy_class: PostVotePolicy
     @post.unvote!
 
     respond_with(@post)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,17 +1,17 @@
 class PostsController < ApplicationController
-  before_action :member_only, :except => [:show, :show_seq, :index, :home, :random]
   respond_to :html, :xml, :json, :js
   layout "sidebar"
 
   def index
     if params[:md5].present?
-      @post = Post.find_by!(md5: params[:md5])
+      @post = authorize Post.find_by!(md5: params[:md5])
       respond_with(@post) do |format|
         format.html { redirect_to(@post) }
       end
     else
+      tag_query = params[:tags] || params.dig(:post, :tags)
       @post_set = PostSets::Post.new(tag_query, params[:page], params[:limit], raw: params[:raw], random: params[:random], format: params[:format])
-      @posts = @post_set.posts
+      @posts = authorize @post_set.posts
       respond_with(@posts) do |format|
         format.atom
       end
@@ -19,7 +19,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = authorize Post.find(params[:id])
 
     if request.format.html?
       @comments = @post.comments
@@ -41,6 +41,7 @@ class PostsController < ApplicationController
   end
 
   def show_seq
+    authorize Post
     context = PostSearchContext.new(params)
     if context.post_id
       redirect_to(post_path(context.post_id, q: params[:q]))
@@ -50,19 +51,15 @@ class PostsController < ApplicationController
   end
 
   def update
-    @post = Post.find(params[:id])
-
-    @post.update(post_params) if @post.visible?
+    @post = authorize Post.find(params[:id])
+    @post.update(permitted_attributes(@post))
     respond_with_post_after_update(@post)
   end
 
   def revert
-    @post = Post.find(params[:id])
+    @post = authorize Post.find(params[:id])
     @version = @post.versions.find(params[:version_id])
-
-    if @post.visible?
-      @post.revert_to!(@version)
-    end
+    @post.revert_to!(@version)
 
     respond_with(@post) do |format|
       format.js
@@ -71,7 +68,7 @@ class PostsController < ApplicationController
 
   def copy_notes
     @post = Post.find(params[:id])
-    @other_post = Post.find(params[:other_post_id].to_i)
+    @other_post = authorize Post.find(params[:other_post_id].to_i)
     @post.copy_notes_to(@other_post)
 
     if @post.errors.any?
@@ -83,7 +80,7 @@ class PostsController < ApplicationController
   end
 
   def random
-    @post = Post.tag_match(params[:tags]).random
+    @post = authorize Post.tag_match(params[:tags]).random
     raise ActiveRecord::RecordNotFound if @post.nil?
     respond_with(@post) do |format|
       format.html { redirect_to post_path(@post, :tags => params[:tags]) }
@@ -91,16 +88,12 @@ class PostsController < ApplicationController
   end
 
   def mark_as_translated
-    @post = Post.find(params[:id])
+    @post = authorize Post.find(params[:id])
     @post.mark_as_translated(params[:post])
     respond_with_post_after_update(@post)
   end
 
   private
-
-  def tag_query
-    params[:tags] || (params[:post] && params[:post][:tags])
-  end
 
   def respond_with_post_after_update(post)
     respond_with(post) do |format|
@@ -123,19 +116,5 @@ class PostsController < ApplicationController
         render :json => post.to_json
       end
     end
-  end
-
-  def post_params
-    permitted_params = %i[
-      tag_string old_tag_string
-      parent_id old_parent_id
-      source old_source
-      rating old_rating
-      has_embedded_notes
-    ]
-    permitted_params += %i[is_rating_locked is_note_locked] if CurrentUser.is_builder?
-    permitted_params += %i[is_status_locked] if CurrentUser.is_admin?
-
-    params.require(:post).permit(permitted_params)
   end
 end

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -2,43 +2,36 @@ class SavedSearchesController < ApplicationController
   respond_to :html, :xml, :json, :js
 
   def index
-    @saved_searches = saved_searches.paginated_search(params, count_pages: true)
+    @saved_searches = authorize SavedSearch.where(user: CurrentUser.user).paginated_search(params, count_pages: true)
     respond_with(@saved_searches)
   end
 
   def labels
+    authorize SavedSearch
     @labels = SavedSearch.search_labels(CurrentUser.id, params[:search]).take(params[:limit].to_i || 10)
     respond_with(@labels)
   end
 
   def create
-    @saved_search = saved_searches.create(saved_search_params)
+    @saved_search = authorize SavedSearch.new(user: CurrentUser.user, **permitted_attributes(SavedSearch))
+    @saved_search.save
     respond_with(@saved_search)
   end
 
   def destroy
-    @saved_search = saved_searches.find(params[:id])
+    @saved_search = authorize SavedSearch.find(params[:id])
     @saved_search.destroy
     respond_with(@saved_search)
   end
 
   def edit
-    @saved_search = saved_searches.find(params[:id])
+    @saved_search = authorize SavedSearch.find(params[:id])
+    respond_with(@saved_search)
   end
 
   def update
-    @saved_search = saved_searches.find(params[:id])
-    @saved_search.update(saved_search_params)
+    @saved_search = authorize SavedSearch.find(params[:id])
+    @saved_search.update(permitted_attributes(@saved_search))
     respond_with(@saved_search, :location => saved_searches_path)
-  end
-
-  private
-
-  def saved_searches
-    CurrentUser.user.saved_searches
-  end
-
-  def saved_search_params
-    params.fetch(:saved_search, {}).permit(%i[query label_string disable_labels])
   end
 end

--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -1,29 +1,22 @@
 class TagAliasesController < ApplicationController
-  before_action :admin_only, only: [:destroy]
   respond_to :html, :xml, :json, :js
 
   def show
-    @tag_alias = TagAlias.find(params[:id])
+    @tag_alias = authorize TagAlias.find(params[:id])
     respond_with(@tag_alias)
   end
 
   def index
-    @tag_aliases = TagAlias.paginated_search(params, count_pages: true)
+    @tag_aliases = authorize TagAlias.paginated_search(params, count_pages: true)
     @tag_aliases = @tag_aliases.includes(:antecedent_tag, :consequent_tag, :approver) if request.format.html?
 
     respond_with(@tag_aliases)
   end
 
   def destroy
-    @tag_alias = TagAlias.find(params[:id])
+    @tag_alias = authorize TagAlias.find(params[:id])
     @tag_alias.reject!
 
     respond_with(@tag_alias, location: tag_aliases_path, notice: "Tag alias was deleted")
-  end
-
-  private
-
-  def tag_alias_params
-    params.require(:tag_alias).permit(%i[antecedent_name consequent_name forum_topic_id skip_secondary_validations])
   end
 end

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -1,29 +1,22 @@
 class TagImplicationsController < ApplicationController
-  before_action :admin_only, only: [:destroy]
   respond_to :html, :xml, :json, :js
 
   def show
-    @tag_implication = TagImplication.find(params[:id])
+    @tag_implication = authorize TagImplication.find(params[:id])
     respond_with(@tag_implication)
   end
 
   def index
-    @tag_implications = TagImplication.paginated_search(params, count_pages: true)
+    @tag_implications = authorize TagImplication.paginated_search(params, count_pages: true)
     @tag_implications = @tag_implications.includes(:antecedent_tag, :consequent_tag, :approver) if request.format.html?
 
     respond_with(@tag_implications)
   end
 
   def destroy
-    @tag_implication = TagImplication.find(params[:id])
+    @tag_implication = authorize TagImplication.find(params[:id])
     @tag_implication.reject!
 
     respond_with(@tag_implication, location: tag_implications_path, notice: "Tag implication was deleted")
-  end
-
-  private
-
-  def tag_implication_params
-    params.require(:tag_implication).permit(%i[antecedent_name consequent_name forum_topic_id skip_secondary_validations])
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,15 +1,13 @@
 class TagsController < ApplicationController
-  before_action :member_only, :only => [:edit, :update]
   respond_to :html, :xml, :json
 
   def edit
-    @tag = Tag.find(params[:id])
-    check_privilege(@tag)
+    @tag = authorize Tag.find(params[:id])
     respond_with(@tag)
   end
 
   def index
-    @tags = Tag.paginated_search(params, hide_empty: true)
+    @tags = authorize Tag.paginated_search(params, hide_empty: true)
     @tags = @tags.includes(:consequent_aliases) if request.format.html?
     respond_with(@tags)
   end
@@ -27,27 +25,13 @@ class TagsController < ApplicationController
   end
 
   def show
-    @tag = Tag.find(params[:id])
+    @tag = authorize Tag.find(params[:id])
     respond_with(@tag)
   end
 
   def update
-    @tag = Tag.find(params[:id])
-    check_privilege(@tag)
-    @tag.update(tag_params)
+    @tag = authorize Tag.find(params[:id])
+    @tag.update(permitted_attributes(@tag))
     respond_with(@tag)
-  end
-
-  private
-
-  def check_privilege(tag)
-    raise User::PrivilegeError unless tag.editable_by?(CurrentUser.user)
-  end
-
-  def tag_params
-    permitted_params = [:category]
-    permitted_params << :is_locked if CurrentUser.is_moderator?
-
-    params.require(:tag).permit(permitted_params)
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,9 +1,9 @@
 class UploadsController < ApplicationController
-  before_action :member_only, except: [:index, :show]
   respond_to :html, :xml, :json, :js
   skip_before_action :verify_authenticity_token, only: [:preprocess]
 
   def new
+    authorize Upload
     @source = Sources::Strategies.find(params[:url], params[:ref]) if params[:url].present?
     @upload, @remote_size = UploadService::ControllerHelper.prepare(
       url: params[:url], ref: params[:ref]
@@ -12,25 +12,27 @@ class UploadsController < ApplicationController
   end
 
   def batch
+    authorize Upload
     @url = params.dig(:batch, :url) || params[:url]
     @source = Sources::Strategies.find(@url, params[:ref]) if @url.present?
     respond_with(@source)
   end
 
   def image_proxy
+    authorize Upload
     resp = ImageProxy.get_image(params[:url])
     send_data resp.body, :type => resp.content_type, :disposition => "inline"
   end
 
   def index
-    @uploads = Upload.paginated_search(params, count_pages: true)
+    @uploads = authorize Upload.paginated_search(params, count_pages: true)
     @uploads = @uploads.includes(:uploader, post: :uploader) if request.format.html?
 
     respond_with(@uploads)
   end
 
   def show
-    @upload = Upload.find(params[:id])
+    @upload = authorize Upload.find(params[:id])
     respond_with(@upload) do |format|
       format.html do
         if @upload.is_completed? && @upload.post_id
@@ -41,14 +43,15 @@ class UploadsController < ApplicationController
   end
 
   def preprocess
+    authorize Upload
     @upload, @remote_size = UploadService::ControllerHelper.prepare(
-      url: upload_params[:source], file: upload_params[:file], ref: upload_params[:referer_url]
+      url: params.dig(:upload, :source), file: params.dig(:upload, :file), ref: params.dig(:upload, :referer_url),
     )
     render body: nil
   end
 
   def create
-    @service = UploadService.new(upload_params)
+    @service = authorize UploadService.new(permitted_attributes(Upload)), policy_class: UploadPolicy
     @upload = @service.start!
 
     if @service.warnings.any?
@@ -56,18 +59,5 @@ class UploadsController < ApplicationController
     end
 
     respond_with(@upload)
-  end
-
-  private
-
-  def upload_params
-    permitted_params = %i[
-      file source tag_string rating status parent_id artist_commentary_title
-      artist_commentary_desc include_artist_commentary referer_url
-      md5_confirmation as_pending translated_commentary_title
-      translated_commentary_desc
-    ]
-
-    params.require(:upload).permit(permitted_params)
   end
 end

--- a/app/controllers/user_feedbacks_controller.rb
+++ b/app/controllers/user_feedbacks_controller.rb
@@ -1,53 +1,37 @@
 class UserFeedbacksController < ApplicationController
-  before_action :gold_only, :only => [:new, :edit, :create, :update]
   respond_to :html, :xml, :json, :js
 
   def new
-    @user_feedback = UserFeedback.new(user_feedback_params(:create))
+    @user_feedback = authorize UserFeedback.new(permitted_attributes(UserFeedback))
     respond_with(@user_feedback)
   end
 
   def edit
-    @user_feedback = UserFeedback.visible(CurrentUser.user).find(params[:id])
-    check_privilege(@user_feedback)
+    @user_feedback = authorize UserFeedback.find(params[:id])
     respond_with(@user_feedback)
   end
 
   def show
-    @user_feedback = UserFeedback.visible(CurrentUser.user).find(params[:id])
+    @user_feedback = authorize UserFeedback.find(params[:id])
     respond_with(@user_feedback)
   end
 
   def index
-    @user_feedbacks = UserFeedback.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    @user_feedbacks = authorize UserFeedback.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @user_feedbacks = @user_feedbacks.includes(:user, :creator) if request.format.html?
 
     respond_with(@user_feedbacks)
   end
 
   def create
-    @user_feedback = UserFeedback.create(user_feedback_params(:create).merge(creator: CurrentUser.user))
+    @user_feedback = authorize UserFeedback.new(creator: CurrentUser.user, **permitted_attributes(UserFeedback))
+    @user_feedback.save
     respond_with(@user_feedback)
   end
 
   def update
-    @user_feedback = UserFeedback.visible(CurrentUser.user).find(params[:id])
-    check_privilege(@user_feedback)
-    @user_feedback.update(user_feedback_params(:update, @user_feedback))
+    @user_feedback = authorize UserFeedback.find(params[:id])
+    @user_feedback.update(permitted_attributes(@user_feedback))
     respond_with(@user_feedback)
-  end
-
-  private
-
-  def check_privilege(user_feedback)
-    raise User::PrivilegeError unless user_feedback.editable_by?(CurrentUser.user)
-  end
-
-  def user_feedback_params(context, user_feedback = nil)
-    permitted_params = %i[body category]
-    permitted_params += %i[user_id user_name] if context == :create
-    permitted_params += %i[is_deleted] if context == :update && user_feedback.deletable_by?(CurrentUser.user)
-
-    params.fetch(:user_feedback, {}).permit(permitted_params)
   end
 end

--- a/app/controllers/user_name_change_requests_controller.rb
+++ b/app/controllers/user_name_change_requests_controller.rb
@@ -1,37 +1,25 @@
 class UserNameChangeRequestsController < ApplicationController
-  before_action :member_only, :only => [:index, :show, :new, :create]
   respond_to :html, :json, :xml
 
   def new
-    @change_request = UserNameChangeRequest.new(change_request_params)
+    @change_request = authorize UserNameChangeRequest.new(permitted_attributes(UserNameChangeRequest))
     respond_with(@change_request)
   end
 
   def create
-    @change_request = UserNameChangeRequest.create_with(user: CurrentUser.user, original_name: CurrentUser.name).create(change_request_params)
+    @change_request = authorize UserNameChangeRequest.new(user: CurrentUser.user, original_name: CurrentUser.name)
+    @change_request.update(permitted_attributes(@change_request))
     flash[:notice] = "Your name has been changed" if @change_request.valid?
     respond_with(@change_request, location: profile_path)
   end
 
   def show
-    @change_request = UserNameChangeRequest.find(params[:id])
-    check_privileges!(@change_request)
+    @change_request = authorize UserNameChangeRequest.find(params[:id])
     respond_with(@change_request)
   end
 
   def index
-    @change_requests = UserNameChangeRequest.visible(CurrentUser.user).order("id desc").paginate(params[:page], :limit => params[:limit])
+    @change_requests = authorize UserNameChangeRequest.visible(CurrentUser.user).order("id desc").paginate(params[:page], :limit => params[:limit])
     respond_with(@change_requests)
-  end
-
-  private
-
-  def check_privileges!(change_request)
-    return if CurrentUser.is_admin?
-    raise User::PrivilegeError if change_request.user_id != CurrentUser.user.id
-  end
-
-  def change_request_params
-    params.fetch(:user_name_change_request, {}).permit(%i[desired_name desired_name_confirmation])
   end
 end

--- a/app/controllers/user_upgrades_controller.rb
+++ b/app/controllers/user_upgrades_controller.rb
@@ -1,5 +1,4 @@
 class UserUpgradesController < ApplicationController
-  before_action :member_only, only: [:show]
   helper_method :user
   skip_before_action :verify_authenticity_token, only: [:create]
 
@@ -13,6 +12,7 @@ class UserUpgradesController < ApplicationController
   end
 
   def show
+    authorize User, :upgrade?
   end
 
   def user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,19 +3,18 @@ class UsersController < ApplicationController
   skip_before_action :api_check
 
   def new
-    @user = User.new
+    @user = authorize User.new
     @user.email_address = EmailAddress.new
     respond_with(@user)
   end
 
   def edit
-    @user = User.find(params[:id])
-    check_privilege(@user)
+    @user = authorize User.find(params[:id])
     respond_with(@user)
   end
 
   def settings
-    @user = CurrentUser.user
+    @user = authorize CurrentUser.user
 
     if @user.is_anonymous?
       redirect_to login_path(url: settings_path)
@@ -32,7 +31,7 @@ class UsersController < ApplicationController
       return
     end
 
-    @users = User.paginated_search(params)
+    @users = authorize User.paginated_search(params)
     @users = @users.includes(:inviter) if request.format.html?
 
     respond_with(@users)
@@ -42,12 +41,12 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = authorize User.find(params[:id])
     respond_with(@user, methods: @user.full_attributes)
   end
 
   def profile
-    @user = CurrentUser.user
+    @user = authorize CurrentUser.user
 
     if @user.is_member?
       params[:action] = "show"
@@ -60,7 +59,8 @@ class UsersController < ApplicationController
   end
 
   def create
-    @user = User.new(last_ip_addr: CurrentUser.ip_addr, **user_params(:create))
+    @user = authorize User.new(last_ip_addr: CurrentUser.ip_addr, **permitted_attributes(User))
+
     if !Danbooru.config.enable_recaptcha? || verify_recaptcha(model: @user)
       @user.save
       if @user.errors.empty?
@@ -78,14 +78,15 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user = User.find(params[:id])
-    check_privilege(@user)
-    @user.update(user_params(:update))
+    @user = authorize User.find(params[:id])
+    @user.update(permitted_attributes(@user))
+
     if @user.errors.any?
       flash[:notice] = @user.errors.full_messages.join("; ")
     else
       flash[:notice] = "Settings updated"
     end
+
     respond_with(@user) do |format|
       format.html { redirect_back fallback_location: edit_user_path(@user) }
     end
@@ -104,33 +105,5 @@ class UsersController < ApplicationController
     else
       true
     end
-  end
-
-  def check_privilege(user)
-    raise User::PrivilegeError unless user.id == CurrentUser.id || CurrentUser.is_admin?
-  end
-
-  def user_params(context)
-    permitted_params = %i[
-      password old_password password_confirmation
-      comment_threshold default_image_size favorite_tags blacklisted_tags
-      time_zone per_page custom_style theme
-
-      receive_email_notifications always_resize_images enable_post_navigation
-      new_post_navigation_layout enable_private_favorites
-      enable_sequential_post_navigation hide_deleted_posts style_usernames
-      enable_auto_complete show_deleted_children
-      disable_categorized_saved_searches disable_tagged_filenames
-      disable_cropped_thumbnails disable_mobile_gestures
-      enable_safe_mode enable_desktop_mode disable_post_tooltips
-    ]
-
-    if context == :create
-      permitted_params += [:name, { email_address_attributes: [:address] }]
-    end
-
-    permitted_params << :level if CurrentUser.is_admin?
-
-    params.require(:user).permit(permitted_params)
   end
 end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -1,31 +1,32 @@
 class WikiPagesController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_action :member_only, :except => [:index, :search, :show, :show_or_new]
   before_action :normalize_search_params, :only => [:index]
   layout "sidebar"
 
   def new
-    @wiki_page = WikiPage.new(wiki_page_params(:create))
+    @wiki_page = authorize WikiPage.new(permitted_attributes(WikiPage))
     respond_with(@wiki_page)
   end
 
   def edit
     @wiki_page, _found_by = WikiPage.find_by_id_or_title(params[:id])
+    authorize @wiki_page
     respond_with(@wiki_page)
   end
 
   def index
-    @wiki_pages = WikiPage.paginated_search(params)
-
+    @wiki_pages = authorize WikiPage.paginated_search(params)
     respond_with(@wiki_pages)
   end
 
   def search
+    authorize WikiPage
     render layout: "default"
   end
 
   def show
     @wiki_page, found_by = WikiPage.find_by_id_or_title(params[:id])
+
     if request.format.html? && @wiki_page.blank? && found_by == :title
       @wiki_page = WikiPage.new(title: params[:id])
       respond_with @wiki_page, status: 404
@@ -39,13 +40,16 @@ class WikiPagesController < ApplicationController
   end
 
   def create
-    @wiki_page = WikiPage.create(wiki_page_params(:create))
+    @wiki_page = authorize WikiPage.new(permitted_attributes(WikiPage))
+    @wiki_page.save
     respond_with(@wiki_page)
   end
 
   def update
     @wiki_page, _found_by = WikiPage.find_by_id_or_title(params[:id])
-    @wiki_page.update(wiki_page_params(:update))
+    authorize @wiki_page
+
+    @wiki_page.update(permitted_attributes(@wiki_page))
     flash[:notice] = @wiki_page.warnings.full_messages.join(".\n \n") if @wiki_page.warnings.any?
 
     respond_with(@wiki_page)
@@ -53,12 +57,16 @@ class WikiPagesController < ApplicationController
 
   def destroy
     @wiki_page, _found_by = WikiPage.find_by_id_or_title(params[:id])
+    authorize @wiki_page
+
     @wiki_page.update(is_deleted: true)
     respond_with(@wiki_page)
   end
 
   def revert
     @wiki_page, _found_by = WikiPage.find_by_id_or_title(params[:id])
+    authorize @wiki_page
+
     @version = @wiki_page.versions.find(params[:version_id])
     @wiki_page.revert_to!(@version)
     flash[:notice] = "Page was reverted"
@@ -67,7 +75,7 @@ class WikiPagesController < ApplicationController
 
   def show_or_new
     if params[:title].blank?
-      redirect_to new_wiki_page_path(wiki_page_params(:create))
+      redirect_to new_wiki_page_path(permitted_attributes(WikiPage))
     else
       redirect_to wiki_page_path(params[:title])
     end
@@ -88,12 +96,5 @@ class WikiPagesController < ApplicationController
       params[:search] ||= {}
       params[:search][:title] = params.delete(:title)
     end
-  end
-
-  def wiki_page_params(context)
-    permitted_params = %i[title body other_names other_names_string is_deleted]
-    permitted_params += %i[is_locked] if CurrentUser.is_builder?
-
-    params.fetch(:wiki_page, {}).permit(permitted_params)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,4 +15,8 @@ module UsersHelper
     verifier = ActiveSupport::MessageVerifier.new(Danbooru.config.email_key, serializer: JSON, digest: "SHA256")
     verifier.generate(user.id.to_s)
   end
+
+  def email_verification_url(user)
+    verify_user_email_url(user, email_verification_key: user.email_address.verification_key)
+  end
 end

--- a/app/logical/forum_updater.rb
+++ b/app/logical/forum_updater.rb
@@ -19,7 +19,7 @@ class ForumUpdater
   end
 
   def create_response(body)
-    forum_topic.posts.create(body: body, skip_mention_notifications: true, creator: User.system)
+    forum_topic.forum_posts.create(body: body, skip_mention_notifications: true, creator: User.system)
   end
 
   def update_post(body)

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -842,14 +842,14 @@ class PostQueryBuilder
 
             when "-favgroup"
               favgroup = FavoriteGroup.find_by_name_or_id!(g2, CurrentUser.user)
-              raise User::PrivilegeError unless favgroup.viewable_by?(CurrentUser.user)
+              raise User::PrivilegeError unless Pundit.policy!([CurrentUser.user, nil], favgroup).show?
 
               q[:favgroups_neg] ||= []
               q[:favgroups_neg] << favgroup
 
             when "favgroup"
               favgroup = FavoriteGroup.find_by_name_or_id!(g2, CurrentUser.user)
-              raise User::PrivilegeError unless favgroup.viewable_by?(CurrentUser.user)
+              raise User::PrivilegeError unless Pundit.policy!([CurrentUser.user, nil], favgroup).show?
 
               q[:favgroups] ||= []
               q[:favgroups] << favgroup

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -10,9 +10,9 @@ class BulkUpdateRequest < ApplicationRecord
 
   validates_presence_of :script
   validates_presence_of :title, if: ->(rec) {rec.forum_topic_id.blank?}
+  validates_presence_of :forum_topic, if: ->(rec) {rec.forum_topic_id.present?}
   validates_inclusion_of :status, :in => %w(pending approved rejected)
   validate :script_formatted_correctly
-  validate :forum_topic_id_not_invalid
   validate :validate_script, :on => :create
   before_validation :normalize_text
   after_create :create_forum_topic
@@ -113,20 +113,6 @@ class BulkUpdateRequest < ApplicationRecord
       errors[:base] << e.message
     end
 
-    def forum_topic_id_not_invalid
-      if forum_topic_id
-        if !forum_topic
-          errors[:base] << "Forum topic ID is invalid"
-        elsif !forum_topic.visible?(CurrentUser.user)
-          errors[:base] << "Forum topic is private"
-        elsif forum_topic.is_locked
-          errors[:base] << "Forum topic is locked"
-        elsif forum_topic.is_deleted
-          errors[:base] << "Forum topic is deleted"
-        end
-      end
-    end
-
     def validate_script
       AliasAndImplicationImporter.new(script, forum_topic_id, "1", skip_secondary_validations).validate!
     rescue RuntimeError => e
@@ -137,18 +123,6 @@ class BulkUpdateRequest < ApplicationRecord
   extend SearchMethods
   include ApprovalMethods
   include ValidationMethods
-
-  def editable?(user)
-    user_id == user.id || user.is_builder?
-  end
-
-  def approvable?(user)
-    !is_approved? && user.is_admin?
-  end
-
-  def rejectable?(user)
-    is_pending? && editable?(user)
-  end
 
   def reason_with_link
     "[bur:#{id}]\n\nReason: #{reason}"

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -63,7 +63,7 @@ class BulkUpdateRequest < ApplicationRecord
     def forum_updater
       @forum_updater ||= begin
         post = if forum_topic
-          forum_post || forum_topic.posts.first
+          forum_post || forum_topic.forum_posts.first
         else
           nil
         end
@@ -89,7 +89,7 @@ class BulkUpdateRequest < ApplicationRecord
     def create_forum_topic
       CurrentUser.as(user) do
         self.forum_topic = ForumTopic.create(title: title, category_id: 1, creator: user) unless forum_topic.present?
-        self.forum_post = forum_topic.posts.create(body: reason_with_link, creator: user) unless forum_post.present?
+        self.forum_post = forum_topic.forum_posts.create(body: reason_with_link, creator: user) unless forum_post.present?
         save
       end
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -117,10 +117,6 @@ class Comment < ApplicationRecord
     end
   end
 
-  def editable_by?(user)
-    updater_id == user.id || user.is_moderator?
-  end
-
   def reportable_by?(user)
     creator_id != user.id && !creator.is_moderator?
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -117,10 +117,6 @@ class Comment < ApplicationRecord
     end
   end
 
-  def reportable_by?(user)
-    creator_id != user.id && !creator.is_moderator?
-  end
-
   def voted_by?(user)
     return false if user.is_anonymous?
     user.id.in?(votes.map(&:user_id))

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -1,9 +1,7 @@
 require 'digest/sha1'
 
 class Dmail < ApplicationRecord
-
   validates_presence_of :title, :body, on: :create
-  validate :validate_sender_is_not_banned, on: :create
 
   belongs_to :owner, :class_name => "User"
   belongs_to :to, :class_name => "User"
@@ -123,10 +121,6 @@ class Dmail < ApplicationRecord
     def valid_key?(key)
       id == verifier.verified(key)
     end
-
-    def visible_to?(user, key)
-      owner_id == user.id || valid_key?(key)
-    end
   end
 
   include AddressMethods
@@ -135,12 +129,6 @@ class Dmail < ApplicationRecord
 
   def self.mark_all_as_read
     unread.update(is_read: true)
-  end
-
-  def validate_sender_is_not_banned
-    if from.try(:is_banned?)
-      errors[:base] << "Sender is banned and cannot send messages"
-    end
   end
 
   def quoted_body

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -169,10 +169,6 @@ class Dmail < ApplicationRecord
     end
   end
 
-  def reportable_by?(user)
-    owner == user && is_recipient? && !is_automated? && !from.is_moderator?
-  end
-
   def dtext_shortlink(key: false, **options)
     key ? "dmail ##{id}/#{self.key}" : "dmail ##{id}"
   end

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -12,4 +12,18 @@ class EmailAddress < ApplicationRecord
     self.normalized_address = EmailNormalizer.normalize(value) || address
     super
   end
+
+  concerning :VerificationMethods do
+    def verifier
+      @verifier ||= Danbooru::MessageVerifier.new(:email_verification_key)
+    end
+
+    def verification_key
+      verifier.generate(id)
+    end
+
+    def valid_key?(key)
+      id == verifier.verified(key)
+    end
+  end
 end

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -160,14 +160,6 @@ class FavoriteGroup < ApplicationRecord
     post_ids.include?(post_id)
   end
 
-  def editable_by?(user)
-    creator_id == user.id
-  end
-
-  def viewable_by?(user)
-    creator_id == user.id || is_public
-  end
-
   def self.available_includes
     [:creator]
   end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -81,10 +81,6 @@ class ForumPost < ApplicationRecord
     end
   end
 
-  def votable?
-    bulk_update_request.present? && bulk_update_request.is_pending?
-  end
-
   def voted?(user, score)
     votes.where(creator_id: user.id, score: score).exists?
   end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -81,10 +81,6 @@ class ForumPost < ApplicationRecord
     end
   end
 
-  def reportable_by?(user)
-    visible?(user) && creator_id != user.id && !creator.is_moderator?
-  end
-
   def votable?
     bulk_update_request.present? && bulk_update_request.is_pending?
   end
@@ -97,10 +93,6 @@ class ForumPost < ApplicationRecord
     if SpamDetector.new(self, user_ip: CurrentUser.ip_addr).spam?
       moderation_reports << ModerationReport.new(creator: User.system, reason: "Spam.")
     end
-  end
-
-  def visible?(user, show_deleted_posts = false)
-    user.is_moderator? || (user.level >= topic.min_level && (show_deleted_posts || !is_deleted?))
   end
 
   def update_topic_updated_at_on_create

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -2,7 +2,7 @@ class ForumPost < ApplicationRecord
   attr_readonly :topic_id
   belongs_to :creator, class_name: "User"
   belongs_to_updater
-  belongs_to :topic, :class_name => "ForumTopic"
+  belongs_to :topic, class_name: "ForumTopic", inverse_of: :forum_posts
   has_many :dtext_links, as: :model, dependent: :destroy
   has_many :moderation_reports, as: :model
   has_many :votes, class_name: "ForumPostVote"
@@ -16,8 +16,6 @@ class ForumPost < ApplicationRecord
   after_update :update_topic_updated_at_on_update_for_original_posts
   after_destroy :update_topic_updated_at_on_destroy
   validates_presence_of :body
-  validate :validate_topic_is_unlocked
-  validate :topic_is_not_restricted, :on => :create
   after_save :delete_topic_if_original_post
   after_update(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
     ModAction.log("#{CurrentUser.name} updated forum ##{rec.id}", :forum_post_update)
@@ -101,24 +99,8 @@ class ForumPost < ApplicationRecord
     end
   end
 
-  def validate_topic_is_unlocked
-    if topic.is_locked? && !updater.is_moderator?
-      errors[:topic] << "is locked"
-    end
-  end
-
-  def topic_is_not_restricted
-    if topic && !topic.visible?(creator)
-      errors[:topic] << "is restricted"
-    end
-  end
-
-  def editable_by?(user)
-    (creator_id == user.id || user.is_moderator?) && visible?(user)
-  end
-
   def visible?(user, show_deleted_posts = false)
-    user.is_moderator? || (topic.visible?(user) && (show_deleted_posts || !is_deleted?))
+    user.is_moderator? || (user.level >= topic.min_level && (show_deleted_posts || !is_deleted?))
   end
 
   def update_topic_updated_at_on_create

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -147,12 +147,8 @@ class Pool < ApplicationRecord
     post_ids.find_index(post_id).to_i + 1
   end
 
-  def deletable_by?(user)
-    user.is_builder?
-  end
-
   def updater_can_edit_deleted
-    if is_deleted? && !deletable_by?(CurrentUser.user)
+    if is_deleted? && !Pundit.policy!([CurrentUser.user, nil], self).update?
       errors[:base] << "You cannot update pools that are deleted"
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -827,12 +827,12 @@ class Post < ApplicationRecord
 
         when /^-favgroup:(.+)$/i
           favgroup = FavoriteGroup.find_by_name_or_id!($1, CurrentUser.user)
-          raise User::PrivilegeError unless favgroup.editable_by?(CurrentUser.user)
+          raise User::PrivilegeError unless Pundit.policy!([CurrentUser.user, nil], favgroup).update?
           favgroup&.remove!(self)
 
         when /^favgroup:(.+)$/i
           favgroup = FavoriteGroup.find_by_name_or_id!($1, CurrentUser.user)
-          raise User::PrivilegeError unless favgroup.editable_by?(CurrentUser.user)
+          raise User::PrivilegeError unless Pundit.policy!([CurrentUser.user, nil], favgroup).update?
           favgroup&.add!(self)
 
         end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -939,7 +939,7 @@ class Post < ApplicationRecord
 
     def add_favorite!(user)
       Favorite.add(post: self, user: user)
-      vote!("up", user) if user.is_voter?
+      vote!("up", user) if Pundit.policy!([user, nil], PostVote).create?
     rescue PostVote::Error
     end
 
@@ -949,7 +949,7 @@ class Post < ApplicationRecord
 
     def remove_favorite!(user)
       Favorite.remove(post: self, user: user)
-      unvote!(user) if user.is_voter?
+      unvote!(user) if Pundit.policy!([user, nil], PostVote).create?
     rescue PostVote::Error
     end
 
@@ -1031,7 +1031,7 @@ class Post < ApplicationRecord
     end
 
     def vote!(vote, voter = CurrentUser.user)
-      unless voter.is_voter?
+      unless Pundit.policy!([voter, nil], PostVote).create?
         raise PostVote::Error.new("You do not have permission to vote")
       end
 

--- a/app/models/post_disapproval.rb
+++ b/app/models/post_disapproval.rb
@@ -66,13 +66,9 @@ class PostDisapproval < ApplicationRecord
     super(message)
   end
 
-  def can_view_creator?(user)
-    user.is_moderator? || user_id == user.id
-  end
-
   def api_attributes
     attributes = super
-    attributes -= [:creator_id] unless can_view_creator?(CurrentUser.user)
+    attributes -= [:creator_id] unless Pundit.policy!([CurrentUser.user, nil], self).can_view_creator?
     attributes
   end
 end

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -48,7 +48,7 @@ class PostEvent
       true
     when PostFlag
       flag = event
-      user.can_view_flagger_on_post?(flag)
+      Pundit.policy!([user, nil], flag).can_view_flagger?
     end
   end
 

--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -233,14 +233,6 @@ class PostVersion < ApplicationRecord
     post.save!
   end
 
-  def can_undo?(user)
-    version > 1 && post&.visible? && user.is_member?
-  end
-
-  def can_revert_to?(user)
-    post&.visible? && user.is_member?
-  end
-
   def api_attributes
     super + [:obsolete_added_tags, :obsolete_removed_tags, :unchanged_tags]
   end

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -169,7 +169,7 @@ class SavedSearch < ApplicationRecord
   end
 
   def disable_labels=(value)
-    CurrentUser.update(disable_categorized_saved_searches: true) if value.to_s.truthy?
+    user.update(disable_categorized_saved_searches: true) if value.to_s.truthy?
   end
 
   def self.available_includes

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -210,7 +210,7 @@ class Tag < ApplicationRecord
             # next few lines if the category is changed.
             tag.update_category_cache
 
-            if tag.editable_by?(creator)
+            if Pundit.policy!([creator, nil], tag).can_change_category?
               tag.update(category: category_id)
             end
           end
@@ -380,13 +380,6 @@ class Tag < ApplicationRecord
   def self.convert_cosplay_tags(tags)
     cosplay_tags, other_tags = tags.partition {|tag| tag.match(/\A(.+)_\(cosplay\)\Z/) }
     cosplay_tags.grep(/\A(.+)_\(cosplay\)\Z/) { "#{TagAlias.to_aliased([$1]).first}_(cosplay)" } + other_tags
-  end
-
-  def editable_by?(user)
-    return true if user.is_admin?
-    return true if !is_locked? && user.is_builder? && post_count < 1_000
-    return true if !is_locked? && user.is_member? && post_count < 50
-    return false
   end
 
   def posts

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -64,10 +64,6 @@ class TagRelationship < ApplicationRecord
     status =~ /\Aerror:/
   end
 
-  def deletable_by?(user)
-    user.is_admin?
-  end
-
   def reject!
     update!(status: "deleted")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -697,10 +697,6 @@ class User < ApplicationRecord
     CurrentUser.as(self, &block)
   end
 
-  def reportable_by?(user)
-    ModerationReport.enabled? && user.is_builder? && id != user.id && !is_moderator?
-  end
-
   def hide_favorites?
     !CurrentUser.is_admin? && enable_private_favorites? && CurrentUser.user.id != id
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,6 +322,10 @@ class User < ApplicationRecord
       User.level_string(value || level)
     end
 
+    def is_deleted?
+      name.match?(/\Auser_[0-9]+~*\z/)
+    end
+
     def is_anonymous?
       level == Levels::ANONYMOUS
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,7 @@ class User < ApplicationRecord
   # Used for `before_action :<role>_only`. Must have a corresponding `is_<role>?` method.
   Roles = Levels.constants.map(&:downcase) + [
     :banned,
-    :approver,
-    :voter
+    :approver
   ]
 
   # candidates for removal:
@@ -352,10 +351,6 @@ class User < ApplicationRecord
 
     def is_admin?
       level >= Levels::ADMIN
-    end
-
-    def is_voter?
-      is_gold?
     end
 
     def is_approver?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -430,14 +430,6 @@ class User < ApplicationRecord
       created_at <= 1.week.ago
     end
 
-    def can_view_flagger?(flagger_id)
-      is_moderator? || flagger_id == id
-    end
-
-    def can_view_flagger_on_post?(flag)
-      (is_moderator? && flag.not_uploaded_by?(id)) || flag.creator_id == id
-    end
-
     def upload_limit
       @upload_limit ||= UploadLimit.new(self)
     end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -11,7 +11,6 @@ class WikiPage < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :body, :unless => -> { is_deleted? || other_names.present? }
   validate :validate_rename
-  validate :validate_not_locked
 
   array_attribute :other_names
   has_one :tag, :foreign_key => "name", :primary_key => "title"
@@ -115,12 +114,6 @@ class WikiPage < ApplicationRecord
 
   extend SearchMethods
   include ApiMethods
-
-  def validate_not_locked
-    if is_locked? && !CurrentUser.is_builder?
-      errors.add(:is_locked, "and cannot be updated")
-    end
-  end
 
   def validate_rename
     return unless title_changed?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,68 @@
+class ApplicationPolicy
+  attr_reader :user, :request, :record
+
+  def initialize(context, record)
+    @user, @request = context
+    @record = record
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    index?
+  end
+
+  def search?
+    index?
+  end
+
+  def new?
+    create?
+  end
+
+  def create?
+    unbanned?
+  end
+
+  def edit?
+    update?
+  end
+
+  def update?
+    unbanned?
+  end
+
+  def destroy?
+    update?
+  end
+
+  def unbanned?
+    user.is_member? && !user.is_banned?
+  end
+
+  def policy(object)
+    Pundit.policy!([user, request], object)
+  end
+
+  def permitted_attributes
+    []
+  end
+
+  def permitted_attributes_for_create
+    permitted_attributes
+  end
+
+  def permitted_attributes_for_update
+    permitted_attributes
+  end
+
+  def permitted_attributes_for_new
+    permitted_attributes_for_create
+  end
+
+  def permitted_attributes_for_edit
+    permitted_attributes_for_update
+  end
+end

--- a/app/policies/artist_commentary_policy.rb
+++ b/app/policies/artist_commentary_policy.rb
@@ -1,0 +1,20 @@
+class ArtistCommentaryPolicy < ApplicationPolicy
+  def create_or_update?
+    unbanned?
+  end
+
+  def revert?
+    unbanned?
+  end
+
+  def permitted_attributes
+    %i[
+      original_description original_title
+      translated_description translated_title
+      remove_commentary_tag remove_commentary_request_tag
+      remove_commentary_check_tag remove_partial_commentary_tag
+      add_commentary_tag add_commentary_request_tag
+      add_commentary_check_tag add_partial_commentary_tag
+    ]
+  end
+end

--- a/app/policies/artist_policy.rb
+++ b/app/policies/artist_policy.rb
@@ -1,0 +1,21 @@
+class ArtistPolicy < ApplicationPolicy
+  def ban?
+    user.is_admin? && !record.is_banned?
+  end
+
+  def unban?
+    user.is_admin? && record.is_banned?
+  end
+
+  def revert?
+    unbanned?
+  end
+
+  def permitted_attributes
+    [:name, :other_names, :other_names_string, :group_name, :url_string, :is_deleted, { wiki_page_attributes: [:id, :body] }]
+  end
+
+  def permitted_attributes_for_new
+    permitted_attributes + [:source]
+  end
+end

--- a/app/policies/ban_policy.rb
+++ b/app/policies/ban_policy.rb
@@ -1,0 +1,18 @@
+class BanPolicy < ApplicationPolicy
+  def bannable?
+    user.is_moderator? && (record.user.blank? || (record.user.level < user.level))
+  end
+
+  alias_method :edit?, :bannable?
+  alias_method :create?, :bannable?
+  alias_method :update?, :bannable?
+  alias_method :destroy?, :bannable?
+
+  def permitted_attributes_for_create
+    [:reason, :duration, :expires_at, :user_id, :user_name]
+  end
+
+  def permitted_attributes_for_update
+    [:reason, :duration, :expires_at]
+  end
+end

--- a/app/policies/bulk_update_request_policy.rb
+++ b/app/policies/bulk_update_request_policy.rb
@@ -1,0 +1,33 @@
+class BulkUpdateRequestPolicy < ApplicationPolicy
+  def create?
+    unbanned? && (record.forum_topic.blank? || policy(record.forum_topic).reply?)
+  end
+
+  def update?
+    unbanned? && (user.is_builder? || record.user_id == user.id)
+  end
+
+  def approve?
+    user.is_admin? && !record.is_approved?
+  end
+
+  def destroy?
+    record.is_pending? && update?
+  end
+
+  def can_update_forum?
+    user.is_admin?
+  end
+
+  def permitted_attributes_for_create
+    [:script, :skip_secondary_validations, :title, :reason, :forum_topic_id]
+  end
+
+  def permitted_attributes_for_update
+    if can_update_forum?
+      [:script, :skip_secondary_validations, :forum_topic_id, :forum_post_id]
+    else
+      [:script, :skip_secondary_validations]
+    end
+  end
+end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -3,6 +3,10 @@ class CommentPolicy < ApplicationPolicy
     unbanned? && (user.is_moderator? || record.updater_id == user.id)
   end
 
+  def reportable?
+    unbanned? && record.creator_id != user.id && !record.creator.is_moderator?
+  end
+
   def can_sticky_comment?
     user.is_moderator?
   end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,0 +1,19 @@
+class CommentPolicy < ApplicationPolicy
+  def update?
+    unbanned? && (user.is_moderator? || record.updater_id == user.id)
+  end
+
+  def can_sticky_comment?
+    user.is_moderator?
+  end
+
+  def permitted_attributes_for_create
+    [:body, :post_id, :do_not_bump_post, (:is_sticky if can_sticky_comment?)].compact
+  end
+
+  def permitted_attributes_for_update
+    [:body, :is_deleted, (:is_sticky if can_sticky_comment?)].compact
+  end
+
+  alias_method :undelete?, :update?
+end

--- a/app/policies/comment_vote_policy.rb
+++ b/app/policies/comment_vote_policy.rb
@@ -1,0 +1,2 @@
+class CommentVotePolicy < ApplicationPolicy
+end

--- a/app/policies/delayed_job_policy.rb
+++ b/app/policies/delayed_job_policy.rb
@@ -1,0 +1,10 @@
+class DelayedJobPolicy < ApplicationPolicy
+  def update?
+    user.is_admin?
+  end
+
+  alias_method :cancel?, :update?
+  alias_method :destroy?, :update?
+  alias_method :retry?, :update?
+  alias_method :run?, :update?
+end

--- a/app/policies/dmail_policy.rb
+++ b/app/policies/dmail_policy.rb
@@ -1,0 +1,29 @@
+class DmailPolicy < ApplicationPolicy
+  def create?
+    unbanned?
+  end
+
+  def index?
+    user.is_member?
+  end
+
+  def mark_all_as_read?
+    user.is_member?
+  end
+
+  def update?
+    user.is_member? && record.owner_id == user.id
+  end
+
+  def show?
+    user.is_member? && (record.owner_id == user.id || record.valid_key?(request.params[:key]))
+  end
+
+  def permitted_attributes_for_create
+    [:title, :body, :to_name, :to_id]
+  end
+
+  def permitted_attributes_for_update
+    [:is_read, :is_deleted]
+  end
+end

--- a/app/policies/dmail_policy.rb
+++ b/app/policies/dmail_policy.rb
@@ -19,6 +19,10 @@ class DmailPolicy < ApplicationPolicy
     user.is_member? && (record.owner_id == user.id || record.valid_key?(request.params[:key]))
   end
 
+  def reportable?
+    unbanned? && record.owner_id == user.id && record.is_recipient? && !record.is_automated? && !record.from.is_moderator?
+  end
+
   def permitted_attributes_for_create
     [:title, :body, :to_name, :to_id]
   end

--- a/app/policies/email_address_policy.rb
+++ b/app/policies/email_address_policy.rb
@@ -1,0 +1,14 @@
+class EmailAddressPolicy < ApplicationPolicy
+  def show?
+    record.user_id == user.id
+  end
+
+  def update?
+    # XXX here record is a user, not the email address.
+    record.id == user.id
+  end
+
+  def verify?
+    record.valid_key?(request.params[:email_verification_key])
+  end
+end

--- a/app/policies/favorite_group_policy.rb
+++ b/app/policies/favorite_group_policy.rb
@@ -1,0 +1,21 @@
+class FavoriteGroupPolicy < ApplicationPolicy
+  def show?
+    record.creator_id == user.id || record.is_public
+  end
+
+  def create?
+    user.is_member?
+  end
+
+  def update?
+    record.creator_id == user.id
+  end
+
+  def add_post?
+    update?
+  end
+
+  def permitted_attributes
+    [:name, :post_ids_string, :is_public, :post_ids, post_ids: []]
+  end
+end

--- a/app/policies/favorite_policy.rb
+++ b/app/policies/favorite_policy.rb
@@ -1,0 +1,9 @@
+class FavoritePolicy < ApplicationPolicy
+  def create?
+    user.is_member?
+  end
+
+  def destroy?
+    user.is_member?
+  end
+end

--- a/app/policies/forum_post_policy.rb
+++ b/app/policies/forum_post_policy.rb
@@ -1,0 +1,33 @@
+class ForumPostPolicy < ApplicationPolicy
+  def show?
+    user.level >= record.topic.min_level
+  end
+
+  def create?
+    unbanned? && policy(record.topic).reply?
+  end
+
+  def update?
+    unbanned? && show? && (user.is_moderator? || (record.creator_id == user.id && !record.topic.is_locked?))
+  end
+
+  def destroy?
+    unbanned? && show? && user.is_moderator?
+  end
+
+  def undelete?
+    unbanned? && show? && user.is_moderator?
+  end
+
+  def show_deleted?
+    !record.is_deleted? || user.is_moderator?
+  end
+
+  def permitted_attributes_for_create
+    [:body, :topic_id]
+  end
+
+  def permitted_attributes_for_update
+    [:body]
+  end
+end

--- a/app/policies/forum_post_policy.rb
+++ b/app/policies/forum_post_policy.rb
@@ -19,6 +19,10 @@ class ForumPostPolicy < ApplicationPolicy
     unbanned? && show? && user.is_moderator?
   end
 
+  def reportable?
+    unbanned? && show? && record.creator_id != user.id && !record.creator.is_moderator?
+  end
+
   def show_deleted?
     !record.is_deleted? || user.is_moderator?
   end

--- a/app/policies/forum_post_policy.rb
+++ b/app/policies/forum_post_policy.rb
@@ -19,6 +19,10 @@ class ForumPostPolicy < ApplicationPolicy
     unbanned? && show? && user.is_moderator?
   end
 
+  def votable?
+    unbanned? && show? && record.bulk_update_request.present? && record.bulk_update_request.is_pending?
+  end
+
   def reportable?
     unbanned? && show? && record.creator_id != user.id && !record.creator.is_moderator?
   end

--- a/app/policies/forum_post_vote_policy.rb
+++ b/app/policies/forum_post_vote_policy.rb
@@ -1,0 +1,13 @@
+class ForumPostVotePolicy < ApplicationPolicy
+  def create?
+    unbanned? && policy(record.forum_post).votable?
+  end
+
+  def destroy?
+    unbanned? && record.creator_id == user.id
+  end
+
+  def permitted_attributes
+    [:score]
+  end
+end

--- a/app/policies/forum_topic_policy.rb
+++ b/app/policies/forum_topic_policy.rb
@@ -1,0 +1,36 @@
+class ForumTopicPolicy < ApplicationPolicy
+  def show?
+    user.level >= record.min_level
+  end
+
+  def update?
+    unbanned? && show? && (user.is_moderator? || (record.creator_id == user.id && !record.is_locked?))
+  end
+
+  def destroy?
+    unbanned? && show? && user.is_moderator?
+  end
+
+  def undelete?
+    unbanned? && show? && user.is_moderator?
+  end
+
+  def mark_all_as_read?
+    user.is_member?
+  end
+
+  def reply?
+    unbanned? && show? && (user.is_moderator? || !record.is_locked?)
+  end
+
+  def moderate?
+    user.is_moderator?
+  end
+
+  def permitted_attributes
+    [
+      :title, :category_id, { original_post_attributes: [:id, :body] },
+      ([:is_sticky, :is_locked, :min_level] if moderate?)
+    ].compact.flatten
+  end
+end

--- a/app/policies/ip_address_policy.rb
+++ b/app/policies/ip_address_policy.rb
@@ -1,0 +1,5 @@
+class IpAddressPolicy < ApplicationPolicy
+  def index?
+    user.is_moderator?
+  end
+end

--- a/app/policies/ip_ban_policy.rb
+++ b/app/policies/ip_ban_policy.rb
@@ -1,0 +1,17 @@
+class IpBanPolicy < ApplicationPolicy
+  def create?
+    user.is_moderator?
+  end
+
+  def index?
+    user.is_moderator?
+  end
+
+  def destroy?
+    user.is_moderator?
+  end
+
+  def permitted_attributes
+    [:ip_addr, :reason]
+  end
+end

--- a/app/policies/moderation_report_policy.rb
+++ b/app/policies/moderation_report_policy.rb
@@ -1,0 +1,13 @@
+class ModerationReportPolicy < ApplicationPolicy
+  def index?
+    user.is_moderator?
+  end
+
+  def create?
+    unbanned? && policy(record.model).reportable?
+  end
+
+  def permitted_attributes
+    [:model_type, :model_id, :reason]
+  end
+end

--- a/app/policies/modqueue_policy.rb
+++ b/app/policies/modqueue_policy.rb
@@ -1,0 +1,5 @@
+class ModqueuePolicy < ApplicationPolicy
+  def index?
+    user.is_approver?
+  end
+end

--- a/app/policies/news_update_policy.rb
+++ b/app/policies/news_update_policy.rb
@@ -1,0 +1,17 @@
+class NewsUpdatePolicy < ApplicationPolicy
+  def index?
+    user.is_admin?
+  end
+
+  def create?
+    user.is_admin?
+  end
+
+  def update?
+    user.is_admin?
+  end
+
+  def permitted_attributes
+    [:message]
+  end
+end

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -1,0 +1,13 @@
+class NotePolicy < ApplicationPolicy
+  def revert?
+    update?
+  end
+
+  def permitted_attributes_for_create
+    [:x, :y, :width, :height, :body, :post_id, :html_id]
+  end
+
+  def permitted_attributes_for_update
+    [:x, :y, :width, :height, :body]
+  end
+end

--- a/app/policies/password_policy.rb
+++ b/app/policies/password_policy.rb
@@ -1,0 +1,9 @@
+class PasswordPolicy < ApplicationPolicy
+  def update?
+    record.id == user.id || user.is_admin?
+  end
+
+  def permitted_attributes
+    [:signed_user_id, :old_password, :password, :password_confirmation]
+  end
+end

--- a/app/policies/pool_policy.rb
+++ b/app/policies/pool_policy.rb
@@ -1,0 +1,25 @@
+class PoolPolicy < ApplicationPolicy
+  def gallery?
+    index?
+  end
+
+  def update?
+    unbanned? && (!record.is_deleted? || user.is_builder?)
+  end
+
+  def destroy?
+    !record.is_deleted? && user.is_builder?
+  end
+
+  def undelete?
+    record.is_deleted? && user.is_builder?
+  end
+
+  def revert?
+    update?
+  end
+
+  def permitted_attributes
+    [:name, :description, :category, :post_ids, :post_ids_string, post_ids: []]
+  end
+end

--- a/app/policies/post_appeal_policy.rb
+++ b/app/policies/post_appeal_policy.rb
@@ -1,0 +1,5 @@
+class PostAppealPolicy < ApplicationPolicy
+  def permitted_attributes
+    [:post_id, :reason]
+  end
+end

--- a/app/policies/post_approval_policy.rb
+++ b/app/policies/post_approval_policy.rb
@@ -1,0 +1,5 @@
+class PostApprovalPolicy < ApplicationPolicy
+  def create?
+    user.is_approver?
+  end
+end

--- a/app/policies/post_disapproval_policy.rb
+++ b/app/policies/post_disapproval_policy.rb
@@ -1,0 +1,13 @@
+class PostDisapprovalPolicy < ApplicationPolicy
+  def create?
+    user.is_approver?
+  end
+
+  def can_view_creator?
+    user.is_moderator? || record.user_id == user.id
+  end
+
+  def permitted_attributes
+    [:post_id, :reason, :message]
+  end
+end

--- a/app/policies/post_flag_policy.rb
+++ b/app/policies/post_flag_policy.rb
@@ -1,0 +1,13 @@
+class PostFlagPolicy < ApplicationPolicy
+  def can_search_flagger?
+    user.is_moderator?
+  end
+
+  def can_view_flagger?
+    (user.is_moderator? || record.creator_id == user.id) && (record.post&.uploader_id != user.id)
+  end
+
+  def permitted_attributes
+    [:post_id, :reason]
+  end
+end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -23,6 +23,26 @@ class PostPolicy < ApplicationPolicy
     update?
   end
 
+  def move_favorites?
+    user.is_approver? && record.fav_count > 0 && record.parent_id.present?
+  end
+
+  def delete?
+    user.is_approver? && !record.is_deleted?
+  end
+
+  def ban?
+    user.is_approver? && !record.is_banned?
+  end
+
+  def unban?
+    user.is_approver? && record.is_banned?
+  end
+
+  def expunge?
+    user.is_admin?
+  end
+
   def visible?
     record.visible?
   end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -1,0 +1,68 @@
+class PostPolicy < ApplicationPolicy
+  def show_seq?
+    true
+  end
+
+  def random?
+    true
+  end
+
+  def update?
+    unbanned? && record.visible?
+  end
+
+  def revert?
+    update?
+  end
+
+  def copy_notes?
+    update?
+  end
+
+  def mark_as_translated?
+    update?
+  end
+
+  def visible?
+    record.visible?
+  end
+
+  def can_view_uploader?
+    user.is_moderator?
+  end
+
+  def can_lock_rating?
+    user.is_builder?
+  end
+
+  def can_lock_notes?
+    user.is_builder?
+  end
+
+  def can_lock_status?
+    user.is_admin?
+  end
+
+  def can_use_mode_menu?
+    user.is_gold?
+  end
+
+  def can_view_favlist?
+    user.is_gold?
+  end
+
+  # whether to show the + - links in the tag list.
+  def show_extra_links?
+    user.is_gold?
+  end
+
+  def permitted_attributes
+    [
+      :tag_string, :old_tag_string, :parent_id, :old_parent_id,
+      :source, :old_source, :rating, :old_rating, :has_embedded_notes,
+      (:is_rating_locked if can_lock_rating?),
+      (:is_noted_locked if can_lock_notes?),
+      (:is_status_locked if can_lock_status?),
+    ].compact
+  end
+end

--- a/app/policies/post_replacement_policy.rb
+++ b/app/policies/post_replacement_policy.rb
@@ -1,0 +1,19 @@
+class PostReplacementPolicy < ApplicationPolicy
+  def create?
+    user.is_moderator?
+  end
+
+  def update?
+    user.is_moderator?
+  end
+
+  def permitted_attributes_for_create
+    [:replacement_url, :replacement_file, :final_source, :tags]
+  end
+
+  def permitted_attributes_for_update
+    [:file_ext_was, :file_size_was, :image_width_was, :image_height_was,
+     :md5_was, :file_ext, :file_size, :image_width, :image_height, :md5,
+     :original_url, :replacement_url]
+  end
+end

--- a/app/policies/post_version_policy.rb
+++ b/app/policies/post_version_policy.rb
@@ -1,0 +1,9 @@
+class PostVersionPolicy < ApplicationPolicy
+  def undo?
+    unbanned? && record.version > 1 && record.post.present? && policy(record.post).visible?
+  end
+
+  def can_mass_undo?
+    user.is_builder?
+  end
+end

--- a/app/policies/post_vote_policy.rb
+++ b/app/policies/post_vote_policy.rb
@@ -1,0 +1,9 @@
+class PostVotePolicy < ApplicationPolicy
+  def create?
+    unbanned? && user.is_gold?
+  end
+
+  def destroy?
+    unbanned? && user.is_gold?
+  end
+end

--- a/app/policies/saved_search_policy.rb
+++ b/app/policies/saved_search_policy.rb
@@ -1,0 +1,21 @@
+class SavedSearchPolicy < ApplicationPolicy
+  def index?
+    user.is_member?
+  end
+
+  def create?
+    user.is_member?
+  end
+
+  def update?
+    record.user_id == user.id
+  end
+
+  def labels?
+    index?
+  end
+
+  def permitted_attributes
+    [:query, :label_string, :disable_labels]
+  end
+end

--- a/app/policies/tag_alias_policy.rb
+++ b/app/policies/tag_alias_policy.rb
@@ -1,0 +1,5 @@
+class TagAliasPolicy < ApplicationPolicy
+  def destroy?
+    user.is_admin?
+  end
+end

--- a/app/policies/tag_implication_policy.rb
+++ b/app/policies/tag_implication_policy.rb
@@ -1,0 +1,5 @@
+class TagImplicationPolicy < ApplicationPolicy
+  def destroy?
+    user.is_admin?
+  end
+end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -1,0 +1,15 @@
+class TagPolicy < ApplicationPolicy
+  def can_change_category?
+    user.is_admin? ||
+      (user.is_builder? && !record.is_locked? && record.post_count < 1_000) ||
+      (user.is_member? && !record.is_locked? && record.post_count < 50)
+  end
+
+  def can_lock?
+    user.is_moderator?
+  end
+
+  def permitted_attributes
+    [(:category if can_change_category?), (:is_locked if can_lock?)].compact
+  end
+end

--- a/app/policies/upload_policy.rb
+++ b/app/policies/upload_policy.rb
@@ -1,0 +1,19 @@
+class UploadPolicy < ApplicationPolicy
+  def batch?
+    unbanned?
+  end
+
+  def image_proxy?
+    unbanned?
+  end
+
+  def preprocess?
+    unbanned?
+  end
+
+  def permitted_attributes
+    %i[file source tag_string rating status parent_id artist_commentary_title
+       artist_commentary_desc include_artist_commentary referer_url
+       md5_confirmation as_pending translated_commentary_title translated_commentary_desc]
+  end
+end

--- a/app/policies/user_feedback_policy.rb
+++ b/app/policies/user_feedback_policy.rb
@@ -1,0 +1,25 @@
+class UserFeedbackPolicy < ApplicationPolicy
+  def create?
+    unbanned? && user.is_gold? && record.user_id != user.id
+  end
+
+  def update?
+    create? && (user.is_moderator? || (record.creator_id == user.id && !record.is_deleted?))
+  end
+
+  def show?
+    !record.is_deleted? || can_view_deleted?
+  end
+
+  def can_view_deleted?
+    user.is_moderator?
+  end
+
+  def permitted_attributes_for_create
+    [:body, :category, :user_id, :user_name]
+  end
+
+  def permitted_attributes_for_update
+    [:body, :category, :is_deleted]
+  end
+end

--- a/app/policies/user_name_change_request_policy.rb
+++ b/app/policies/user_name_change_request_policy.rb
@@ -1,0 +1,13 @@
+class UserNameChangeRequestPolicy < ApplicationPolicy
+  def index?
+    user.is_member?
+  end
+
+  def show?
+    user.is_admin? || (user.is_member? && !record.user.is_deleted?) || (record.user == user)
+  end
+
+  def permitted_attributes
+    [:desired_name, :desired_name_confirmation]
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,44 @@
+class UserPolicy < ApplicationPolicy
+  def create?
+    true
+  end
+
+  def update?
+    record.id == user.id || user.is_admin?
+  end
+
+  def promote?
+    user.is_moderator?
+  end
+
+  def upgrade?
+    user.is_member?
+  end
+
+  def fix_counts?
+    user.is_member?
+  end
+
+  def permitted_attributes_for_create
+    [:name, :password, :password_confirmation, { email_address_attributes: [:address] }]
+  end
+
+  def permitted_attributes_for_update
+    [
+      :comment_threshold, :default_image_size, :favorite_tags,
+      :blacklisted_tags, :time_zone, :per_page, :custom_style, :theme,
+      :receive_email_notifications, :always_resize_images,
+      :enable_post_navigation, :new_post_navigation_layout,
+      :enable_private_favorites, :enable_sequential_post_navigation,
+      :hide_deleted_posts, :style_usernames, :enable_auto_complete,
+      :show_deleted_children, :disable_categorized_saved_searches,
+      :disable_tagged_filenames, :disable_cropped_thumbnails,
+      :disable_mobile_gestures, :enable_safe_mode, :enable_desktop_mode,
+      :disable_post_tooltips,
+      (:level if CurrentUser.is_admin?)
+    ].compact
+  end
+
+  alias_method :profile?, :show?
+  alias_method :settings?, :edit?
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,6 +15,10 @@ class UserPolicy < ApplicationPolicy
     user.is_member?
   end
 
+  def reportable?
+    false
+  end
+
   def fix_counts?
     user.is_member?
   end

--- a/app/policies/wiki_page_policy.rb
+++ b/app/policies/wiki_page_policy.rb
@@ -1,0 +1,17 @@
+class WikiPagePolicy < ApplicationPolicy
+  def update?
+    unbanned? && (can_edit_locked? || !record.is_locked?)
+  end
+
+  def revert?
+    update?
+  end
+
+  def can_edit_locked?
+    user.is_builder?
+  end
+
+  def permitted_attributes
+    [:title, :body, :other_names, :other_names_string, :is_deleted, (:is_locked if can_edit_locked?)].compact
+  end
+end

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -2,7 +2,7 @@
   <%= quick_search_form_for(:any_name_or_url_matches, artists_path, "artists", autocomplete: "artist", redirect: true) %>
   <%= subnav_link_to "Listing", artists_path %>
   <%= subnav_link_to "Banned", artists_path(search: { is_banned: "true", order: "updated_at" }) %>
-  <% if CurrentUser.is_member? %>
+  <% if policy(Artist).create? %>
     <%= subnav_link_to "New", new_artist_path %>
   <% end %>
   <%= subnav_link_to "Recent changes", artist_versions_path %>
@@ -11,23 +11,21 @@
     <li>|</li>
     <%= subnav_link_to "Posts (#{@artist.tag.try(:post_count).to_i})", posts_path(:tags => @artist.name) %>
     <%= subnav_link_to "Show", artist_path(@artist) %>
-    <% if CurrentUser.is_member? %>
+    <% if policy(@artist).update? %>
       <%= subnav_link_to "Edit", edit_artist_path(@artist), :"data-shortcut" => "e" %>
     <% end %>
     <%= subnav_link_to "History", artist_versions_path(:search => {:artist_id => @artist.id}) %>
-    <% if CurrentUser.is_member? %>
+    <% if policy(@artist).update? %>
       <% if @artist.is_deleted? %>
         <%= subnav_link_to "Undelete", artist_path(@artist, format: "js"), method: :put, data: {confirm: "Are you sure you want to undelete this artist?", params: "artist[is_deleted]=false"}, remote: true %>
       <% else %>
         <%= subnav_link_to "Delete", artist_path(@artist), method: :delete, "data-shortcut": "shift+d", "data-confirm": "Are you sure you want to delete this artist?" %>
       <% end %>
     <% end %>
-    <% if CurrentUser.is_admin? %>
-      <% if @artist.is_banned? %>
-        <%= subnav_link_to "Unban", unban_artist_path(@artist), :method => :put, :data => {:confirm => "Are you sure you want to unban this artist?"} %>
-      <% else %>
-        <%= subnav_link_to "Ban", ban_artist_path(@artist), :method => :put, :data => {:confirm => "Are you sure you want to ban this artist?"} %>
-      <% end %>
+    <% if policy(@artist).unban? %>
+      <%= subnav_link_to "Unban", unban_artist_path(@artist), :method => :put, :data => {:confirm => "Are you sure you want to unban this artist?"} %>
+    <% elsif policy(@artist).ban? %>
+      <%= subnav_link_to "Ban", ban_artist_path(@artist), :method => :put, :data => {:confirm => "Are you sure you want to ban this artist?"} %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -30,7 +30,7 @@
         <%= time_ago_in_words_tagged(artist.updated_at) %>
       <% end %>
       <% t.column column: "control" do |artist| %>
-        <% if CurrentUser.is_member? %>
+        <% if policy(artist).update? %>
           <%= link_to "Edit", edit_artist_path(artist) %>
 
           <% if artist.is_deleted? %>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -23,7 +23,7 @@
         <div><%= time_ago_in_words_tagged(ban.created_at) %></div>
       <% end %>
       <% t.column column: "control" do |ban| %>
-        <% if CurrentUser.is_moderator? %>
+        <% if policy(ban).update? %>
           <%= link_to "Edit", edit_ban_path(ban) %>
           | <%= link_to "Delete", ban_path(ban), :method => :delete, :remote => true %>
         <% end %>

--- a/app/views/bulk_update_requests/_bur_edit_links.html.erb
+++ b/app/views/bulk_update_requests/_bur_edit_links.html.erb
@@ -1,11 +1,11 @@
 <%# bur %>
 
-<% if bur.approvable?(CurrentUser.user) %>
+<% if policy(bur).approve? %>
   <%= link_to "Approve", approve_bulk_update_request_path(bur), remote: true, method: :post, "data-confirm": "Are you sure you want to approve this bulk update request?" %> |
 <% end %>
-<% if bur.rejectable?(CurrentUser.user) %>
+<% if policy(bur).destroy? %>
   <%= link_to "Reject", bur, remote: true, method: :delete, "data-confirm": "Are you sure you want to reject this bulk update request?" %> |
 <% end %>
-<% if bur.editable?(CurrentUser.user) %>
+<% if policy(bur).update? %>
   <%= link_to "Edit", edit_bulk_update_request_path(bur), :"data-shortcut" => "e" %>
 <% end %>

--- a/app/views/bulk_update_requests/_form.html.erb
+++ b/app/views/bulk_update_requests/_form.html.erb
@@ -38,7 +38,7 @@
     </div>
   <% end %>
 
-  <% if @bulk_update_request.persisted? && CurrentUser.is_admin? %>
+  <% if @bulk_update_request.persisted? && policy(@bulk_update_request).can_update_forum? %>
     <%= f.input :forum_topic_id %>
     <%= f.input :forum_post_id %>
   <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,14 +1,16 @@
 <%= error_messages_for :comment %>
 
 <%= edit_form_for(comment, html: { style: ("display: none;" if local_assigns[:hidden]), class: "edit_comment" }) do |f| %>
-  <%= f.hidden_field :post_id %>
+  <% if comment.new_record? %>
+    <%= f.hidden_field :post_id %>
+  <% end %>
   <%= dtext_field "comment", "body", :classes => "autocomplete-mentions", :value => comment.body, :input_id => "comment_body_for_#{comment.id}", :preview_id => "dtext-preview-for-#{comment.id}" %>
   <%= f.button :submit, "Submit" %>
   <%= dtext_preview_button "comment", "body", :input_id => "comment_body_for_#{comment.id}", :preview_id => "dtext-preview-for-#{comment.id}" %>
   <% if comment.new_record? %>
     <%= f.input :do_not_bump_post, :label => "No bump" %>
   <% end %>
-  <% if CurrentUser.is_moderator? %>
+  <% if policy(comment).can_sticky_comment? %>
     <%= f.input :is_sticky, :label => "Post as moderator", :for => "comment_is_sticky" %>
   <% end %>
 <% end %>

--- a/app/views/comments/_index_by_comment.html.erb
+++ b/app/views/comments/_index_by_comment.html.erb
@@ -4,7 +4,7 @@
       <% if CurrentUser.is_moderator? || (params[:search] && params[:search][:is_deleted] =~ /t/) || !comment.is_deleted? %>
         <%= content_tag(:div, { id: "post_#{comment.post.id}", class: ["post", *PostPresenter.preview_class(comment.post)].join(" ") }.merge(PostPresenter.data_attributes(comment.post))) do %>
           <div class="preview">
-            <% if comment.post.visible? %>
+            <% if policy(comment.post).visible? %>
               <%= link_to(image_tag(comment.post.preview_file_url), post_path(comment.post)) %>
             <% end %>
           </div>

--- a/app/views/comments/partials/index/_header.html.erb
+++ b/app/views/comments/partials/index/_header.html.erb
@@ -4,7 +4,7 @@
       <strong>Date</strong>
       <%= compact_time(post.created_at) %>
     </span>
-    <% if CurrentUser.is_moderator? %>
+    <% if policy(post).can_view_uploader? %>
       <span class="info">
         <strong>User</strong>
         <%= link_to_user(post.uploader) %>

--- a/app/views/comments/partials/index/_header.html.erb
+++ b/app/views/comments/partials/index/_header.html.erb
@@ -18,7 +18,7 @@
       <strong>Score</strong>
       <span>
         <span id="score-for-post-<%= post.id %>"><%= post.score %></span>
-        <% if CurrentUser.is_voter? %>
+        <% if policy(PostVote).create? %>
           (vote <%= link_to(content_tag("i", nil, class: "far fa-thumbs-up"), post_post_votes_path(:score => "up", :post_id => post.id), :remote => true, :method => :post) %>/<%= link_to(content_tag("i", nil, class: "far fa-thumbs-down"), post_post_votes_path(:score => "down", :post_id => post.id), :remote => true, :method => :post) %>)
         <% end %>
       </span>

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -28,7 +28,7 @@
     <% end %>
   </div>
 
-  <% if CurrentUser.is_member? %>
+  <% if policy(Comment).create? %>
     <div class="new-comment">
       <p><%= link_to "Post comment", new_comment_path(comment: { post_id: post.id }), :class => "expand-comment-response" %></p>
       <%= render "comments/form", comment: post.comments.new, hidden: true %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -31,7 +31,7 @@
       </div>
       <%= render "application/update_notice", record: comment %>
       
-      <% if CurrentUser.is_member? %>
+      <% if policy(comment).create? %>
         <menu>
           <% if context == :index_by_comment %>
             <li><%= link_to "Reply", new_comment_path(id: comment, comment: { post_id: comment.post_id }), class: "reply-link" %></li>
@@ -39,7 +39,7 @@
             <li><%= link_to "Reply", new_comment_path(id: comment, comment: { post_id: comment.post_id }), class: "reply-link", remote: true %></li>
           <% end %>
 
-          <% if comment.editable_by?(CurrentUser.user) %>
+          <% if policy(comment).update? %>
             <% if comment.is_deleted? %>
               <li><%= link_to "Undelete", undelete_comment_path(comment.id), method: :post, remote: true %></li>
             <% else %>
@@ -60,7 +60,7 @@
             <li><%= link_to "Report", new_moderation_report_path(moderation_report: { model_type: "Comment", model_id: comment.id }), remote: true %></li>
           <% end %>
         </menu>
-        <% if comment.editable_by?(CurrentUser.user) %>
+        <% if policy(comment).update? %>
           <%= render "comments/form", comment: comment, hidden: true %>
         <% end %>
       <% end %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -12,7 +12,7 @@
            data-is-deleted="<%= comment.is_deleted? %>"
            data-is-sticky="<%= comment.is_sticky? %>"
            data-below-threshold="<%= comment.score < CurrentUser.user.comment_threshold %>"
-           <% if CurrentUser.is_moderator? %>
+           <% if policy(moderation_reports).show? %>
             data-is-reported="<%= moderation_reports.pluck(:model_id).include?(comment.id) %>"
            <% end %>
            data-is-voted="<%= comment.voted_by?(CurrentUser.user) %>">
@@ -56,7 +56,7 @@
           <li class="comment-unvote-link">
             <%= link_to "Unvote", comment_comment_votes_path(comment_id: comment.id), method: :delete, remote: true %>
           </li>
-          <% if comment.reportable_by?(CurrentUser.user) %>
+          <% if policy(comment).reportable? %>
             <li><%= link_to "Report", new_moderation_report_path(moderation_report: { model_type: "Comment", model_id: comment.id }), remote: true %></li>
           <% end %>
         </menu>

--- a/app/views/delayed_jobs/index.html.erb
+++ b/app/views/delayed_jobs/index.html.erb
@@ -24,7 +24,7 @@
         <%= time_ago_in_words_tagged(job.run_at) %>
       <% end %>
       <% t.column column: "control" do |job| %>
-        <% if CurrentUser.is_admin? %>
+        <% if policy(job).update? %>
           <% if job.locked_at? %>
             Running
           <% elsif job.failed? %>

--- a/app/views/dmails/index.html.erb
+++ b/app/views/dmails/index.html.erb
@@ -37,7 +37,7 @@
           <%= link_to "Delete", dmail_path(dmail, format: :js), remote: true, method: :put, "data-params": "dmail[is_deleted]=true", "data-confirm": "Are you sure you want to delete this dmail?" %>
         <% end %>
 
-        <% if dmail.reportable_by?(CurrentUser.user) %>
+        <% if policy(dmail).reportable? %>
           | <%= link_to "Report", new_moderation_report_path(moderation_report: { model_type: "Dmail", model_id: dmail.id }), remote: true, title: "Report this dmail to the moderators" %>
         <% end %>
       <% end %>

--- a/app/views/dmails/show.html.erb
+++ b/app/views/dmails/show.html.erb
@@ -29,7 +29,7 @@
           <%= link_to "Respond", new_dmail_path(:respond_to_id => @dmail) %>
           | <%= link_to "Forward", new_dmail_path(:respond_to_id => @dmail, :forward => true) %>
           | <%= link_to "Share", dmail_path(@dmail, key: @dmail.key), title: "Anyone with this link will be able to view this dmail." %>
-          <% if @dmail.reportable_by?(CurrentUser.user) %>
+          <% if policy(@dmail).reportable? %>
             | <%= link_to "Report", new_moderation_report_path(moderation_report: { model_type: "Dmail", model_id: @dmail.id }), remote: true, title: "Report this dmail to the moderators" %>
           <% end %>
         </p>

--- a/app/views/favorite_groups/_secondary_links.html.erb
+++ b/app/views/favorite_groups/_secondary_links.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "Listing", favorite_groups_path %>
-  <% if CurrentUser.is_member? %>
+  <% if policy(FavoriteGroup).create? %>
     <%= subnav_link_to "New", new_favorite_group_path %>
   <% end %>
   <%= subnav_link_to "Help", wiki_page_path("help:favorite_groups") %>
@@ -9,7 +9,7 @@
     <li>|</li>
     <%= subnav_link_to "Show", favorite_group_path(@favorite_group) %>
     <%= subnav_link_to "Posts", posts_path(:tags => "favgroup:#{@favorite_group.id}") %>
-    <% if @favorite_group.editable_by?(CurrentUser.user) %>
+    <% if policy(@favorite_group).update? %>
       <%= subnav_link_to "Edit", edit_favorite_group_path(@favorite_group) %>
       <%= subnav_link_to "Delete", favorite_group_path(@favorite_group), :method => :delete, :data => {:confirm => "Are you sure you want to delete this favorite group?"} %>
       <% if @favorite_group.post_count <= 100 %>

--- a/app/views/favorite_groups/index.html.erb
+++ b/app/views/favorite_groups/index.html.erb
@@ -26,7 +26,7 @@
         <%= time_ago_in_words_tagged(favgroup.updated_at) %>
       <% end %>
       <% t.column column: "control" do |favgroup| %>
-        <% if favgroup.editable_by?(CurrentUser.user) %>
+        <% if policy(favgroup).update? %>
           <%= link_to "Edit", edit_favorite_group_path(favgroup) %> |
           <%= link_to "Delete", favorite_group_path(favgroup), method: :delete, remote: true, "data-confirm": "Are you sure you want to delete this favgroup? This cannot be undone." %>
         <% end %>

--- a/app/views/favorites/_update.js.erb
+++ b/app/views/favorites/_update.js.erb
@@ -4,7 +4,7 @@ $("#score-for-post-<%= @post.id %>").text(<%= @post.score %>);
 $("#favcount-for-post-<%= @post.id %>").text(<%= @post.fav_count %>);
 $(".fav-buttons").toggleClass("fav-buttons-false").toggleClass("fav-buttons-true");
 
-<% if CurrentUser.is_gold? %>
+<% if policy(@post).can_view_favlist? %>
   var fav_count = <%= @post.fav_count %>;
   $("#favlist").html("<%= j post_favlist(@post) %>");
 

--- a/app/views/forum_post_votes/_list.html.erb
+++ b/app/views/forum_post_votes/_list.html.erb
@@ -11,6 +11,6 @@
   <%= render "forum_post_votes/vote", vote: vote, forum_post: forum_post %>
 <% end %>
 
-<% if forum_post.votable? && !votes.by(CurrentUser.user.id).exists? %>
+<% if policy(forum_post).votable? && !votes.by(CurrentUser.user.id).exists? %>
   <%= render "forum_post_votes/add_vote", vote: votes.by(CurrentUser.user.id).first, forum_post: forum_post %>
 <% end %>

--- a/app/views/forum_post_votes/_vote.html.erb
+++ b/app/views/forum_post_votes/_vote.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <li class="vote-score-<%= vote.vote_type %>">
-  <% if forum_post.votable? && vote.creator_id == CurrentUser.id %>
+  <% if policy(forum_post).votable? && vote.creator_id == CurrentUser.id %>
     <%= link_to content_tag(:i, nil, class: "far #{vote.fa_class}"), forum_post_vote_path(vote, format: "js"), remote: true, method: :delete %>
     <%= link_to_user vote.creator %>
   <% else %>

--- a/app/views/forum_post_votes/create.js.erb
+++ b/app/views/forum_post_votes/create.js.erb
@@ -2,6 +2,6 @@
   Danbooru.error(<%= raw @forum_post_vote.errors.full_messages.join("; ").to_json %>);
 <% else %>
   Danbooru.notice("Voted");
-  var code = <%= raw render(partial: "forum_post_votes/list", locals: {forum_post: @forum_post, votes: @forum_post.votes}).to_json %>;
-  $("#forum-post-votes-for-<%= @forum_post.id %>").html(code);
+  var code = <%= raw render(partial: "forum_post_votes/list", locals: {forum_post: @forum_post_vote.forum_post, votes: @forum_post_vote.forum_post.votes }).to_json %>;
+  $("#forum-post-votes-for-<%= @forum_post_vote.forum_post.id %>").html(code);
 <% end %>

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -1,4 +1,4 @@
-<% if forum_post.visible?(CurrentUser.user, ActiveModel::Type::Boolean.new.cast(params.dig(:search, :is_deleted))) %>
+<% if policy(forum_post).show_deleted? %>
   <article class="forum-post message" id="forum_post_<%= forum_post.id %>" 
            data-forum-post-id="<%= forum_post.id %>"
            <% if CurrentUser.is_moderator? %>
@@ -20,17 +20,17 @@
       </div>
       <%= render "application/update_notice", record: forum_post %>
       <menu>
-        <% if CurrentUser.is_member? && @forum_topic %>
+        <% if policy(forum_post).create? %>
           <li><%= link_to "Reply", new_forum_post_path(:post_id => forum_post.id), :method => :get, :remote => true %></li>
         <% end %>
-        <% if CurrentUser.is_moderator? && !forum_post.is_original_post?(original_forum_post_id) %>
+        <% if policy(forum_post).destroy? && !forum_post.is_original_post?(original_forum_post_id) %>
           <% if forum_post.is_deleted %>
             <li><%= link_to "Undelete", undelete_forum_post_path(forum_post.id), :method => :post, :remote => true %></li>
           <% else %>
             <li><%= link_to "Delete", forum_post_path(forum_post.id), :data => {:confirm => "Are you sure you want to delete this forum post?"}, :method => :delete, :remote => true %></li>
           <% end %>
         <% end %>
-        <% if forum_post.editable_by?(CurrentUser.user) %>
+        <% if policy(forum_post).update? %>
           <% if forum_post.is_original_post?(original_forum_post_id) %>
             <li><%= link_to "Edit", edit_forum_topic_path(forum_post.topic), :id => "edit_forum_topic_link_#{forum_post.topic.id}", :class => "edit_forum_topic_link" %></li>
           <% else %>
@@ -46,7 +46,7 @@
           </ul>
         <% end %>
       </menu>
-      <% if forum_post.editable_by?(CurrentUser.user) %>
+      <% if policy(forum_post).update? %>
         <% if forum_post.is_original_post?(original_forum_post_id) %>
           <%= render "forum_topics/form", :forum_topic => forum_post.topic %>
         <% else %>

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -1,7 +1,7 @@
 <% if policy(forum_post).show_deleted? %>
   <article class="forum-post message" id="forum_post_<%= forum_post.id %>" 
            data-forum-post-id="<%= forum_post.id %>"
-           <% if CurrentUser.is_moderator? %>
+           <% if policy(moderation_reports).show? %>
             data-is-reported="<%= moderation_reports.pluck(:model_id).include?(forum_post.id) %>"
            <% end %>
            data-creator="<%= forum_post.creator.name %>">
@@ -37,7 +37,7 @@
             <li><%= link_to "Edit", edit_forum_post_path(forum_post.id), :id => "edit_forum_post_link_#{forum_post.id}", :class => "edit_forum_post_link" %></li>
           <% end %>
         <% end %>
-        <% if forum_post.reportable_by?(CurrentUser.user) %>
+        <% if policy(forum_post).reportable? %>
           <li><%= link_to "Report", new_moderation_report_path(moderation_report: { model_type: "ForumPost", model_id: forum_post.id }), remote: true, title: "Report this forum post to the moderators" %></li>
         <% end %>
         <% if forum_post.bulk_update_request.present? %>

--- a/app/views/forum_posts/new.html.erb
+++ b/app/views/forum_posts/new.html.erb
@@ -1,7 +1,7 @@
 <div id="c-forum-posts">
   <div id="a-new">
-    <% if @forum_topic %>
-      <h1>Reply to <%= @forum_topic.title %></h1>
+    <% if @forum_post.topic.present? %>
+      <h1>Reply to <%= @forum_post.topic.title %></h1>
     <% else %>
       <h1>New Forum Post</h1>
     <% end %>

--- a/app/views/forum_posts/partials/new/_form.html.erb
+++ b/app/views/forum_posts/partials/new/_form.html.erb
@@ -1,7 +1,7 @@
 <%= error_messages_for("forum_post") %>
 
 <%= edit_form_for(forum_post) do |f| %>
-  <% if @forum_topic %>
+  <% if forum_post.topic_id.present? %>
     <%= f.input :topic_id, :as => :hidden %>
   <% else %>
     <%= f.input :topic_id, :label => "Topic ID" %>

--- a/app/views/forum_topics/_form.html.erb
+++ b/app/views/forum_topics/_form.html.erb
@@ -13,7 +13,7 @@
       <%= dtext_field "forum_post", "body", :classes => "autocomplete-mentions", :input_name => "forum_topic[original_post_attributes][body]", :value => forum_topic.original_post.body, :input_id => "forum_post_body_for_#{forum_topic.original_post.id}", :preview_id => "dtext-preview-for-#{forum_topic.original_post.id}" %>
     <% end %>
 
-    <% if CurrentUser.is_moderator? %>
+    <% if policy(forum_topic).moderate? %>
       <%= f.input :min_level, :include_blank => false, :collection => available_min_user_levels %>
       <%= f.input :is_sticky, :label => "Sticky" %>
       <%= f.input :is_locked, :label => "Locked" %>

--- a/app/views/forum_topics/_secondary_links.html.erb
+++ b/app/views/forum_topics/_secondary_links.html.erb
@@ -18,9 +18,9 @@
   <% if CurrentUser.is_member? && @forum_topic && !@forum_topic.new_record? %>
     <li>|</li>
     <%= subnav_link_to "Reply", new_forum_post_path(:topic_id => @forum_topic.id) %>
-    <% if !@forum_topic.new_record? && @forum_topic.editable_by?(CurrentUser.user) %>
+    <% if !@forum_topic.new_record? && policy(@forum_topic).update? %>
       <%= subnav_link_to "Edit", edit_forum_topic_path(@forum_topic), "data-shortcut": "e" %>
-      <% if CurrentUser.is_moderator? %>
+      <% if policy(@forum_topic).destroy? # XXX %>
         <% if @forum_topic.is_deleted? %>
           <%= subnav_link_to "Undelete", undelete_forum_topic_path(@forum_topic), :method => :post %>
         <% else %>

--- a/app/views/forum_topics/_secondary_links.html.erb
+++ b/app/views/forum_topics/_secondary_links.html.erb
@@ -2,15 +2,17 @@
   <%= quick_search_form_for(:body_matches, forum_posts_path, "forum posts") %>
   <%= subnav_link_to "Listing", forum_topics_path %>
   
-  <% if CurrentUser.is_member? %>
+  <% if policy(ForumTopic).create? %>
     <%= subnav_link_to "New", new_forum_topic_path %>
+  <% end %>
+  <% if policy(ForumTopic).mark_all_as_read? %>
     <%= subnav_link_to "Mark all as read", mark_all_as_read_forum_topics_path, :method => :post, :"data-shortcut" => "shift+r" %>
+  <% end %>
 
-    <% if @forum_topic %>
-      <%= subnav_link_to "Request alias/implication", new_bulk_update_request_path(bulk_update_request: { forum_topic_id: @forum_topic.id }) %>
-    <% else %>
-      <%= subnav_link_to "Request alias/implication", new_bulk_update_request_path %>
-    <% end %>
+  <% if @forum_topic && policy(BulkUpdateRequest.new(forum_topic: @forum_topic)).create? %>
+    <%= subnav_link_to "Request alias/implication", new_bulk_update_request_path(bulk_update_request: { forum_topic_id: @forum_topic.id }) %>
+  <% else %>
+    <%= subnav_link_to "Request alias/implication", new_bulk_update_request_path %>
   <% end %>
   
   <%= subnav_link_to "Search", search_forum_posts_path %>

--- a/app/views/forum_topics/index.html.erb
+++ b/app/views/forum_topics/index.html.erb
@@ -11,7 +11,7 @@
       Categories:
       <%= link_to "All", forum_topics_path %>, 
       <%= link_to "New", forum_topics_path(search: { is_read: false }) %>,
-      <% if CurrentUser.is_moderator? %>
+      <% if policy(ForumTopic).moderate? %>
         <%= link_to "Private", forum_topics_path(search: { is_private: true }) %>,
       <% end %>
       <%= ForumTopic::CATEGORIES.map {|id, name| link_to_unless_current(name, forum_topics_path(:search => {:category_id => id}))}.join(", ").html_safe %>

--- a/app/views/forum_topics/show.html.erb
+++ b/app/views/forum_topics/show.html.erb
@@ -28,14 +28,12 @@
 
     <%= render "forum_posts/listing", forum_posts: @forum_posts, original_forum_post_id: @forum_topic.original_post&.id, dtext_data: DText.preprocess(@forum_posts.map(&:body)), moderation_reports: @forum_topic.moderation_reports.visible.recent %>
 
-    <% if CurrentUser.is_member? %>
-      <% if CurrentUser.is_moderator? || !@forum_topic.is_locked? %>
-        <p><%= link_to "Post reply", new_forum_post_path(topic_id: @forum_topic.id), id: "new-response-link" %></p>
+    <% if policy(ForumPost.new(topic: @forum_topic)).create? %>
+      <p><%= link_to "Post reply", new_forum_post_path(topic_id: @forum_topic.id), id: "new-response-link" %></p>
 
-        <div style="display: none;" id="topic-response">
-          <%= render "forum_posts/partials/new/form", :forum_post => ForumPost.new(:topic_id => @forum_topic.id) %>
-        </div>
-      <% end %>
+      <div style="display: none;" id="topic-response">
+        <%= render "forum_posts/partials/new/form", forum_post: ForumPost.new(topic_id: @forum_topic.id) %>
+      </div>
     <% end %>
 
     <%= numbered_paginator(@forum_posts) %>

--- a/app/views/modqueue/_post.html.erb
+++ b/app/views/modqueue/_post.html.erb
@@ -30,7 +30,7 @@
         <strong>Score</strong>
         <span>
           <span id="score-for-post-<%= post.id %>"><%= post.score %></span>
-          <% if CurrentUser.is_voter? %>
+          <% if policy(PostVote).create? %>
             (vote <%= link_to tag.i(class: "far fa-thumbs-up"), post_post_votes_path(score: "up", post_id: post.id), remote: true, method: :post %>/<%= link_to tag.i(class: "far fa-thumbs-down"), post_post_votes_path(score: "down", post_id: post.id), remote: true, method: :post %>)
           <% end %>
         </span>

--- a/app/views/pool_elements/create.js.erb
+++ b/app/views/pool_elements/create.js.erb
@@ -1,5 +1,1 @@
-<% if @error %>
-  Danbooru.error("<%= j @error.to_s %>");
-<% else %>
-  location.reload();
-<% end %>
+location.reload();

--- a/app/views/pools/_secondary_links.html.erb
+++ b/app/views/pools/_secondary_links.html.erb
@@ -2,26 +2,26 @@
   <%= quick_search_form_for(:name_matches, pools_path, "pools", autocomplete: "pool", redirect: true) %>
   <%= subnav_link_to "Gallery", gallery_pools_path %>
   <%= subnav_link_to "Listing", pools_path %>
-  <%= subnav_link_to "New", new_pool_path %>
+  <% if policy(Pool).create? %>
+    <%= subnav_link_to "New", new_pool_path %>
+  <% end %>
   <%= subnav_link_to "Help", wiki_page_path("help:pools") %>
   <% if @pool && !@pool.new_record? %>
     <li>|</li>
     <%= subnav_link_to "Show", pool_path(@pool) %>
     <%= subnav_link_to "Posts", posts_path(:tags => "pool:#{@pool.id}") %>
-    <% if CurrentUser.is_member? %>
+    <% if policy(@pool).update? %>
       <%= subnav_link_to "Edit", edit_pool_path(@pool), "data-shortcut": "e" %>
     <% end %>
-    <% if @pool.deletable_by?(CurrentUser.user) %>
-      <% if @pool.is_deleted? %>
-        <%= subnav_link_to "Undelete", undelete_pool_path(@pool), :method => :post, :remote => true %>
-      <% else %>
-        <%= subnav_link_to "Delete", pool_path(@pool), :method => :delete, :"data-shortcut" => "shift+d", :"data-confirm" => "Are you sure you want to delete this pool?", :remote => true %>
-      <% end %>
+    <% if policy(@pool).undelete? %>
+      <%= subnav_link_to "Undelete", undelete_pool_path(@pool), :method => :post, :remote => true %>
+    <% elsif policy(@pool).destroy? %>
+      <%= subnav_link_to "Delete", pool_path(@pool), :method => :delete, :"data-shortcut" => "shift+d", :"data-confirm" => "Are you sure you want to delete this pool?", :remote => true %>
     <% end %>
     <% if PoolVersion.enabled? %>
       <%= subnav_link_to "History", pool_versions_path(:search => {:pool_id => @pool.id}) %>
     <% end %>
-    <% if CurrentUser.is_member? %>
+    <% if policy(@pool).update? %>
       <%= subnav_link_to "Order", edit_pool_order_path(@pool) %>
     <% end %>
   <% end %>

--- a/app/views/post_disapprovals/index.html.erb
+++ b/app/views/post_disapprovals/index.html.erb
@@ -27,7 +27,7 @@
         <%= link_to post_disapproval.reason.humanize, post_disapprovals_path(search: params[:search].merge(reason: post_disapproval.reason)) %>
       <% end %>
       <% t.column "Created" do |post_disapproval| %>
-        <% if post_disapproval.can_view_creator?(CurrentUser.user) %>
+        <% if policy(post_disapproval).can_view_creator? %>
           <%= link_to_user post_disapproval.user %>
           <%= link_to "»", post_disapprovals_path(search: params[:search].merge(creator_name: post_disapproval.user&.name)) %>
         <% end %>

--- a/app/views/post_flags/_reasons.html.erb
+++ b/app/views/post_flags/_reasons.html.erb
@@ -3,7 +3,7 @@
     <li class="post-flag-reason">
       <span class="prose"><%= format_text(flag.reason, inline: true) %></span>
 
-      <% if CurrentUser.can_view_flagger_on_post?(flag) %>
+      <% if policy(flag).can_view_flagger? %>
         - <%= link_to_user(flag.creator) %>
       <% end %>
 

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -2,7 +2,7 @@
   <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches", input_html: { value: params[:search][:reason_matches] } %>
   <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
-  <% if CurrentUser.is_moderator? %>
+  <% if policy(PostFlag).can_search_flagger? %>
     <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name], data: { autocomplete: "user" } } %>
   <% end %>
   <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_resolved] %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -29,7 +29,7 @@
       <% end %>
       <% t.column "Flagged", width: "15%" do |post_flag| %>
         <%= compact_time post_flag.created_at %>
-        <% if CurrentUser.can_view_flagger_on_post?(post_flag) %>
+        <% if policy(post_flag).can_view_flagger? %>
           <br> by <%= link_to_user post_flag.creator %>
           <%= link_to "»", post_flags_path(search: params[:search].merge(creator_name: post_flag.creator.name)) %>
         <% end %>

--- a/app/views/post_versions/_listing.html.erb
+++ b/app/views/post_versions/_listing.html.erb
@@ -4,9 +4,9 @@
   <% end %>
 
     <%= table_for @post_versions, {id: "post-versions-table", class: "striped autofit"} do |t| %>
-      <% if CurrentUser.user.is_builder? %>
+      <% if policy(@post_versions).can_mass_undo? %>
         <% t.column tag.label(tag.input type: :checkbox, id: "post-version-select-all-checkbox", class: "post-version-select-checkbox"), column: "post-version-select" do |post_version| %>
-          <input type="checkbox" class="post-version-select-checkbox" <%= "disabled" unless post_version.can_undo?(CurrentUser.user) %>>
+          <input type="checkbox" class="post-version-select-checkbox" <%= "disabled" unless policy(post_version).undo? %>>
         <% end %>
       <% end %>
       <% if listing_type(:post_id) == :standard %>
@@ -31,10 +31,10 @@
         </div>
       <% end %>
       <% t.column do |post_version| %>
-        <% if post_version.can_undo?(CurrentUser.user) %>
+        <% if policy(post_version).can_undo? %>
           <%= link_to "Undo", undo_post_version_path(post_version), method: :put, remote: true, class: "post-version-undo-link" %>
         <% end %>
-        <% if listing_type(:post_id) == :revert && post_version.can_revert_to?(CurrentUser.user) %>
+        <% if listing_type(:post_id) == :revert && policy(post_version.post).revert? %>
           | <%= link_to "Revert to", revert_post_path(post_version.post_id, version_id: post_version.id), method: :put, remote: true %>
         <% end %>
       <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,7 +7,7 @@
 
   <section id="tag-box">
     <h1>Tags</h1>
-    <%= @post_set.presenter.tag_list_html(current_query: params[:tags], show_extra_links: CurrentUser.user.is_gold?) %>
+    <%= @post_set.presenter.tag_list_html(current_query: params[:tags], show_extra_links: policy(Post).show_extra_links?) %>
   </section>
 
   <% if Danbooru.config.addthis_key.present? %>

--- a/app/views/posts/partials/common/_secondary_links.html.erb
+++ b/app/views/posts/partials/common/_secondary_links.html.erb
@@ -5,13 +5,17 @@
   <% if RecommenderService.available_for_user?(CurrentUser.user) %>
     <%= subnav_link_to "Recommended", recommended_posts_path(search: { user_name: CurrentUser.name }) %>
   <% end %>
-  <% unless CurrentUser.is_anonymous? %>
+  <% if policy(Favorite).create? %>
     <%= subnav_link_to "Favorites", posts_path(tags: "ordfav:#{CurrentUser.user.name}") %>
+  <% end %>
+  <% if policy(FavoriteGroup).create? %>
     <%= subnav_link_to "Fav groups", favorite_groups_path(search: { creator_name: CurrentUser.name }) %>
+  <% end %>
+  <% if policy(SavedSearch).create? %>
     <%= subnav_link_to "Saved searches", posts_path(tags: "search:all") %>
   <% end %>
   <%= subnav_link_to "Changes", post_versions_path %>
-  <% if CurrentUser.can_approve_posts? %>
+  <% if policy(PostApproval).create? %>
     <%= subnav_link_to "Modqueue", modqueue_index_path %>
   <% end %>
   <%= subnav_link_to "Help", wiki_page_path("help:posts") %>

--- a/app/views/posts/partials/index/_mode_menu.html.erb
+++ b/app/views/posts/partials/index/_mode_menu.html.erb
@@ -1,4 +1,4 @@
-<% if CurrentUser.is_gold? %>
+<% if policy(Post).can_use_mode_menu? %>
   <section id="mode-box">
     <h1>Mode</h1>
     <form action="/">

--- a/app/views/posts/partials/index/_options.html.erb
+++ b/app/views/posts/partials/index/_options.html.erb
@@ -1,7 +1,7 @@
 <section id="options-box">
   <h1>Options</h1>
   <ul>
-    <% if CurrentUser.is_member? %>
+    <% if policy(SavedSearch).create? %>
       <li><%= button_tag(tag.i(class: "fas fa-bookmark") + " Save search", id: "save-search", class: "ui-button ui-widget ui-corner-all sub") %></li>
     <% end %>
   </ul>

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -26,13 +26,17 @@
     <%= f.input :has_embedded_notes, label: "Embed notes", as: :boolean, boolean_style: :inline, disabled: post.is_note_locked? %>
   </fieldset>
 
-  <% if CurrentUser.is_builder? %>
+  <% if policy(post).can_lock_rating? || policy(post).can_lock_notes? || policy(post).can_lock_status? %>
     <fieldset class="inline-fieldset">
       <label>Lock</label>
 
-      <%= f.input :is_rating_locked, label: "Rating", as: :boolean, boolean_style: :inline  %>
-      <%= f.input :is_note_locked, label: "Notes", as: :boolean, boolean_style: :inline  %>
-      <% if CurrentUser.is_admin? %>
+      <% if policy(post).can_lock_rating? %>
+        <%= f.input :is_rating_locked, label: "Rating", as: :boolean, boolean_style: :inline  %>
+      <% end %>
+      <% if policy(post).can_lock_notes? %>
+        <%= f.input :is_note_locked, label: "Notes", as: :boolean, boolean_style: :inline  %>
+      <% end %>
+      <% if policy(post).can_lock_status? %>
         <%= f.input :is_status_locked, label: "Status", as: :boolean, boolean_style: :inline  %>
       <% end %>
     </fieldset>

--- a/app/views/posts/partials/show/_image.html.erb
+++ b/app/views/posts/partials/show/_image.html.erb
@@ -1,3 +1,3 @@
-<% if post.visible? %>
+<% if policy(post).visible? %>
   <%= image_tag(post.file_url_for(CurrentUser.user), :width => post.image_width_for(CurrentUser.user), :height => post.image_height_for(CurrentUser.user), :id => "image", "data-original-width" => post.image_width, "data-original-height" => post.image_height, "data-large-width" => post.large_image_width, "data-large-height" => post.large_image_height, "data-tags" => post.tag_string, :alt => post.presenter.humanized_essential_tag_string, "data-uploader" => post.uploader.name, "data-rating" => post.rating, "data-flags" => post.status_flags, "data-parent-id" => post.parent_id, "data-has-children" => post.has_children?, "data-has-active-children" => post.has_active_children?, "data-score" => post.score, "data-fav-count" => post.fav_count, "itemprop" => "contentUrl") %>
 <% end %>

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -19,7 +19,7 @@
   <li id="post-info-source">Source: <%= post_source_tag(post) %></li>
   <li id="post-info-rating">Rating: <%= post.pretty_rating %></li>
   <li id="post-info-score">Score: <span id="score-for-post-<%= post.id %>"><%= post.score %></span>
-    <% if CurrentUser.is_voter? %>
+    <% if policy(PostVote).create? %>
       <%= tag.span id: "vote-links-for-post-#{post.id}", style: ("display: none;" if !@post.can_be_voted_by?(CurrentUser.user)) do %>
         (vote
         <%= link_to tag.i(class: "far fa-thumbs-up"), post_post_votes_path(post_id: post.id, score: "up"), remote: true, method: :post %>

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -1,6 +1,6 @@
 <ul>
   <li id="post-info-id">ID: <%= post.id %></li>
-  <% if CurrentUser.is_moderator? %>
+  <% if policy(post).can_view_uploader? %>
     <li id="post-info-uploader">Uploader: <%= link_to_user(post.uploader) %></li>
   <% end %>
   <li id="post-info-date">
@@ -11,7 +11,7 @@
     <li id="post-info-approver">Approver: <%= link_to_user(post.approver) %></li>
   <% end %>
   <li id="post-info-size">
-    Size: <%= link_to_if post.visible?, number_to_human_size(post.file_size), post.tagged_file_url %>
+    Size: <%= link_to_if policy(post).visible?, number_to_human_size(post.file_size), post.tagged_file_url %>
     <% if post.has_dimensions? %>
       (<span itemprop="width"><%= post.image_width %></span>x<span itemprop="height"><%= post.image_height %></span>)
     <% end %>
@@ -31,7 +31,7 @@
     <% end %>
   </li>
   <li id="post-info-favorites">Favorites: <span id="favcount-for-post-<%= post.id %>"><%= post.fav_count %></span>
-  <% if CurrentUser.is_gold? %>
+    <% if policy(post).can_view_favlist? %>
     <%= link_to "Show »", "#", id: "show-favlist-link", style: ("display: none;" if post.fav_count == 0) %>
     <%= link_to "« Hide", "#", id: "hide-favlist-link", style: "display: none;" %>
     <div id="favlist" style="display: none;"><%= post_favlist(post) %></div>

--- a/app/views/posts/partials/show/_notices.html.erb
+++ b/app/views/posts/partials/show/_notices.html.erb
@@ -41,7 +41,7 @@
 
     <%= render "post_disapprovals/counts", :disapprovals => post.disapprovals, :post => post %>
 
-    <% if CurrentUser.can_approve_posts? && !post.disapproved_by?(CurrentUser.user) %>
+    <% if policy(PostDisapproval).create? && !post.disapproved_by?(CurrentUser.user) %>
       <%= render "modqueue/quick_mod", post: post %>
       <%= render "post_disapprovals/detailed_rejection_dialog" %>
     <% end %>
@@ -67,7 +67,7 @@
   </div>
 <% end %>
 
-<% if post.visible? && post.has_large? && !post.is_ugoira? %>
+<% if policy(post).visible? && post.has_large? && !post.is_ugoira? %>
   <div class="notice notice-small post-notice post-notice-resized" id="image-resize-notice" style="<%= CurrentUser.default_image_size == "original" ? "display: none;" : "" %>">
     <span>Resized to <%= number_to_percentage post.resize_percentage.floor, :precision => 0 %> of original (<%= link_to "view original", post.tagged_file_url, :id => "image-resize-link" %>)</span>
     <span style="display: none;">Loading...</span>

--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -52,10 +52,10 @@
       <% if policy(PostApproval).create? %>
         <% if post.is_deleted? %>
           <li id="post-option-undelete"><%= link_to "Undelete", post_approvals_path(post_id: post.id), remote: true, method: :post, "data-confirm": "Are you sure you want to undelete this post?" %></li>
-          <% if post.fav_count > 0 && post.parent_id %>
+          <% if policy(post).move_favorites? %>
             <li id="post-option-move-favorites"><%= link_to "Move favorites", confirm_move_favorites_moderator_post_post_path(post_id: post.id) %></li>
           <% end %>
-        <% else %>
+        <% elsif policy(post).delete? %>
           <li id="post-option-delete"><%= link_to "Delete", confirm_delete_moderator_post_post_path(post_id: post.id) %></li>
         <% end %>
 
@@ -64,13 +64,13 @@
           <li id="post-option-disapprove"><%= link_to "Hide from queue", post_disapprovals_path(post_disapproval: { post_id: post.id, reason: "disinterest" }), remote: true, method: :post, id: "disapprove" %></li>
         <% end %>
 
-        <% if post.is_banned? %>
+        <% if policy(post).unban? %>
           <li id="post-option-unban"><%= link_to "Unban", unban_moderator_post_post_path(post), method: :post, "data-confirm": "Are you sure you want to unban this post?" %></li>
-        <% else %>
+        <% elsif policy(post).ban? %>
           <li id="post-option-ban"><%= link_to "Ban", ban_moderator_post_post_path(post), method: :post, "data-confirm": "Are you sure you want to ban this post?" %></li>
         <% end %>
 
-        <% if CurrentUser.is_admin? %>
+        <% if policy(post).expunge? %>
           <li id="post-option-expunge"><%= link_to "Expunge", expunge_moderator_post_post_path(post_id: post.id), remote: true, method: :post, "data-confirm": "This will permanently delete this post (meaning the file will be deleted). Are you sure you want to delete this post?" %></li>
         <% end %>
       <% end %>

--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -7,17 +7,21 @@
   <li id="post-option-find-similar">
     <%= link_to "Find similar", iqdb_queries_path(post_id: post.id) %>
   </li>
-  <li id="post-option-download">
-    <%= link_to_if post.visible?, "Download", post.tagged_file_url + "?download=1", download: post.presenter.filename_for_download %>
-  </li>
+  <% if policy(post).visible? %>
+    <li id="post-option-download">
+      <%= link_to "Download", post.tagged_file_url + "?download=1", download: post.presenter.filename_for_download %>
+    </li>
+  <% end %>
 
-  <% if CurrentUser.is_member? %>
+  <% if policy(Favorite).create? %>
     <li id="post-option-add-to-favorites">
       <%= link_to "Favorite", favorites_path(post_id: post.id), remote: true, method: :post, id: "add-to-favorites", "data-shortcut": "f", style: ("display: none;" if @post.is_favorited?) %>
     </li>
     <li id="post-option-remove-from-favorites">
       <%= link_to "Unfavorite", favorite_path(post), remote: true, method: :delete, id: "remove-from-favorites", "data-shortcut": "shift+f", style: ("display: none;" if !@post.is_favorited?) %>
     </li>
+  <% end %>
+  <% if policy(post).update? %>
     <li id="post-option-edit"><%= link_to "Edit", "#edit", id: "side-edit-link" %></li>
     <li id="post-option-add-to-pool"><%= link_to "Add to pool", "#", id: "pool" %></li>
     <li id="post-option-add-note">
@@ -31,18 +35,21 @@
       <li id="post-option-copy-notes"><%= link_to "Copy notes", "#", id: "copy-notes" %></li>
     <% end %>
     <li id="post-option-add-commentary"><%= link_to "Add commentary", "#", id: "add-commentary" %></li>
+  <% end %>
+  <% if policy(FavoriteGroup).create? %>
     <li id="post-option-add-fav-group"><%= link_to "Add to fav group", "#", id: "open-favgroup-dialog-link", "data-shortcut": "g" %></li>
+  <% end %>
 
     <% if post.is_status_locked? %>
       <li id="post-option-status-locked">Status locked</li>
     <% else %>
-      <% if !post.is_deleted? && !post.is_pending? && !post.is_flagged? %>
+      <% if (!post.is_deleted? && !post.is_pending? && !post.is_flagged?) && policy(PostFlag).create? %>
         <li id="post-option-flag"><%= link_to "Flag", new_post_flag_path(post_flag: { post_id: post.id }), remote: true %></li>
-      <% elsif post.is_flagged? || post.is_deleted? %>
+      <% elsif (post.is_flagged? || post.is_deleted?) && policy(PostAppeal).create? %>
         <li id="post-option-appeal"><%= link_to "Appeal", new_post_appeal_path(post_appeal: { post_id: post.id }), remote: true %></li>
       <% end %>
 
-      <% if CurrentUser.can_approve_posts? %>
+      <% if policy(PostApproval).create? %>
         <% if post.is_deleted? %>
           <li id="post-option-undelete"><%= link_to "Undelete", post_approvals_path(post_id: post.id), remote: true, method: :post, "data-confirm": "Are you sure you want to undelete this post?" %></li>
           <% if post.fav_count > 0 && post.parent_id %>
@@ -66,11 +73,10 @@
         <% if CurrentUser.is_admin? %>
           <li id="post-option-expunge"><%= link_to "Expunge", expunge_moderator_post_post_path(post_id: post.id), remote: true, method: :post, "data-confirm": "This will permanently delete this post (meaning the file will be deleted). Are you sure you want to delete this post?" %></li>
         <% end %>
+      <% end %>
 
-        <% if CurrentUser.is_moderator? %>
-          <li id="post-option-replace-image"><%= link_to "Replace image", new_post_replacement_path(post_id: post.id), remote: true %></li>
-        <% end %>
+      <% if policy(PostReplacement).create? %>
+        <li id="post-option-replace-image"><%= link_to "Replace image", new_post_replacement_path(post_id: post.id), remote: true %></li>
       <% end %>
     <% end %>
-  <% end %>
 </ul>

--- a/app/views/posts/show.html+tooltip.erb
+++ b/app/views/posts/show.html+tooltip.erb
@@ -1,6 +1,6 @@
 <div class="post-tooltip-header">
   <span class="post-tooltip-header-left">
-    <% if CurrentUser.is_moderator? %>
+    <% if policy(@post).can_view_uploader? %>
       <%= link_to_user @post.uploader %>
     <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,7 @@
   <%= render "posts/partials/index/blacklist" %>
 
   <section id="tag-list">
-    <%= @post.presenter.split_tag_list_html(current_query: params[:q], show_extra_links: CurrentUser.user.is_gold?) %>
+    <%= @post.presenter.split_tag_list_html(current_query: params[:q], show_extra_links: policy(@post).show_extra_links?) %>
   </section>
 
   <section id="post-information">
@@ -108,7 +108,7 @@
       <li><a href="#recommended">Recommended</a></li>
     <% end %>
 
-    <% if CurrentUser.is_member? && @post.visible? %>
+    <% if policy(@post).update? %>
       <li><a href="#edit" id="post-edit-link" data-shortcut="e">Edit</a></li>
     <% end %>
   </menu>
@@ -134,22 +134,26 @@
     <% end %>
   </section>
 
-  <% if CurrentUser.is_member? && @post.visible? %>
+  <% if policy(@post).update? %>
     <section id="edit" style="display: none;">
       <%= render "posts/partials/show/edit", :post => @post %>
     </section>
   <% end %>
 <% end %>
 
-<% if CurrentUser.is_member? %>
+<% if policy(Pool).create? %>
   <div id="add-to-pool-dialog" title="Add to pool" style="display: none;">
     <%= render "pool_elements/new" %>
   </div>
+<% end %>
 
+<% if policy(ArtistCommentary).create_or_update? %>
   <div id="add-commentary-dialog" title="Add artist commentary" style="display: none;">
     <%= render "artist_commentaries/form", post: @post, artist_commentary: @post.artist_commentary || ArtistCommentary.new(post: @post) %>
   </div>
+<% end %>
 
+<% if policy(FavoriteGroup).create? %>
   <div id="add-to-favgroup-dialog" title="Add to favorite group" style="display: none;">
     <%= render "favorite_groups/add_to_favgroup_dialog", :post => @post %>
   </div>
@@ -161,7 +165,7 @@
   <meta name="post-id" content="<%= @post.id %>">
   <meta name="post-has-embedded-notes" content="<%= @post.has_embedded_notes? %>">
 
-  <% if @post.visible? %>
+  <% if policy(@post).visible? %>
     <%= tag.meta name: "og:image", content: @post.open_graph_image_url %>
   <% end %>
 
@@ -170,7 +174,7 @@
   <% if @post.twitter_card_supported? %>
     <meta name="twitter:card" content="summary_large_image">
 
-    <% if @post.visible? %>
+    <% if policy(@post).visible? %>
       <%= tag.meta name: "twitter:image", content: @post.open_graph_image_url %>
     <% end %>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -56,7 +56,7 @@
     <%= render "posts/partials/show/embedded", post: @post %>
   <% end -%>
 
-  <% if CurrentUser.is_member? %>
+  <% if policy(Favorite).create? %>
     <%= content_tag(:div, class: "fav-buttons fav-buttons-#{@post.is_favorited?}") do %>
       <%= form_tag(favorites_path(post_id: @post.id), method: "post", id: "add-fav-button", "data-remote": true) do %>
         <%= button_tag tag.i(class: "far fa-heart"), class: "ui-button ui-widget ui-corner-all", "data-disable-with": tag.i(class: "fas fa-spinner fa-spin") %>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -121,7 +121,7 @@
         <% else %>
           <li><%= link_to "Profile", profile_path %></li>
           <li><%= link_to "Settings", settings_path %></li>
-          <% if CurrentUser.is_gold? %>
+          <% if policy(UserNameChangeRequest).create? %>
             <li><%= link_to "Change name", new_user_name_change_request_path %></li>
           <% end %>
           <li><%= link_to "Delete account", maintenance_user_deletion_path %></li>
@@ -150,7 +150,7 @@
         <li><%= link_to("Jobs", delayed_jobs_path) %></li>
         <li><%= link_to("Bulk Update Requests", bulk_update_requests_path) %></li>
 
-        <% if CurrentUser.is_member? %>
+        <% if policy(UserNameChangeRequest).index? %>
           <li><%= link_to("User Name Change Requests", user_name_change_requests_path) %></li>
         <% end %>
 

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -13,7 +13,7 @@
         <li><%= link_to("Curated", curated_explore_posts_path) %></li>
         <li><%= link_to("Most Viewed", viewed_explore_posts_path) %></li>
         <li><%= link_to("Votes", post_votes_path) %></li>
-        <% if CurrentUser.can_approve_posts? %>
+        <% if policy(PostApproval).create? %>
           <li><%= link_to("Modqueue", modqueue_index_path) %></li>
         <% end %>
       </ul>
@@ -21,9 +21,7 @@
         <li><h1>Post Events</h1></li>
         <li><%= link_to("Changes", post_versions_path) %></li>
         <li><%= link_to("Approvals", post_approvals_path) %></li>
-        <% if CurrentUser.is_approver? %>
-          <li><%= link_to("Disapprovals", post_disapprovals_path) %></li>
-        <% end %>
+        <li><%= link_to("Disapprovals", post_disapprovals_path) %></li>
         <li><%= link_to("Appeals", post_appeals_path) %></li>
         <li><%= link_to("Flags", post_flags_path) %></li>
         <li><%= link_to("Replacements", post_replacements_path) %></li>
@@ -154,8 +152,11 @@
           <li><%= link_to("User Name Change Requests", user_name_change_requests_path) %></li>
         <% end %>
 
-        <% if CurrentUser.is_moderator? %>
+        <% if policy(ModerationReport).index? %>
           <li><%= link_to("Moderation Reports", moderation_reports_path) %></li>
+        <% end %>
+
+        <% if policy(IpAddress).index? %>
           <li><%= link_to("IP Addresses", ip_addresses_path) %></li>
         <% end %>
 
@@ -163,8 +164,11 @@
           <li><%= link_to("IP Bans", ip_bans_path) %></li>
         <% end %>
 
-        <% if CurrentUser.is_admin? %>
+        <% if policy(NewsUpdate).index? %>
           <li><%= link_to("News Updates", news_updates_path) %></li>
+        <% end %>
+
+        <% if CurrentUser.is_admin? %>
           <li><%= link_to("Admin Dashboard", admin_dashboard_path) %></li>
         <% end %>
       </ul>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -157,6 +157,9 @@
         <% if CurrentUser.is_moderator? %>
           <li><%= link_to("Moderation Reports", moderation_reports_path) %></li>
           <li><%= link_to("IP Addresses", ip_addresses_path) %></li>
+        <% end %>
+
+        <% if policy(IpBan).index? %>
           <li><%= link_to("IP Bans", ip_bans_path) %></li>
         <% end %>
 

--- a/app/views/tag_aliases/_listing.html.erb
+++ b/app/views/tag_aliases/_listing.html.erb
@@ -23,7 +23,7 @@
   <% t.column column: "control", width: "15%" do |tag_alias| %>
     <%= link_to "Show", tag_alias_path(tag_alias) %>
 
-    <% if tag_alias.deletable_by?(CurrentUser.user) %>
+    <% if policy(tag_alias).destroy? %>
       | <%= link_to "Delete", tag_alias_path(tag_alias), :remote => true, :method => :delete, :data => {:confirm => "Are you sure you want to delete this alias?"} %>
     <% end %>
   <% end %>

--- a/app/views/tag_implications/_listing.html.erb
+++ b/app/views/tag_implications/_listing.html.erb
@@ -23,7 +23,7 @@
   <% t.column column: "control", width: "15%" do |tag_implication| %>
     <%= link_to "Show", tag_implication_path(tag_implication) %>
 
-    <% if tag_implication.deletable_by?(CurrentUser.user) %>
+    <% if policy(tag_implication).destroy? %>
       | <%= link_to "Delete", tag_implication_path(tag_implication), :remote => true, :method => :delete, :data => {:confirm => "Are you sure you want to delete this implication?"} %>
     <% end %>
   <% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -9,7 +9,7 @@
         <%= f.input :category, :collection => TagCategory.canonical_mapping.to_a, :include_blank => false %>
       <% end %>
 
-      <% if CurrentUser.is_moderator? %>
+      <% if policy(@tag).can_lock? %>
         <%= f.input :is_locked, :collection => [["No", "false"], ["Yes", "true"]], :include_blank => false %>
       <% end %>
 

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -16,7 +16,9 @@
         <% end %>
       <% end %>
       <% t.column column: "control" do |tag| %>
-        <%= link_to_if tag.editable_by?(CurrentUser.user), "Edit", edit_tag_path(tag) %> |
+        <% if policy(tag).update? %>
+          <%= link_to "Edit", edit_tag_path(tag) %> |
+        <% end %>
         <%= link_to "History", post_versions_path(search: { changed_tags: tag.name }) %> |
         <%= link_to "Related", related_tag_path(search: { query: tag.name }) %> |
         <%= link_to "Similar", tags_path(search: { fuzzy_name_matches: tag.name, order: :similarity }) %>

--- a/app/views/user_feedbacks/_secondary_links.html.erb
+++ b/app/views/user_feedbacks/_secondary_links.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:secondary_links) do %>
-  <% if CurrentUser.is_gold? %>
-    <% if @user_feedback %>
+  <% if policy(UserFeedback.new).create? %>
+    <% if @user_feedback.present? && policy(@user_feedback).create? %>
       <%= subnav_link_to "New", new_user_feedback_path(:user_feedback => {:user_id => @user_feedback.user_id}) %>
     <% elsif params[:search] && params[:search][:user_id] %>
       <%= subnav_link_to "New", new_user_feedback_path(:user_feedback => {:user_id => params[:search][:user_id]}) %>

--- a/app/views/user_feedbacks/edit.html.erb
+++ b/app/views/user_feedbacks/edit.html.erb
@@ -10,9 +10,7 @@
     <%= edit_form_for(@user_feedback) do |f| %>
       <%= f.input :category, :collection => ["positive", "neutral", "negative"], :include_blank => false %>
       <%= dtext_field "user_feedback", "body" %>
-      <% if @user_feedback.deletable_by?(CurrentUser.user) %>
-        <%= f.input :is_deleted, label: "Deleted" %>
-      <% end %>
+      <%= f.input :is_deleted, label: "Deleted" %>
       <%= f.button :submit, "Submit" %>
       <%= dtext_preview_button "user_feedback", "body" %>
     <% end %>

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -7,7 +7,7 @@
       <%= f.input :creator_name, input_html: { value: params.dig(:search, :creator_name), "data-autocomplete": "user" } %>
       <%= f.input :body_matches, label: "Message", input_html: { value: params.dig(:search, :body_matches) } %>
       <%= f.input :category, collection: %w[positive negative neutral], include_blank: true, selected: params.dig(:search, :category) %>
-      <% if CurrentUser.is_moderator? %>
+      <% if policy(UserFeedback).can_view_deleted? %>
         <%= f.input :is_deleted, label: "Deleted", collection: %w[Yes No], include_blank: true, selected: params.dig(:search, :is_deleted) %>
       <% end %>
       <%= f.submit "Search" %>
@@ -24,9 +24,9 @@
         </div>
         <%= render "application/update_notice", record: feedback, interval: 0.minutes %>
       <% end %>
-      <% if CurrentUser.is_moderator? %>
+      <% if policy(UserFeedback).can_view_deleted? %>
         <% t.column "Status" do |feedback| %>
-          <%= "deleted" if feedback.is_deleted? %>
+          <%= "Deleted" if feedback.is_deleted? %>
         <% end %>
       <% end %>
       <% t.column "Category" do |feedback| %>
@@ -38,12 +38,12 @@
         <div><%= time_ago_in_words_tagged(feedback.created_at) %></div>
       <% end %>
       <% t.column column: "control" do |feedback| %>
-        <% if feedback.editable_by?(CurrentUser.user) %>
-          <%= link_to "edit", edit_user_feedback_path(feedback) %>
-          <% if feedback.deletable_by?(CurrentUser.user) && !feedback.is_deleted? %>
-            | <%= link_to "delete", user_feedback_path(feedback), method: :put, remote: true, "data-params": "user_feedback[is_deleted]=true", "data-confirm": "Are you sure you want to delete this user feedback?" %>
-          <% elsif feedback.deletable_by?(CurrentUser.user) && feedback.is_deleted? %>
-            | <%= link_to "undelete", user_feedback_path(feedback), method: :put, remote: true, "data-params": "user_feedback[is_deleted]=false" %>
+        <% if policy(feedback).update? %>
+          <%= link_to "Edit", edit_user_feedback_path(feedback) %>
+          <% if feedback.is_deleted? %>
+            | <%= link_to "Undelete", user_feedback_path(feedback), method: :put, remote: true, "data-params": "user_feedback[is_deleted]=false" %>
+          <% else %>
+            | <%= link_to "Delete", user_feedback_path(feedback), method: :put, remote: true, "data-params": "user_feedback[is_deleted]=true", "data-confirm": "Are you sure you want to delete this user feedback?" %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/user_feedbacks/show.html.erb
+++ b/app/views/user_feedbacks/show.html.erb
@@ -17,7 +17,7 @@
       </li>
     </ul>
 
-    <% if @user_feedback.editable_by?(CurrentUser.user) %>
+    <% if policy(@user_feedback).update? %>
       <p><%= link_to "Edit", edit_user_feedback_path(@user_feedback) %></p>
     <% end %>
   </div>

--- a/app/views/user_mailer/email_change_confirmation.html.erb
+++ b/app/views/user_mailer/email_change_confirmation.html.erb
@@ -9,7 +9,7 @@
     </p>
 
     <p>
-      <%= link_to "Verify email address", verify_user_email_url(@user, email_verification_key: Danbooru::MessageVerifier.new(:email_verification_key).generate(@user.email_address.id)) %>
+      <%= link_to "Verify email address", email_verification_url(@user) %>
     </p>
 
     <p>

--- a/app/views/user_mailer/welcome_user.html.erb
+++ b/app/views/user_mailer/welcome_user.html.erb
@@ -8,7 +8,7 @@
     </p>
 
     <p>
-      <%= link_to "Verify email address", verify_user_email_url(@user, email_verification_key: Danbooru::MessageVerifier.new(:email_verification_key).generate(@user.email_address.id)) %>
+      <%= link_to "Verify email address", email_verification_url(@user) %>
     </p>
 
     <p>

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -27,8 +27,11 @@
       <% end %>
     <% end %>
 
-    <% if CurrentUser.user.is_moderator? %>
+    <% if policy(CurrentUser.user).promote? %>
       <%= subnav_link_to "Promote", edit_admin_user_path(@user) %>
+    <% end %>
+
+    <% if policy(Ban.new(user: @user)).create? %>
       <% if @user.is_banned? && @user.recent_ban.present? %>
         <%= subnav_link_to "Unban", ban_path(@user.recent_ban) %>
       <% else %>

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -22,7 +22,7 @@
       <% if !@user.is_platinum? %>
         <%= subnav_link_to "Gift upgrade", new_user_upgrade_path(:user_id => @user.id) %>
       <% end %>
-      <% if @user.reportable_by?(CurrentUser.user) %>
+      <% if policy(@user).reportable? %>
         <%= subnav_link_to "Report user", new_moderation_report_path(moderation_report: { model_type: "User", model_id: @user.id }), remote: true %>
       <% end %>
     <% end %>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -10,7 +10,7 @@
         <th>Join Date</th>
         <td><%= presenter.join_date %></td>
       </tr>
-      <% if CurrentUser.is_moderator? %>
+      <% if policy(IpAddress).show? %>
         <tr>
           <th>Last IP</th>
           <td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,7 +4,7 @@
 
     <%= table_for @users, width: "100%" do |t| %>
       <% t.column column: "control" do |user| %>
-        <% if CurrentUser.is_admin? %>
+        <% if policy(CurrentUser.user).promote? %>
           <%= link_to "Edit", edit_admin_user_path(user) %>
         <% end %>
       <% end %>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -7,7 +7,7 @@
 
     <%= dtext_field "wiki_page", "body" %>
 
-    <% if CurrentUser.is_builder? %>
+    <% if policy(@wiki_page).can_edit_locked? %>
       <%= f.input :is_locked, label: "Locked", hint: "Locked wikis can only be edited by Builders." %>
     <% end %>
 

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -2,7 +2,7 @@
   <%= quick_search_form_for(:title_normalize, wiki_pages_path, "wiki pages", autocomplete: "wiki-page", redirect: true) %>
   <%= subnav_link_to "Listing", wiki_pages_path %>
   <%= subnav_link_to "Search", search_wiki_pages_path %>
-  <% if CurrentUser.is_member? %>
+  <% if policy(WikiPage).new? %>
     <%= subnav_link_to "New", new_wiki_page_path %>
   <% end %>
   <%= subnav_link_to "Help", wiki_page_path("help:wiki") %>
@@ -13,7 +13,7 @@
     <li>|</li>
     <%= subnav_link_to "Posts (#{@wiki_page.tag.try(:post_count) || 0})", posts_path(:tags => @wiki_page.title) %>
     <%= subnav_link_to "History", wiki_page_versions_path(:search => {:wiki_page_id => @wiki_page.id}) %>
-    <% if CurrentUser.is_member? %>
+    <% if policy(@wiki_page).edit? %>
       <%= subnav_link_to "Edit", edit_wiki_page_path(@wiki_page.id), "data-shortcut": "e" %>
 
       <% if @wiki_page.is_deleted? %>
@@ -28,7 +28,7 @@
     <% if @wiki_page_version.previous %>
       <%= subnav_link_to "Diff", diff_wiki_page_versions_path(:otherpage => @wiki_page_version.id, :thispage => @wiki_page_version.previous.id) %>
     <% end %>
-    <% if CurrentUser.is_member? %>
+    <% if policy(@wiki_page_version.wiki_page).revert? %>
       <%= subnav_link_to "Revert to", revert_wiki_page_path(@wiki_page_version.wiki_page_id, :version_id => @wiki_page_version.id), :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
     <% end %>
   <% end %>

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -20,8 +20,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
         should "succeed" do
           put_auth admin_user_path(@user), @mod, params: {:user => {:level => "30"}}
           assert_redirected_to(edit_admin_user_path(@user))
-          @user.reload
-          assert_equal(30, @user.level)
+          assert_equal(30, @user.reload.level)
           assert_equal(@mod.id, @user.inviter_id)
         end
 
@@ -29,8 +28,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
           should "fail" do
             put_auth admin_user_path(@user), @mod, params: {:user => {:level => "50"}}
             assert_response(403)
-            @user.reload
-            assert_equal(20, @user.level)
+            assert_equal(20, @user.reload.level)
           end
         end
       end
@@ -39,8 +37,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
         should "fail" do
           put_auth admin_user_path(@admin), @mod, params: {:user => {:level => "30"}}
           assert_response(403)
-          @admin.reload
-          assert_equal(50, @admin.level)
+          assert_equal(50, @admin.reload.level)
         end
       end
     end

--- a/test/functional/artists_controller_test.rb
+++ b/test/functional/artists_controller_test.rb
@@ -39,100 +39,115 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
     end
 
     context "show action" do
+      should "work for html responses" do
+        get artist_path(@masao.id)
+        assert_response :success
+      end
+
       should "work for xml responses" do
         get artist_path(@masao.id), as: :xml
         assert_response :success
       end
-    end
 
-    should "get the new page" do
-      get_auth new_artist_path, @user
-      assert_response :success
-    end
-
-    should "get the show_or_new page for an existing artist" do
-      get_auth show_or_new_artists_path(name: "masao"), @user
-      assert_redirected_to(@masao)
-    end
-
-    should "get the show_or_new page for a nonexisting artist" do
-      get_auth show_or_new_artists_path(name: "nobody"), @user
-      assert_response :success
-    end
-
-    should "get the edit page" do
-      get_auth edit_artist_path(@artist.id), @user
-      assert_response :success
-    end
-
-    should "get the show page" do
-      get artist_path(@artist.id)
-      assert_response :success
-    end
-
-    should "get the show page for a negated tag" do
-      @artist.update(name: "-aaa")
-      get artist_path(@artist.id)
-      assert_response :success
-    end
-
-    should "get the banned page" do
-      get banned_artists_path
-      assert_redirected_to artists_path(search: { is_banned: true, order: "updated_at" })
-    end
-
-    should "ban an artist" do
-      put_auth ban_artist_path(@artist.id), @admin
-      assert_redirected_to(@artist)
-      @artist.reload
-      assert_equal(true, @artist.is_banned?)
-      assert_equal(true, TagImplication.exists?(antecedent_name: @artist.name, consequent_name: "banned_artist"))
-    end
-
-    should "unban an artist" do
-      as_admin do
-        @artist.ban!
-      end
-
-      put_auth unban_artist_path(@artist.id), @admin
-      assert_redirected_to(@artist)
-      @artist.reload
-      assert_equal(false, @artist.is_banned?)
-      assert_equal(false, TagImplication.exists?(antecedent_name: @artist.name, consequent_name: "banned_artist"))
-    end
-
-    should "get the index page" do
-      get artists_path
-      assert_response :success
-    end
-
-    context "when searching the index page" do
-      should "find artists by name" do
-        get artists_path(name: "masao", format: "json")
-        assert_artist_found("masao")
-      end
-
-      should "find artists by image URL" do
-        get artists_path(search: { url_matches: "http://i2.pixiv.net/img04/img/syounen_no_uta/46170939_m.jpg" }, format: "json")
-        assert_artist_found("masao")
-      end
-
-      should "find artists by page URL" do
-        url = "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=46170939"
-        get artists_path(search: { url_matches: url }, format: "json")
-        assert_artist_found("masao")
+      should "get the show page for a negated tag" do
+        @artist.update(name: "-aaa")
+        get artist_path(@artist.id)
+        assert_response :success
       end
     end
 
-    should "create an artist" do
-      attributes = FactoryBot.attributes_for(:artist)
-      assert_difference("Artist.count", 1) do
-        attributes.delete(:is_deleted)
-        post_auth artists_path, @user, params: {artist: attributes}
+    context "new action" do
+      should "render" do
+        get_auth new_artist_path, @user
+        assert_response :success
       end
-      artist = Artist.find_by_name(attributes[:name])
-      assert_not_nil(artist)
-      assert_redirected_to(artist_path(artist.id))
+    end
+
+    context "show_or_new action" do
+      should "get the show_or_new page for an existing artist" do
+        get_auth show_or_new_artists_path(name: "masao"), @user
+        assert_redirected_to(@masao)
+      end
+
+      should "get the show_or_new page for a nonexisting artist" do
+        get_auth show_or_new_artists_path(name: "nobody"), @user
+        assert_response :success
+      end
+    end
+
+    context "edit action" do
+      should "render" do
+        get_auth edit_artist_path(@artist.id), @user
+        assert_response :success
+      end
+    end
+
+    context "banned action" do
+      should "redirect to a banned search" do
+        get banned_artists_path
+        assert_response :redirect
+      end
+    end
+
+    context "ban action" do
+      should "ban an artist" do
+        put_auth ban_artist_path(@artist.id), @admin
+        assert_redirected_to(@artist)
+        assert_equal(true, @artist.reload.is_banned?)
+        assert_equal(true, TagImplication.exists?(antecedent_name: @artist.name, consequent_name: "banned_artist"))
+      end
+
+      should "not allow non-admins to ban artists" do
+        put_auth ban_artist_path(@artist.id), @user
+        assert_response 403
+        assert_equal(false, @artist.reload.is_banned?)
+      end
+    end
+
+    context "unban action" do
+      should "unban an artist" do
+        @artist.ban!(banner: @admin)
+        put_auth unban_artist_path(@artist.id), @admin
+
+        assert_redirected_to(@artist)
+        assert_equal(false, @artist.reload.is_banned?)
+        assert_equal(false, TagImplication.exists?(antecedent_name: @artist.name, consequent_name: "banned_artist"))
+      end
+    end
+
+    context "index action" do
+      should "get the index page" do
+        get artists_path
+        assert_response :success
+      end
+
+      context "when searching the index page" do
+        should "find artists by name" do
+          get artists_path(name: "masao", format: "json")
+          assert_artist_found("masao")
+        end
+
+        should "find artists by image URL" do
+          get artists_path(search: { url_matches: "http://i2.pixiv.net/img04/img/syounen_no_uta/46170939_m.jpg" }, format: "json")
+          assert_artist_found("masao")
+        end
+
+        should "find artists by page URL" do
+          url = "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=46170939"
+          get artists_path(search: { url_matches: url }, format: "json")
+          assert_artist_found("masao")
+        end
+      end
+    end
+
+    context "create action" do
+      should "create an artist" do
+        assert_difference("Artist.count", 1) do
+          post_auth artists_path, @user, params: { artist: { name: "test" }}
+          assert_response :redirect
+          assert_equal("test", Artist.last.name)
+        end
+      end
     end
 
     context "with an artist that has a wiki page" do
@@ -166,22 +181,23 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "delete an artist" do
-      @builder = create(:builder_user)
-      delete_auth artist_path(@artist.id), @builder
-      assert_redirected_to(artist_path(@artist.id))
-      @artist.reload
-      assert_equal(true, @artist.is_deleted)
+    context "destroy action" do
+      should "delete an artist" do
+        delete_auth artist_path(@artist.id), create(:builder_user)
+        assert_redirected_to(artist_path(@artist.id))
+        assert_equal(true, @artist.reload.is_deleted)
+      end
     end
 
-    should "undelete an artist" do
-      @builder = create(:builder_user)
-      put_auth artist_path(@artist.id), @builder, params: {artist: {is_deleted: false}}
-      assert_redirected_to(artist_path(@artist.id))
-      assert_equal(false, @artist.reload.is_deleted)
+    context "update action" do
+      should "undelete an artist" do
+        put_auth artist_path(@artist.id), create(:builder_user), params: {artist: {is_deleted: false}}
+        assert_redirected_to(artist_path(@artist.id))
+        assert_equal(false, @artist.reload.is_deleted)
+      end
     end
 
-    context "reverting an artist" do
+    context "revert action" do
       should "work" do
         as_user do
           @artist.update(name: "xyz")
@@ -196,9 +212,8 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
           @artist2 = create(:artist)
         end
         put_auth artist_path(@artist.id), @user, params: {version_id: @artist2.versions.first.id}
-        @artist.reload
-        assert_not_equal(@artist.name, @artist2.name)
         assert_redirected_to(artist_path(@artist.id))
+        assert_not_equal(@artist.reload.name, @artist2.name)
       end
     end
 

--- a/test/functional/bans_controller_test.rb
+++ b/test/functional/bans_controller_test.rb
@@ -10,51 +10,96 @@ class BansControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "get the new page" do
-      get_auth new_ban_path, @mod
-      assert_response :success
-    end
-
-    should "get the edit page" do
-      get_auth edit_ban_path(@ban.id), @mod
-      assert_response :success
-    end
-
-    should "get the show page" do
-      get_auth ban_path(@ban.id), @mod
-      assert_response :success
-    end
-
-    should "get the index page" do
-      get_auth bans_path, @mod
-      assert_response :success
-    end
-
-    should "search" do
-      get_auth bans_path(search: {user_name: @user.name}), @mod
-      assert_response :success
-    end
-
-    should "create a ban" do
-      assert_difference("Ban.count", 1) do
-        post_auth bans_path, @mod, params: {ban: {duration: 60, reason: "xxx", user_id: @user.id}}
+    context "new action" do
+      should "render" do
+        get_auth new_ban_path, @mod
+        assert_response :success
       end
-      ban = Ban.last
-      assert_redirected_to(ban_path(ban))
     end
 
-    should "update a ban" do
-      put_auth ban_path(@ban.id), @mod, params: {ban: {reason: "xxx", duration: 60}}
-      @ban.reload
-      assert_equal("xxx", @ban.reason)
-      assert_redirected_to(ban_path(@ban))
-    end
-
-    should "destroy a ban" do
-      assert_difference("Ban.count", -1) do
-        delete_auth ban_path(@ban.id), @mod
+    context "edit action" do
+      should "render" do
+        get_auth edit_ban_path(@ban.id), @mod
+        assert_response :success
       end
-      assert_redirected_to(bans_path)
+    end
+
+    context "show action" do
+      should "render" do
+        get_auth ban_path(@ban.id), @mod
+        assert_response :success
+      end
+    end
+
+    context "index action" do
+      should "render" do
+        get_auth bans_path, @mod
+        assert_response :success
+      end
+    end
+
+    context "search action" do
+      should "render" do
+        get_auth bans_path(search: {user_name: @user.name}), @mod
+        assert_response :success
+      end
+    end
+
+    context "create action" do
+      should "allow mods to ban members" do
+        assert_difference("Ban.count", 1) do
+          post_auth bans_path, @mod, params: { ban: { duration: 60, reason: "xxx", user_id: @user.id }}
+
+          assert_response :redirect
+          assert_equal(true, @user.reload.is_banned?)
+        end
+      end
+
+      should "not allow mods to ban admins" do
+        assert_difference("Ban.count", 0) do
+          @admin = create(:admin_user)
+          post_auth bans_path, @mod, params: { ban: { duration: 60, reason: "xxx", user_id: @admin.id }}
+
+          assert_response 403
+          assert_equal(false, @admin.reload.is_banned?)
+        end
+      end
+
+      should "not allow mods to ban other mods" do
+        assert_difference("Ban.count", 0) do
+          @mod2 = create(:mod_user)
+          post_auth bans_path, @mod, params: { ban: { duration: 60, reason: "xxx", user_id: @mod2.id }}
+
+          assert_response 403
+          assert_equal(false, @mod2.reload.is_banned?)
+        end
+      end
+
+      should "not allow regular users to ban anyone" do
+        assert_difference("Ban.count", 0) do
+          post_auth bans_path, @user, params: { ban: { duration: 60, reason: "xxx", user_id: @mod.id }}
+
+          assert_response 403
+          assert_equal(false, @mod.reload.is_banned?)
+        end
+      end
+    end
+
+    context "update action" do
+      should "update a ban" do
+        put_auth ban_path(@ban.id), @mod, params: {ban: {reason: "xxx", duration: 60}}
+        assert_equal("xxx", @ban.reload.reason)
+        assert_redirected_to(ban_path(@ban))
+      end
+    end
+
+    context "destroy action" do
+      should "destroy a ban" do
+        assert_difference("Ban.count", -1) do
+          delete_auth ban_path(@ban.id), @mod
+          assert_redirected_to bans_path
+        end
+      end
     end
   end
 end

--- a/test/functional/bulk_update_requests_controller_test.rb
+++ b/test/functional/bulk_update_requests_controller_test.rb
@@ -19,6 +19,7 @@ class BulkUpdateRequestsControllerTest < ActionDispatch::IntegrationTest
       should "succeed" do
         assert_difference("BulkUpdateRequest.count", 1) do
           post_auth bulk_update_requests_path, @user, params: {bulk_update_request: {skip_secondary_validations: "1", script: "create alias aaa -> bbb", title: "xxx"}}
+          assert_response :redirect
         end
       end
     end
@@ -26,14 +27,26 @@ class BulkUpdateRequestsControllerTest < ActionDispatch::IntegrationTest
     context "#update" do
       should "still handle enabled secondary validations correctly" do
         put_auth bulk_update_request_path(@bulk_update_request.id), @user, params: {bulk_update_request: {script: "create alias zzz -> 222", skip_secondary_validations: "0"}}
-        @bulk_update_request.reload
-        assert_equal("create alias zzz -> 222", @bulk_update_request.script)
+        assert_response :redirect
+        assert_equal("create alias zzz -> 222", @bulk_update_request.reload.script)
       end
 
       should "still handle disabled secondary validations correctly" do
         put_auth bulk_update_request_path(@bulk_update_request.id), @user, params: {bulk_update_request: {script: "create alias zzz -> 222", skip_secondary_validations: "1"}}
-        @bulk_update_request.reload
-        assert_equal("create alias zzz -> 222", @bulk_update_request.script)
+        assert_response :redirect
+        assert_equal("create alias zzz -> 222", @bulk_update_request.reload.script)
+      end
+
+      should "allow builders to update other people's requests" do
+        put_auth bulk_update_request_path(@bulk_update_request.id), create(:builder_user), params: {bulk_update_request: {script: "create alias zzz -> 222", skip_secondary_validations: "0"}}
+        assert_response :redirect
+        assert_equal("create alias zzz -> 222", @bulk_update_request.reload.script)
+      end
+
+      should "not allow members to update other people's requests" do
+        put_auth bulk_update_request_path(@bulk_update_request.id), create(:user), params: {bulk_update_request: {script: "create alias zzz -> 222", skip_secondary_validations: "0"}}
+        assert_response 403
+        assert_equal("create alias aaa -> bbb", @bulk_update_request.reload.script)
       end
     end
 
@@ -55,19 +68,16 @@ class BulkUpdateRequestsControllerTest < ActionDispatch::IntegrationTest
       context "for the creator" do
         should "succeed" do
           delete_auth bulk_update_request_path(@bulk_update_request), @user
-          @bulk_update_request.reload
-          assert_equal("rejected", @bulk_update_request.status)
+          assert_response :redirect
+          assert_equal("rejected", @bulk_update_request.reload.status)
         end
       end
 
       context "for another member" do
-        setup do
-          @another_user = create(:user)
-        end
-
         should "fail" do
           assert_difference("BulkUpdateRequest.count", 0) do
-            delete_auth bulk_update_request_path(@bulk_update_request), @another_user
+            delete_auth bulk_update_request_path(@bulk_update_request), create(:user)
+            assert_response 403
           end
         end
       end
@@ -75,8 +85,8 @@ class BulkUpdateRequestsControllerTest < ActionDispatch::IntegrationTest
       context "for an admin" do
         should "succeed" do
           delete_auth bulk_update_request_path(@bulk_update_request), @admin
-          @bulk_update_request.reload
-          assert_equal("rejected", @bulk_update_request.status)
+          assert_response :redirect
+          assert_equal("rejected", @bulk_update_request.reload.status)
         end
       end
     end
@@ -85,16 +95,16 @@ class BulkUpdateRequestsControllerTest < ActionDispatch::IntegrationTest
       context "for a member" do
         should "fail" do
           post_auth approve_bulk_update_request_path(@bulk_update_request), @user
-          @bulk_update_request.reload
-          assert_equal("pending", @bulk_update_request.status)
+          assert_response 403
+          assert_equal("pending", @bulk_update_request.reload.status)
         end
       end
 
       context "for an admin" do
         should "succeed" do
           post_auth approve_bulk_update_request_path(@bulk_update_request), @admin
-          @bulk_update_request.reload
-          assert_equal("approved", @bulk_update_request.status)
+          assert_response :redirect
+          assert_equal("approved", @bulk_update_request.reload.status)
         end
       end
     end

--- a/test/functional/emails_controller_test.rb
+++ b/test/functional/emails_controller_test.rb
@@ -1,15 +1,23 @@
 require "test_helper"
 
 class EmailsControllerTest < ActionDispatch::IntegrationTest
+  include UsersHelper
+
   context "in all cases" do
     setup do
       @user = create(:user, email_address: build(:email_address, { address: "bob@ogres.net", is_verified: false }))
+      @other_user = create(:user, email_address: build(:email_address, { address: "alice@ogres.net", is_verified: false }))
     end
 
     context "#show" do
       should "render" do
         get_auth user_email_path(@user), @user, as: :json
         assert_response :success
+      end
+
+      should "not show email addresses to other users" do
+        get_auth user_email_path(@user), @other_user, as: :json
+        assert_response 403
       end
     end
 
@@ -20,13 +28,29 @@ class EmailsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "#create" do
+    context "#update" do
       context "with the correct password" do
-        should "work" do
-          put_auth user_email_path(@user), @user, params: { user: { password: "password", email: "abc@ogres.net" }}
+        should "update an existing address" do
+          assert_difference("EmailAddress.count", 0) do
+            put_auth user_email_path(@user), @user, params: { user: { password: "password", email: "abc@ogres.net" }}
+          end
 
           assert_redirected_to(settings_path)
           assert_equal("abc@ogres.net", @user.reload.email_address.address)
+          assert_equal(false, @user.email_address.is_verified)
+          assert_enqueued_email_with UserMailer, :email_change_confirmation, args: [@user]
+        end
+
+        should "create a new address" do
+          @user.email_address.destroy
+
+          assert_difference("EmailAddress.count", 1) do
+            put_auth user_email_path(@user), @user, params: { user: { password: "password", email: "abc@ogres.net" }}
+          end
+
+          assert_redirected_to(settings_path)
+          assert_equal("abc@ogres.net", @user.reload.email_address.address)
+          assert_equal(false, @user.reload.email_address.is_verified)
           assert_enqueued_email_with UserMailer, :email_change_confirmation, args: [@user]
         end
       end
@@ -46,10 +70,19 @@ class EmailsControllerTest < ActionDispatch::IntegrationTest
       context "with a correct verification key" do
         should "mark the email address as verified" do
           assert_equal(false, @user.reload.email_address.is_verified)
-          get_auth verify_user_email_path(@user), @user, params: { email_verification_key: Danbooru::MessageVerifier.new(:email_verification_key).generate(@user.email_address.id) }
+          get email_verification_url(@user)
 
           assert_redirected_to @user
           assert_equal(true, @user.reload.email_address.is_verified)
+        end
+      end
+
+      context "with an incorrect verification key" do
+        should "not mark the email address as verified" do
+          get verify_user_email_path(@user, email_verification_key: @other_user.email_address.verification_key)
+
+          assert_response 403
+          assert_equal(false, @user.reload.email_address.is_verified)
         end
       end
     end

--- a/test/functional/favorite_groups_controller_test.rb
+++ b/test/functional/favorite_groups_controller_test.rb
@@ -15,9 +15,21 @@ class FavoriteGroupsControllerTest < ActionDispatch::IntegrationTest
     end
 
     context "show action" do
-      should "render" do
+      should "show public favgroups to anonymous users" do
         get favorite_group_path(@favgroup)
         assert_response :success
+      end
+
+      should "show private favgroups to the creator" do
+        @favgroup.update!(is_public: false)
+        get_auth favorite_group_path(@favgroup), @user
+        assert_response :success
+      end
+
+      should "not show private favgroups to other users" do
+        @favgroup = create(:favorite_group, is_public: false)
+        get_auth favorite_group_path(@favgroup), create(:user)
+        assert_response 403
       end
     end
 
@@ -51,25 +63,46 @@ class FavoriteGroupsControllerTest < ActionDispatch::IntegrationTest
         assert_equal("foo", @favgroup.reload.name)
         assert_equal(@posts.map(&:id), @favgroup.post_ids)
       end
+
+      should "not allow users to update favgroups belonging to other users" do
+        put_auth favorite_group_path(@favgroup), create(:user), params: { favorite_group: { name: "foo" } }
+
+        assert_response 403
+        assert_not_equal("foo", @favgroup.reload.name)
+      end
     end
 
     context "destroy action" do
       should "render" do
         delete_auth favorite_group_path(@favgroup), @user
-        assert_redirected_to favorite_groups_path
+        assert_redirected_to favorite_groups_path(search: { creator_name: @user.name })
+      end
+
+      should "not destroy favgroups belonging to other users" do
+        delete_auth favorite_group_path(@favgroup), create(:user)
+        assert_response 403
       end
     end
 
     context "add_post action" do
       should "render" do
-        as_user do
-          @post = FactoryBot.create(:post)
-        end
-
+        @post = create(:post)
         put_auth add_post_favorite_group_path(@favgroup), @user, params: {post_id: @post.id, format: "js"}
         assert_response :success
-        @favgroup.reload
-        assert_equal([@post.id], @favgroup.post_ids)
+        assert_equal([@post.id], @favgroup.reload.post_ids)
+      end
+
+      should "not add posts to favgroups belonging to other users" do
+        @post = create(:post)
+        put_auth add_post_favorite_group_path(@favgroup), create(:user), params: {post_id: @post.id, format: "js"}
+        assert_response 403
+      end
+    end
+
+    context "edit order action" do
+      should "render" do
+        get_auth edit_favorite_group_order_path(@favgroup), @user
+        assert_response :success
       end
     end
   end

--- a/test/functional/favorites_controller_test.rb
+++ b/test/functional/favorites_controller_test.rb
@@ -4,51 +4,56 @@ class FavoritesControllerTest < ActionDispatch::IntegrationTest
   context "The favorites controller" do
     setup do
       @user = create(:user)
+      @post = create(:post)
+      @faved_post = create(:post)
+      @faved_post.add_favorite!(@user)
     end
 
     context "index action" do
-      setup do
-        @post = create(:post)
-        @post.add_favorite!(@user)
-      end
-
       should "redirect the user_id param to an ordfav: search" do
         get favorites_path(user_id: @user.id)
-        assert_redirected_to posts_path(tags: "ordfav:#{@user.name}")
+        assert_redirected_to posts_path(tags: "ordfav:#{@user.name}", format: "html")
       end
 
       should "redirect members to an ordfav: search" do
         get_auth favorites_path, @user
-        assert_redirected_to posts_path(tags: "ordfav:#{@user.name}")
+        assert_redirected_to posts_path(tags: "ordfav:#{@user.name}", format: "html")
       end
 
       should "redirect anonymous users to the posts index" do
         get favorites_path
-        assert_redirected_to posts_path
+        assert_redirected_to posts_path(format: "html")
       end
     end
 
     context "create action" do
-      setup do
-        @post = create(:post)
-      end
-
       should "create a favorite for the current user" do
         assert_difference("Favorite.count", 1) do
-          post_auth favorites_path, @user, params: {:format => "js", :post_id => @post.id}
+          post_auth favorites_path(post_id: @post.id), @user, as: :javascript
+          assert_response :redirect
+        end
+      end
+
+      should "allow banned users to create favorites" do
+        assert_difference("Favorite.count", 1) do
+          post_auth favorites_path(post_id: @post.id), create(:banned_user), as: :javascript
+          assert_response :redirect
         end
       end
     end
 
     context "destroy action" do
-      setup do
-        @post = create(:post)
-        @post.add_favorite!(@user)
-      end
-
       should "remove the favorite from the current user" do
         assert_difference("Favorite.count", -1) do
-          delete_auth favorite_path(@post.id), @user, params: {:format => "js"}
+          delete_auth favorite_path(@faved_post.id), @user, as: :javascript
+          assert_response :redirect
+        end
+      end
+
+      should "allow banned users to destroy favorites" do
+        assert_difference("Favorite.count", -1) do
+          delete_auth favorite_path(@faved_post.id), @user, as: :javascript
+          assert_response :redirect
         end
       end
     end

--- a/test/functional/forum_post_votes_controller_test.rb
+++ b/test/functional/forum_post_votes_controller_test.rb
@@ -4,10 +4,12 @@ class ForumPostVotesControllerTest < ActionDispatch::IntegrationTest
   context "The forum post votes controller" do
     setup do
       @user = create(:user)
+      @other_user = create(:user)
 
       as(@user) do
         @forum_topic = create(:forum_topic)
         @forum_post = create(:forum_post, topic: @forum_topic)
+        @bulk_update_request = create(:bulk_update_request, forum_post: @forum_post)
       end
     end
 
@@ -15,26 +17,44 @@ class ForumPostVotesControllerTest < ActionDispatch::IntegrationTest
       should "render" do
         @forum_post_vote = create(:forum_post_vote, creator: @user, forum_post: @forum_post)
         get forum_post_votes_path
-
         assert_response :success
       end
     end
 
-    should "allow voting" do
-      assert_difference("ForumPostVote.count") do
-        post_auth forum_post_votes_path(format: :js), @user, params: { forum_post_id: @forum_post.id, forum_post_vote: { score: 1 }}
+    context "create action" do
+      should "allow members to vote" do
+        assert_difference("ForumPostVote.count", 1) do
+          post_auth forum_post_votes_path(format: :js), @user, params: { forum_post_id: @forum_post.id, forum_post_vote: { score: 1 }}
+          assert_response :success
+        end
       end
-      assert_response :success
+
+      should "not allow privileged users to vote on private forum posts" do
+        as(@user) { @forum_post.topic.update!(min_level: User::Levels::ADMIN) }
+        assert_difference("ForumPostVote.count", 0) do
+          post_auth forum_post_votes_path(format: :js), @user, params: { forum_post_id: @forum_post.id, forum_post_vote: { score: 1 }}
+          assert_response 403
+        end
+      end
     end
 
-    context "when deleting" do
-      should "allow removal" do
+    context "destroy action" do
+      setup do
         @forum_post_vote = create(:forum_post_vote, creator: @user, forum_post: @forum_post)
+      end
+
+      should "allow members to destroy their own votes" do
         assert_difference("ForumPostVote.count", -1) do
           delete_auth forum_post_vote_path(@forum_post_vote.id, format: :js), @user
+          assert_response :success
         end
+      end
 
-        assert_response :success
+      should "not allow members to destroy other people's votes" do
+        assert_difference("ForumPostVote.count", 0) do
+          delete_auth forum_post_vote_path(@forum_post_vote.id, format: :js), @other_user
+          assert_response 403
+        end
       end
     end
   end

--- a/test/functional/forum_posts_controller_test.rb
+++ b/test/functional/forum_posts_controller_test.rb
@@ -21,11 +21,13 @@ class ForumPostsControllerTest < ActionDispatch::IntegrationTest
 
       should "render the vote links" do
         get_auth forum_topic_path(@forum_topic), @mod
+        assert_response :success
         assert_select "a[title='Vote up']"
       end
 
       should "render existing votes" do
         get_auth forum_topic_path(@forum_topic), @mod
+        assert_response :success
         assert_select "li.vote-score-up"
       end
 
@@ -39,10 +41,12 @@ class ForumPostsControllerTest < ActionDispatch::IntegrationTest
 
         should "hide the vote links" do
           assert_select "a[title='Vote up']", false
+          assert_response :success
         end
 
         should "still render existing votes" do
           assert_select "li.vote-score-up"
+          assert_response :success
         end
       end
     end
@@ -73,28 +77,38 @@ class ForumPostsControllerTest < ActionDispatch::IntegrationTest
         end
       end
 
-      context "with private topics" do
+      context "for posts in private topics" do
         setup do
-          as(@mod) do
-            @mod_topic = create(:mod_up_forum_topic, creator: @mod)
-            @mod_posts = create_list(:forum_post, 2, topic: @mod_topic, creator: @mod)
-          end
-          @mod_post_ids = ([@forum_post] + @mod_posts).map(&:id).reverse
+          @admin = create(:admin_user)
+          @mod_post = as(@mod) { create(:forum_post, creator: @mod, topic: build(:forum_topic, min_level: User::Levels::MODERATOR)) }
+          @admin_post = as(@admin) { create(:forum_post, creator: @admin, topic: build(:forum_topic, min_level: User::Levels::ADMIN)) }
         end
 
-        should "list only permitted posts for members" do
+        should "list only permitted posts for anons" do
           get forum_posts_path
 
           assert_response :success
           assert_select "#forum-post-#{@forum_post.id}"
-          assert_select "#forum-post-#{@mod_posts[0].id}", false
+          assert_select "#forum-post-#{@mod_post.id}", false
+          assert_select "#forum-post-#{@admin_post.id}", false
         end
 
         should "list only permitted posts for mods" do
           get_auth forum_posts_path, @mod
 
           assert_response :success
-          assert_select "#forum-post-#{@mod_posts[0].id}"
+          assert_select "#forum-post-#{@forum_post.id}"
+          assert_select "#forum-post-#{@mod_post.id}"
+          assert_select "#forum-post-#{@admin_post.id}", false
+        end
+
+        should "list only permitted posts for admins" do
+          get_auth forum_posts_path, @admin
+
+          assert_response :success
+          assert_select "#forum-post-#{@forum_post.id}"
+          assert_select "#forum-post-#{@mod_post.id}"
+          assert_select "#forum-post-#{@admin_post.id}"
         end
       end
     end
@@ -128,6 +142,12 @@ class ForumPostsControllerTest < ActionDispatch::IntegrationTest
         get_auth edit_forum_post_path(@forum_post), @other_user
         assert_response(403)
       end
+
+      should "fail if the topic is private and the editor is unauthorized" do
+        as(@user) { @forum_post.topic.update(min_level: User::Levels::ADMIN) }
+        get_auth edit_forum_post_path(@forum_post), @user
+        assert_response(403)
+      end
     end
 
     context "new action" do
@@ -135,40 +155,96 @@ class ForumPostsControllerTest < ActionDispatch::IntegrationTest
         get_auth new_forum_post_path, @user, params: {:topic_id => @forum_topic.id}
         assert_response :success
       end
+
+      should "not allow unauthorized users to quote posts in private forum topics" do
+        as(@user) { @forum_post.topic.update(min_level: User::Levels::ADMIN) }
+        get_auth new_forum_post_path, @user, params: { post_id: @forum_post.id }
+
+        assert_response 403
+      end
     end
 
     context "create action" do
       should "create a new forum post" do
         assert_difference("ForumPost.count", 1) do
           post_auth forum_posts_path, @user, params: {:forum_post => {:body => "xaxaxa", :topic_id => @forum_topic.id}}
+          assert_redirected_to(forum_topic_path(@forum_topic))
         end
+      end
 
-        forum_post = ForumPost.last
+      should "not allow unauthorized users to create posts in private topics" do
+        as(@user) { @forum_post.topic.update!(min_level: User::Levels::ADMIN) }
+
+        post_auth forum_posts_path, @user, params: { forum_post: { body: "xaxaxa", topic_id: @forum_topic.id }}
+        assert_response 403
+      end
+
+      should "not allow non-moderators to create posts in locked topics" do
+        as(@user) { @forum_post.topic.update!(is_locked: true) }
+
+        post_auth forum_posts_path, @user, params: { forum_post: { body: "xaxaxa", topic_id: @forum_topic.id }}
+        assert_response 403
+      end
+
+      should "allow moderators to create posts in locked topics" do
+        as(@user) { @forum_post.topic.update!(is_locked: true) }
+
+        post_auth forum_posts_path, @mod, params: { forum_post: { body: "xaxaxa", topic_id: @forum_topic.id }}
         assert_redirected_to(forum_topic_path(@forum_topic))
       end
     end
 
+    context "update action" do
+      should "allow users to update their own posts" do
+        put_auth forum_post_path(@forum_post), @user, params: { forum_post: { body: "test" }}
+        assert_redirected_to(forum_topic_path(@forum_topic, anchor: "forum_post_#{@forum_post.id}"))
+      end
+
+      should "not allow users to update their own posts in locked topics" do
+        as(@user) { @forum_post.topic.update!(is_locked: true) }
+
+        put_auth forum_post_path(@forum_post), @user, params: { forum_post: { body: "test" }}
+        assert_response 403
+      end
+
+      should "not allow users to update other people's posts" do
+        put_auth forum_post_path(@forum_post), @other_user, params: { forum_post: { body: "test" }}
+        assert_response 403
+      end
+
+      should "allow moderators to update other people's posts" do
+        put_auth forum_post_path(@forum_post), @mod, params: { forum_post: { body: "test" }}
+        assert_redirected_to(forum_topic_path(@forum_topic, anchor: "forum_post_#{@forum_post.id}"))
+      end
+    end
+
     context "destroy action" do
-      should "destroy the posts" do
+      should "allow mods to delete posts" do
         delete_auth forum_post_path(@forum_post), @mod
         assert_redirected_to(forum_post_path(@forum_post))
-        @forum_post.reload
-        assert_equal(true, @forum_post.is_deleted?)
+        assert_equal(true, @forum_post.reload.is_deleted?)
+      end
+
+      should "not allow users to delete their own posts" do
+        delete_auth forum_post_path(@forum_post), @user
+        assert_response 403
+        assert_equal(false, @forum_post.reload.is_deleted?)
       end
     end
 
     context "undelete action" do
-      setup do
-        as(@mod) do
-          @forum_post.update(is_deleted: true)
-        end
-      end
-
-      should "restore the post" do
+      should "allow mods to undelete posts" do
+        as(@mod) { @forum_post.update!(is_deleted: true) }
         post_auth undelete_forum_post_path(@forum_post), @mod
         assert_redirected_to(forum_post_path(@forum_post))
-        @forum_post.reload
-        assert_equal(false, @forum_post.is_deleted?)
+        assert_equal(false, @forum_post.reload.is_deleted?)
+      end
+
+      should "not allow users to undelete their own posts" do
+        as(@mod) { @forum_post.update!(is_deleted: true) }
+        post_auth undelete_forum_post_path(@forum_post), @user
+        assert_response 403
+        assert_equal(true, @forum_post.reload.is_deleted?)
       end
     end
   end

--- a/test/functional/ip_addresses_controller_test.rb
+++ b/test/functional/ip_addresses_controller_test.rb
@@ -34,6 +34,11 @@ class IpAddressesControllerTest < ActionDispatch::IntegrationTest
         get_auth ip_addresses_path(search: { user_id: @user.id, group_by: "ip_addr" }), @mod
         assert_response :success
       end
+
+      should "not allow non-moderators to view IP addresses" do
+        get_auth ip_addresses_path, @user
+        assert_response 403
+      end
     end
   end
 end

--- a/test/functional/ip_bans_controller_test.rb
+++ b/test/functional/ip_bans_controller_test.rb
@@ -4,6 +4,7 @@ class IpBansControllerTest < ActionDispatch::IntegrationTest
   context "The ip bans controller" do
     setup do
       @admin = create(:admin_user)
+      @ip_ban = create(:ip_ban)
     end
 
     context "new action" do
@@ -17,17 +18,12 @@ class IpBansControllerTest < ActionDispatch::IntegrationTest
       should "create a new ip ban" do
         assert_difference("IpBan.count", 1) do
           post_auth ip_bans_path, @admin, params: {:ip_ban => {:ip_addr => "1.2.3.4", :reason => "xyz"}}
+          assert_response :redirect
         end
       end
     end
 
     context "index action" do
-      setup do
-        as(@admin) do
-          create(:ip_ban)
-        end
-      end
-
       should "render" do
         get_auth ip_bans_path, @admin
         assert_response :success
@@ -42,15 +38,10 @@ class IpBansControllerTest < ActionDispatch::IntegrationTest
     end
 
     context "destroy action" do
-      setup do
-        as(@admin) do
-          @ip_ban = create(:ip_ban)
-        end
-      end
-
       should "destroy an ip ban" do
         assert_difference("IpBan.count", -1) do
           delete_auth ip_ban_path(@ip_ban), @admin, params: {:format => "js"}
+          assert_response :success
         end
       end
     end

--- a/test/functional/moderator/post/posts_controller_test.rb
+++ b/test/functional/moderator/post/posts_controller_test.rb
@@ -37,7 +37,7 @@ module Moderator
 
         context "confirm_move_favorites action" do
           should "render" do
-            get_auth confirm_ban_moderator_post_post_path(@post), @admin
+            get_auth confirm_move_favorites_moderator_post_post_path(@post), @admin
             assert_response :success
           end
         end
@@ -78,18 +78,11 @@ module Moderator
           end
         end
 
-        context "confirm_ban action" do
-          should "render" do
-            get_auth confirm_ban_moderator_post_post_path(@post), @admin
-            assert_response :success
-          end
-        end
-
         context "ban action" do
           should "render" do
-            post_auth ban_moderator_post_post_path(@post), @admin, params: { commit: "Ban", format: "js" }
+            post_auth ban_moderator_post_post_path(@post), @admin
 
-            assert_response :success
+            assert_redirected_to @post
             assert_equal(true, @post.reload.is_banned?)
           end
         end
@@ -97,7 +90,7 @@ module Moderator
         context "unban action" do
           should "render" do
             @post.ban!
-            post_auth unban_moderator_post_post_path(@post), @admin, params: { format: "js" }
+            post_auth unban_moderator_post_post_path(@post), @admin
 
             assert_redirected_to(@post)
             assert_equal(false, @post.reload.is_banned?)

--- a/test/functional/pool_elements_controller_test.rb
+++ b/test/functional/pool_elements_controller_test.rb
@@ -20,15 +20,15 @@ class PoolElementsControllerTest < ActionDispatch::IntegrationTest
     context "create action" do
       should "add a post to a pool" do
         post_auth pool_element_path, @user, params: {:pool_id => @pool.id, :post_id => @post.id, :format => "json"}
-        @pool.reload
-        assert_equal([@post.id], @pool.post_ids)
+        assert_response :success
+        assert_equal([@post.id], @pool.reload.post_ids)
       end
 
       should "add a post to a pool once and only once" do
         as_user { @pool.add!(@post) }
         post_auth pool_element_path, @user, params: {:pool_id => @pool.id, :post_id => @post.id, :format => "json"}
-        @pool.reload
-        assert_equal([@post.id], @pool.post_ids)
+        assert_response :success
+        assert_equal([@post.id], @pool.reload.post_ids)
       end
     end
   end

--- a/test/functional/post_approvals_controller_test.rb
+++ b/test/functional/post_approvals_controller_test.rb
@@ -26,6 +26,14 @@ class PostApprovalsControllerTest < ActionDispatch::IntegrationTest
           assert(!@post.reload.is_deleted?)
         end
       end
+
+      should "not allow non-approvers to approve posts" do
+        @post = create(:post, is_pending: true)
+        post_auth post_approvals_path(post_id: @post.id, format: :js), create(:user)
+
+        assert_response 403
+        assert_equal(true, @post.reload.is_pending?)
+      end
     end
 
     context "index action" do

--- a/test/functional/post_disapprovals_controller_test.rb
+++ b/test/functional/post_disapprovals_controller_test.rb
@@ -3,38 +3,45 @@ require 'test_helper'
 class PostDisapprovalsControllerTest < ActionDispatch::IntegrationTest
   context "The post disapprovals controller" do
     setup do
-      @admin = create(:admin_user)
-      as_user do
-        @post = create(:post, :is_pending => true)
-      end
-
-      CurrentUser.user = @admin
+      @approver = create(:approver)
+      @post = create(:post, is_pending: true)
+      @post_disapproval = create(:post_disapproval, post: @post)
     end
 
     context "create action" do
       should "render" do
         assert_difference("PostDisapproval.count", 1) do
-          post_auth post_disapprovals_path, @admin, params: { post_disapproval: { post_id: @post.id, reason: "breaks_rules" }, format: "js" }
+          post_auth post_disapprovals_path, @approver, params: { post_disapproval: { post_id: @post.id, reason: "breaks_rules" }, format: "js" }
+          assert_response :success
         end
-        assert_response :success
       end
 
-      context "for json" do
-        should "render" do
-          assert_difference("PostDisapproval.count", 1) do
-            post_auth post_disapprovals_path, @admin, params: { post_disapproval: { post_id: @post.id, reason: "breaks_rules" }, format: "json" }
-          end
+      should "render for json" do
+        assert_difference("PostDisapproval.count", 1) do
+          post_auth post_disapprovals_path, @approver, params: { post_disapproval: { post_id: @post.id, reason: "breaks_rules" }, format: "json" }
           assert_response :success
+        end
+      end
+
+      should "not allow non-approvers to create disapprovals" do
+        assert_difference("PostDisapproval.count", 0) do
+          post_auth post_disapprovals_path, create(:user), params: { post_disapproval: { post_id: @post.id, reason: "breaks_rules" }, format: "json" }
+          assert_response 403
         end
       end
     end
 
     context "index action" do
-      should "render" do
-        disapproval = FactoryBot.create(:post_disapproval, post: @post)
-        get_auth post_disapprovals_path, @admin
-
+      should "allow mods to see disapprover names" do
+        get_auth post_disapprovals_path, create(:mod_user)
         assert_response :success
+        assert_select "tr#post-disapproval-#{@post_disapproval.id} .created-column a.user-member", true
+      end
+
+      should "not allow non-mods to see disapprover names" do
+        get post_disapprovals_path
+        assert_response :success
+        assert_select "tr#post-disapproval-#{@post_disapproval.id} .created-column a.user-member", false
       end
     end
   end

--- a/test/functional/post_flags_controller_test.rb
+++ b/test/functional/post_flags_controller_test.rb
@@ -3,46 +3,85 @@ require 'test_helper'
 class PostFlagsControllerTest < ActionDispatch::IntegrationTest
   context "The post flags controller" do
     setup do
-      @user = create(:user, created_at: 2.weeks.ago)
+      @user = create(:user)
+      @flagger = create(:gold_user, created_at: 2.weeks.ago)
+      @uploader = create(:mod_user, created_at: 2.weeks.ago)
+      @mod = create(:mod_user)
+      @post = create(:post, is_flagged: true, uploader: @uploader)
+      @post_flag = create(:post_flag, post: @post, creator: @flagger)
     end
 
     context "new action" do
       should "render" do
-        get_auth new_post_flag_path, @user
+        get_auth new_post_flag_path, @flagger
+        assert_response :success
+      end
+    end
+
+    context "show action" do
+      should "work" do
+        get post_flag_path(@post_flag), as: :json
         assert_response :success
       end
     end
 
     context "index action" do
-      setup do
-        @post_flag = create(:post_flag, creator: @user)
+      should "render" do
+        get post_flags_path
+        assert_response :success
       end
 
-      should "render" do
+      should "hide flagger names from regular users" do
         get_auth post_flags_path, @user
         assert_response :success
+        assert_select "tr#post-flag-#{@post_flag.id} .flagged-column a.user-gold", false
+      end
+
+      should "hide flagger names from uploaders" do
+        get_auth post_flags_path, @uploader
+        assert_response :success
+        assert_select "tr#post-flag-#{@post_flag.id} .flagged-column a.user-gold", false
+      end
+
+      should "show flagger names to the flagger themselves" do
+        get_auth post_flags_path, @flagger
+        assert_response :success
+        assert_select "tr#post-flag-#{@post_flag.id} .flagged-column a.user-gold", true
+      end
+
+      should "show flagger names to mods" do
+        get_auth post_flags_path, @mod
+        assert_response :success
+        assert_select "tr#post-flag-#{@post_flag.id} .flagged-column a.user-gold", true
       end
 
       context "with search parameters" do
         should "render" do
-          get_auth post_flags_path, @user, params: {:search => {:post_id => @post_flag.post_id}}
+          get_auth post_flags_path(search: { post_id: @post_flag.post_id }), @user
           assert_response :success
+        end
+
+        should "hide flagged posts when the searcher is the uploader" do
+          get_auth post_flags_path(search: { creator_id: @flagger.id }), @uploader
+          assert_response :success
+          assert_select "tr#post-flag-#{@post_flag.id}", false
+        end
+
+        should "show flagged posts when the searcher is not the uploader" do
+          get_auth post_flags_path(search: { creator_id: @flagger.id }), @mod
+          assert_response :success
+          assert_select "tr#post-flag-#{@post_flag.id}", true
         end
       end
     end
 
     context "create action" do
-      setup do
-        @user.as_current do
-          @post = create(:post)
-        end
-      end
-
       should "create a new flag" do
         assert_difference("PostFlag.count", 1) do
-          assert_difference("PostFlag.count") do
-            post_auth post_flags_path, @user, params: {:format => "js", :post_flag => {:post_id => @post.id, :reason => "xxx"}}
-          end
+          @post = create(:post)
+          post_auth post_flags_path, @flagger, params: { post_flag: { post_id: @post.id, reason: "xxx" }}, as: :javascript
+          assert_redirected_to PostFlag.last
+          assert_equal(true, @post.reload.is_flagged?)
         end
       end
     end

--- a/test/functional/post_replacements_controller_test.rb
+++ b/test/functional/post_replacements_controller_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class PostReplacementsControllerTest < ActionDispatch::IntegrationTest
   context "The post replacements controller" do
     setup do
-      @user = create(:moderator_user, can_approve_posts: true, created_at: 1.month.ago)
-      @user.as_current do
+      @mod = create(:moderator_user, can_approve_posts: true, created_at: 1.month.ago)
+      as(@mod) do
         @post = create(:post, source: "https://google.com")
         @post_replacement = create(:post_replacement, post: @post)
       end
@@ -20,18 +20,24 @@ class PostReplacementsControllerTest < ActionDispatch::IntegrationTest
           }
         }
 
-        assert_difference(-> { @post.replacements.size }) do
-          post_auth post_replacements_path, @user, params: params
-          @post.reload
+        assert_difference("PostReplacement.count") do
+          post_auth post_replacements_path, @mod, params: params
+          assert_response :success
         end
 
         travel(PostReplacement::DELETION_GRACE_PERIOD + 1.day)
         perform_enqueued_jobs
 
-        assert_response :success
-        assert_equal("https://cdn.donmai.us/original/d3/4e/d34e4cf0a437a5d65f8e82b7bcd02606.jpg", @post.source)
+        assert_equal("https://cdn.donmai.us/original/d3/4e/d34e4cf0a437a5d65f8e82b7bcd02606.jpg", @post.reload.source)
         assert_equal("d34e4cf0a437a5d65f8e82b7bcd02606", @post.md5)
         assert_equal("d34e4cf0a437a5d65f8e82b7bcd02606", Digest::MD5.file(@post.file(:original)).hexdigest)
+      end
+
+      should "not allow non-mods to replace posts" do
+        assert_difference("PostReplacement.count", 0) do
+          post_auth post_replacements_path(post_id: @post.id), create(:user), params: { post_replacement: { replacement_url: "https://cdn.donmai.us/original/d3/4e/d34e4cf0a437a5d65f8e82b7bcd02606.jpg" }}
+          assert_response 403
+        end
       end
     end
 
@@ -46,9 +52,9 @@ class PostReplacementsControllerTest < ActionDispatch::IntegrationTest
           }
         }
 
-        put_auth post_replacement_path(@post_replacement), @user, params: params
-        @post_replacement.reload
-        assert_equal(23, @post_replacement.file_size_was)
+        put_auth post_replacement_path(@post_replacement), @mod, params: params
+        assert_response :success
+        assert_equal(23, @post_replacement.reload.file_size_was)
         assert_equal(42, @post_replacement.file_size)
       end
     end

--- a/test/functional/post_versions_controller_test.rb
+++ b/test/functional/post_versions_controller_test.rb
@@ -3,30 +3,26 @@ require 'test_helper'
 class PostVersionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user)
+
+    as(@user) do
+      @post = create(:post, tag_string: "tagme", rating: "s")
+      travel(2.hours) { @post.update(tag_string: "1 2", source: "xxx") }
+      travel(4.hours) { @post.update(tag_string: "2 3", rating: "e") }
+      @post2 = create(:post)
+    end
   end
 
   context "The post versions controller" do
     context "index action" do
       setup do
-        @user.as_current do
-          @post = create(:post)
-          travel(2.hours) do
-            @post.update(:tag_string => "1 2", :source => "xxx")
-          end
-          travel(4.hours) do
-            @post.update(:tag_string => "2 3", :rating => "e")
-          end
-          @versions = @post.versions
-          @post2 = create(:post)
-        end
       end
 
       should "list all versions" do
         get_auth post_versions_path, @user
         assert_response :success
-        assert_select "#post-version-#{@versions[0].id}"
-        assert_select "#post-version-#{@versions[1].id}"
-        assert_select "#post-version-#{@versions[2].id}"
+        assert_select "#post-version-#{@post.versions[0].id}"
+        assert_select "#post-version-#{@post.versions[1].id}"
+        assert_select "#post-version-#{@post.versions[2].id}"
       end
 
       should "list all versions that match the search criteria" do
@@ -38,12 +34,27 @@ class PostVersionsControllerTest < ActionDispatch::IntegrationTest
       should "list all versions for search[changed_tags]" do
         get post_versions_path, as: :json, params: { search: { changed_tags: "1" }}
         assert_response :success
-        assert_equal @versions[1].id, response.parsed_body[1]["id"].to_i
-        assert_equal @versions[2].id, response.parsed_body[0]["id"].to_i
+        assert_equal @post.versions[1].id, response.parsed_body[1]["id"].to_i
+        assert_equal @post.versions[2].id, response.parsed_body[0]["id"].to_i
 
         get post_versions_path, as: :json, params: { search: { changed_tags: "1 2" }}
         assert_response :success
-        assert_equal @versions[1].id, response.parsed_body[0]["id"].to_i
+        assert_equal @post.versions[1].id, response.parsed_body[0]["id"].to_i
+      end
+    end
+
+    context "undo action" do
+      should "undo the edit" do
+        put_auth undo_post_version_path(@post.versions.first), @user
+        assert_response :success
+        assert_equal("s", @post.reload.rating)
+        assert_equal("tagme", @post.reload.tag_string)
+      end
+
+      should "not allow non-members to undo edits" do
+        put undo_post_version_path(@post.versions.first)
+        assert_response 403
+        assert_equal("2 3", @post.reload.tag_string)
       end
     end
   end

--- a/test/functional/saved_searches_controller_test.rb
+++ b/test/functional/saved_searches_controller_test.rb
@@ -4,9 +4,7 @@ class SavedSearchesControllerTest < ActionDispatch::IntegrationTest
   context "The saved searches controller" do
     setup do
       @user = create(:user)
-      as_user do
-        @saved_search = create(:saved_search, user: @user)
-      end
+      @saved_search = create(:saved_search, user: @user)
     end
 
     context "index action" do
@@ -17,24 +15,29 @@ class SavedSearchesControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "labels action" do
+      should "render" do
+        get_auth labels_saved_searches_path, @user, as: :json
+        assert_response :success
+      end
+    end
+
     context "create action" do
       should "render" do
         post_auth saved_searches_path, @user, params: { saved_search: { query: "bkub", label_string: "artist" }}
-        assert_response :redirect
+        assert_redirected_to SavedSearch.last
       end
 
       should "disable labels when the disable_labels param is given" do
         post_auth saved_searches_path, @user, params: { saved_search: { query: "bkub", disable_labels: "1" }}
+        assert_redirected_to SavedSearch.last
         assert_equal(true, @user.reload.disable_categorized_saved_searches)
       end
     end
 
     context "edit action" do
       should "render" do
-        as_user do
-          @saved_search = create(:saved_search, user: @user)
-        end
-
+        @saved_search = create(:saved_search, user: @user)
         get_auth edit_saved_search_path(@saved_search), @user, params: { id: @saved_search.id }
         assert_response :success
       end
@@ -42,24 +45,33 @@ class SavedSearchesControllerTest < ActionDispatch::IntegrationTest
 
     context "update action" do
       should "render" do
-        as_user do
-          @saved_search = create(:saved_search, user: @user)
-        end
-        params = { id: @saved_search.id, saved_search: { label_string: "foo" } }
-        put_auth saved_search_path(@saved_search), @user, params: params
+        put_auth saved_search_path(@saved_search), @user, params: { saved_search: { label_string: "foo" }}
         assert_redirected_to saved_searches_path
         assert_equal(["foo"], @saved_search.reload.labels)
+      end
+
+      should "not allow users to update saved searches belonging to other users" do
+        put_auth saved_search_path(@saved_search), create(:user), params: { saved_search: { label_string: "foo" }}
+        assert_response 403
+        assert_not_equal(["foo"], @saved_search.reload.labels)
       end
     end
 
     context "destroy action" do
       should "render" do
-        as_user do
-          @saved_search = create(:saved_search, user: @user)
+        @saved_search = create(:saved_search, user: @user)
+        assert_difference("SavedSearch.count", -1) do
+          delete_auth saved_search_path(@saved_search), @user
+          assert_redirected_to saved_searches_path
         end
+      end
 
-        delete_auth saved_search_path(@saved_search), @user
-        assert_redirected_to saved_searches_path
+      should "not allow users to destroy saved searches belonging to other users" do
+        @saved_search = create(:saved_search, user: @user)
+        assert_difference("SavedSearch.count", 0) do
+          delete_auth saved_search_path(@saved_search), create(:user)
+          assert_response 403
+        end
       end
     end
   end

--- a/test/functional/tag_aliases_controller_test.rb
+++ b/test/functional/tag_aliases_controller_test.rb
@@ -3,28 +3,34 @@ require 'test_helper'
 class TagAliasesControllerTest < ActionDispatch::IntegrationTest
   context "The tag aliases controller" do
     setup do
-      @user = create(:admin_user)
       @tag_alias = create(:tag_alias, antecedent_name: "aaa", consequent_name: "bbb")
     end
 
     context "index action" do
       should "list all tag alias" do
-        get_auth tag_aliases_path, @user
+        get tag_aliases_path
         assert_response :success
       end
 
       should "list all tag_alias (with search)" do
-        get_auth tag_aliases_path, @user, params: {:search => {:antecedent_name => "aaa"}}
+        get tag_aliases_path, params: {:search => {:antecedent_name => "aaa"}}
         assert_response :success
       end
     end
 
     context "destroy action" do
-      should "mark the alias as deleted" do
-        assert_difference("TagAlias.count", 0) do
-          delete_auth tag_alias_path(@tag_alias), @user
-          assert_equal("deleted", @tag_alias.reload.status)
-        end
+      should "allow admins to delete aliases" do
+        delete_auth tag_alias_path(@tag_alias), create(:admin_user)
+
+        assert_response :redirect
+        assert_equal("deleted", @tag_alias.reload.status)
+      end
+
+      should "not allow members to delete aliases" do
+        delete_auth tag_alias_path(@tag_alias), create(:user)
+
+        assert_response 403
+        assert_equal("active", @tag_alias.reload.status)
       end
     end
   end

--- a/test/functional/tag_implications_controller_test.rb
+++ b/test/functional/tag_implications_controller_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class TagImplicationsControllerTest < ActionDispatch::IntegrationTest
   context "The tag implications controller" do
     setup do
-      @user = create(:admin_user)
       @tag_implication = create(:tag_implication, antecedent_name: "aaa", consequent_name: "bbb")
     end
 
@@ -20,11 +19,18 @@ class TagImplicationsControllerTest < ActionDispatch::IntegrationTest
     end
 
     context "destroy action" do
-      should "mark the implication as deleted" do
-        assert_difference("TagImplication.count", 0) do
-          delete_auth tag_implication_path(@tag_implication), @user
-          assert_equal("deleted", @tag_implication.reload.status)
-        end
+      should "allow admins to delete implications" do
+        delete_auth tag_implication_path(@tag_implication), create(:admin_user)
+
+        assert_response :redirect
+        assert_equal("deleted", @tag_implication.reload.status)
+      end
+
+      should "not allow members to delete aliases" do
+        delete_auth tag_implication_path(@tag_implication), create(:user)
+
+        assert_response 403
+        assert_equal("active", @tag_implication.reload.status)
       end
     end
   end

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -86,6 +86,7 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
       should "not lock the tag for a user" do
         put_auth tag_path(@tag), @user, params: {tag: { is_locked: true }}
 
+        assert_response 403
         assert_equal(false, @tag.reload.is_locked)
       end
 
@@ -100,6 +101,7 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
           @member = create(:member_user)
           put_auth tag_path(@tag), @member, params: {tag: { category: Tag.categories.general }}
 
+          assert_response 403
           assert_not_equal(Tag.categories.general, @tag.reload.category)
         end
 

--- a/test/functional/uploads_controller_test.rb
+++ b/test/functional/uploads_controller_test.rb
@@ -243,6 +243,7 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
         assert_difference("Upload.count", 1) do
           file = Rack::Test::UploadedFile.new("#{Rails.root}/test/files/test.jpg", "image/jpeg")
           post_auth uploads_path, @user, params: {:upload => {:file => file, :tag_string => "aaa", :rating => "q", :source => "aaa"}}
+          assert_redirected_to Upload.last
         end
       end
     end

--- a/test/functional/user_feedbacks_controller_test.rb
+++ b/test/functional/user_feedbacks_controller_test.rb
@@ -23,10 +23,31 @@ class UserFeedbacksControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "show action" do
+      should "allow all users to see undeleted feedbacks" do
+        get user_feedback_path(@user_feedback)
+        assert_response :success
+      end
+
+      should "allow moderators to see deleted feedbacks" do
+        as(@user) { @user_feedback.update!(is_deleted: true) }
+        get_auth user_feedback_path(@user_feedback), @mod
+        assert_response :success
+      end
+    end
+
     context "index action" do
       should "render" do
         get_auth user_feedbacks_path, @user
         assert_response :success
+      end
+
+      should "not allow members to see deleted feedbacks" do
+        as(@user) { @user_feedback.update!(is_deleted: true) }
+        get_auth user_feedbacks_path, @user
+
+        assert_response :success
+        assert_select "tr#user-feedback-#{@user_feedback.id}", false
       end
 
       context "with search parameters" do
@@ -38,31 +59,53 @@ class UserFeedbacksControllerTest < ActionDispatch::IntegrationTest
     end
 
     context "create action" do
-      should "create a new feedback" do
+      should "allow gold users to create new feedbacks" do
         assert_difference("UserFeedback.count", 1) do
           post_auth user_feedbacks_path, @critic, params: {:user_feedback => {:category => "positive", :user_name => @user.name, :body => "xxx"}}
+          assert_response :redirect
+        end
+      end
+
+      should "not allow users to create feedbacks for themselves" do
+        assert_no_difference("UserFeedback.count") do
+          post_auth user_feedbacks_path, @critic, params: { user_feedback: { user_id: @critic.id, category: "positive", body: "xxx" }}
+          assert_response 403
         end
       end
     end
 
     context "update action" do
-      should "update the feedback" do
+      should "allow updating undeleted feedbacks" do
         put_auth user_feedback_path(@user_feedback), @critic, params: { user_feedback: { category: "positive" }}
 
         assert_redirected_to(@user_feedback)
-        assert("positive", @user_feedback.reload.category)
+        assert_equal("positive", @user_feedback.reload.category)
+      end
+
+      should "not allow updating deleted feedbacks" do
+        as(@user) { @user_feedback.update!(is_deleted: true) }
+        put_auth user_feedback_path(@user_feedback), @critic, params: { user_feedback: { body: "test" }}
+
+        assert_response 403
+      end
+
+      should "allow deleting feedbacks given to others" do
+        put_auth user_feedback_path(@user_feedback), @critic, params: { user_feedback: { is_deleted: true }}
+
+        assert_response :redirect
+        assert_equal(true, @user_feedback.reload.is_deleted)
       end
 
       context "by a moderator" do
-        should "allow deleting feedbacks given to other users" do
+        should "allow updating feedbacks given to other users" do
           put_auth user_feedback_path(@user_feedback), @mod, params: { user_feedback: { is_deleted: "true" }}
 
           assert_redirected_to @user_feedback
           assert(@user_feedback.reload.is_deleted?)
         end
 
-        should "not allow deleting feedbacks given to themselves" do
-          @user_feedback = as(@critic) { create(:user_feedback, user: @mod) }
+        should "not allow updating feedbacks given to themselves" do
+          @user_feedback = create(:user_feedback, user: @mod, creator: @mod)
           put_auth user_feedback_path(@user_feedback), @mod, params: { id: @user_feedback.id, user_feedback: { is_deleted: "true" }}
 
           assert_response 403

--- a/test/functional/user_upgrades_controller_test.rb
+++ b/test/functional/user_upgrades_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class UserUpgradesControllerTest < ActionDispatch::IntegrationTest
+  context "The user upgrades controller" do
+    context "new action" do
+      should "render" do
+        get new_user_upgrade_path
+        assert_response :success
+      end
+    end
+
+    context "show action" do
+      should "render" do
+        get_auth user_upgrade_path, create(:user)
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -186,14 +186,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
 
       context "changing the level" do
-        setup do
-          @cuser = create(:user)
-        end
-
         should "not work" do
+          @cuser = create(:user)
           put_auth user_path(@user), @cuser, params: {:user => {:level => 40}}
-          @user.reload
-          assert_equal(20, @user.level)
+
+          assert_response 403
+          assert_equal(20, @user.reload.level)
         end
       end
 

--- a/test/functional/wiki_pages_controller_test.rb
+++ b/test/functional/wiki_pages_controller_test.rb
@@ -33,6 +33,13 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "search action" do
+      should "work" do
+        get search_wiki_pages_path
+        assert_response :success
+      end
+    end
+
     context "show action" do
       setup do
         as_user do
@@ -146,6 +153,7 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
       should "create a wiki_page" do
         assert_difference("WikiPage.count", 1) do
           post_auth wiki_pages_path, @user, params: {:wiki_page => {:title => "abc", :body => "abc"}}
+          assert_redirected_to(wiki_page_path(WikiPage.last))
         end
       end
     end
@@ -155,13 +163,45 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
         as_user do
           @tag = create(:tag, name: "foo", post_count: 42)
           @wiki_page = create(:wiki_page, title: "foo")
+          @builder = create(:builder_user)
         end
       end
 
       should "update a wiki_page" do
         put_auth wiki_page_path(@wiki_page), @user, params: {:wiki_page => {:body => "xyz"}}
-        @wiki_page.reload
-        assert_equal("xyz", @wiki_page.body)
+
+        assert_redirected_to wiki_page_path(@wiki_page)
+        assert_equal("xyz", @wiki_page.reload.body)
+      end
+
+      should "not allow members to edit locked wiki pages" do
+        as(@user) { @wiki_page.update!(is_locked: true) }
+        put_auth wiki_page_path(@wiki_page), @user, params: { wiki_page: { body: "xyz" }}
+
+        assert_response 403
+        assert_not_equal("xyz", @wiki_page.reload.body)
+      end
+
+      should "allow builders to edit locked wiki pages" do
+        as(@builder) { @wiki_page.update!(is_locked: true) }
+        put_auth wiki_page_path(@wiki_page), @builder, params: { wiki_page: { body: "xyz" }}
+
+        assert_redirected_to wiki_page_path(@wiki_page)
+        assert_equal("xyz", @wiki_page.reload.body)
+      end
+
+      should "not allow members to edit the is_locked flag" do
+        put_auth wiki_page_path(@wiki_page), @user, params: { wiki_page: { is_locked: true }}
+
+        assert_response 403
+        assert_equal(false, @wiki_page.reload.is_locked)
+      end
+
+      should "allow builders to edit the is_locked flag" do
+        put_auth wiki_page_path(@wiki_page), @builder, params: { wiki_page: { is_locked: true }}
+
+        assert_redirected_to wiki_page_path(@wiki_page)
+        assert_equal(true, @wiki_page.reload.is_locked)
       end
 
       should "warn about renaming a wiki page with a non-empty tag" do

--- a/test/unit/ban_test.rb
+++ b/test/unit/ban_test.rb
@@ -23,66 +23,7 @@ class BanTest < ActiveSupport::TestCase
         assert(user.is_banned?)
       end
 
-      should "not be valid against another admin" do
-        user = FactoryBot.create(:admin_user)
-        ban = FactoryBot.build(:ban, :user => user, :banner => @banner)
-        ban.save
-        assert(ban.errors.any?)
-      end
-
-      should "be valid against anyone who is not an admin" do
-        user = FactoryBot.create(:moderator_user)
-        ban = FactoryBot.create(:ban, :user => user, :banner => @banner)
-        assert(ban.errors.empty?)
-
-        user = FactoryBot.create(:contributor_user)
-        ban = FactoryBot.create(:ban, :user => user, :banner => @banner)
-        assert(ban.errors.empty?)
-
-        user = FactoryBot.create(:gold_user)
-        ban = FactoryBot.create(:ban, :user => user, :banner => @banner)
-        assert(ban.errors.empty?)
-
-        user = FactoryBot.create(:user)
-        ban = FactoryBot.create(:ban, :user => user, :banner => @banner)
-        assert(ban.errors.empty?)
-      end
-    end
-
-    context "created by a moderator" do
-      setup do
-        @banner = FactoryBot.create(:moderator_user)
-        CurrentUser.user = @banner
-        CurrentUser.ip_addr = "127.0.0.1"
-      end
-
-      teardown do
-        @banner = nil
-        CurrentUser.user = nil
-        CurrentUser.ip_addr = nil
-      end
-
-      should "not be valid against an admin or moderator" do
-        user = FactoryBot.create(:admin_user)
-        ban = FactoryBot.build(:ban, :user => user, :banner => @banner)
-        ban.save
-        assert(ban.errors.any?)
-
-        user = FactoryBot.create(:moderator_user)
-        ban = FactoryBot.build(:ban, :user => user, :banner => @banner)
-        ban.save
-        assert(ban.errors.any?)
-      end
-
-      should "be valid against anyone who is not an admin or a moderator" do
-        user = FactoryBot.create(:contributor_user)
-        ban = FactoryBot.create(:ban, :user => user, :banner => @banner)
-        assert(ban.errors.empty?)
-
-        user = FactoryBot.create(:gold_user)
-        ban = FactoryBot.create(:ban, :user => user, :banner => @banner)
-        assert(ban.errors.empty?)
-
+      should "be valid" do
         user = FactoryBot.create(:user)
         ban = FactoryBot.create(:ban, :user => user, :banner => @banner)
         assert(ban.errors.empty?)

--- a/test/unit/dmail_test.rb
+++ b/test/unit/dmail_test.rb
@@ -25,16 +25,6 @@ class DmailTest < ActiveSupport::TestCase
       end
     end
 
-    context "from a banned user" do
-      should "not validate" do
-        user = create(:banned_user)
-        dmail = build(:dmail, owner: user, from: user)
-
-        assert_equal(false, dmail.valid?)
-        assert_equal(["Sender is banned and cannot send messages"], dmail.errors.full_messages)
-      end
-    end
-
     context "search" do
       should "return results based on title contents" do
         dmail = FactoryBot.create(:dmail, :title => "xxx", :owner => @user)

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -102,25 +102,6 @@ class ForumPostTest < ActiveSupport::TestCase
       end
     end
 
-    context "belonging to a locked topic" do
-      setup do
-        @post = create(:forum_post, topic: @topic, body: "zzz")
-        @topic.update(is_locked: true)
-      end
-
-      should "not be updateable" do
-        @post.update(body: "xxx")
-        assert_equal(true, @post.invalid?)
-        assert_equal("zzz", @post.reload.body)
-      end
-
-      should "not be deletable" do
-        @post.delete!
-        assert_equal(true, @post.invalid?)
-        assert_equal(false, @post.reload.is_deleted)
-      end
-    end
-
     should "update the topic when created" do
       @original_topic_updated_at = @topic.updated_at
       travel(1.second) do

--- a/test/unit/post_flag_test.rb
+++ b/test/unit/post_flag_test.rb
@@ -95,22 +95,5 @@ class PostFlagTest < ActiveSupport::TestCase
         assert_equal(@alice.id, @post_flag.creator_id)
       end
     end
-
-    context "a moderator user" do
-      should "not be able to view flags on their own uploads" do
-        @dave = create(:moderator_user, created_at: 1.month.ago)
-        @modpost = create(:post, :tag_string => "mmm", :uploader => @dave)
-        @flag1 = create(:post_flag, post: @modpost, creator: @alice)
-
-        assert_equal(false, @dave.can_view_flagger_on_post?(@flag1))
-
-        as(@dave) do
-          flag2 = PostFlag.search(:creator_id => @alice.id)
-          assert_equal(0, flag2.length)
-          flag3 = PostFlag.search({})
-          assert_nil(JSON.parse(flag3.to_json)[0]["creator_id"])
-        end
-      end
-    end
   end
 end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2792,31 +2792,6 @@ class PostTest < ActiveSupport::TestCase
     end
   end
 
-  context "Notes:" do
-    context "#copy_notes_to" do
-      setup do
-        @src = FactoryBot.create(:post, image_width: 100, image_height: 100, tag_string: "translated partially_translated", has_embedded_notes: true)
-        @dst = FactoryBot.create(:post, image_width: 200, image_height: 200, tag_string: "translation_request")
-
-        create(:note, post: @src, x: 10, y: 10, width: 10, height: 10, body: "test")
-        create(:note, post: @src, x: 10, y: 10, width: 10, height: 10, body: "deleted", is_active: false)
-
-        @src.reload.copy_notes_to(@dst)
-      end
-
-      should "copy notes and tags" do
-        assert_equal(1, @dst.notes.active.length)
-        assert_equal(true, @dst.has_embedded_notes)
-        assert_equal("lowres partially_translated translated", @dst.tag_string)
-      end
-
-      should "rescale notes" do
-        note = @dst.notes.active.first
-        assert_equal([20, 20, 20, 20], [note.x, note.y, note.width, note.height])
-      end
-    end
-  end
-
   context "#replace!" do
     subject { @post.replace!(tags: "something", replacement_url: "https://danbooru.donmai.us/images/download-preview.png") }
 

--- a/test/unit/user_feedback_test.rb
+++ b/test/unit/user_feedback_test.rb
@@ -17,25 +17,5 @@ class UserFeedbackTest < ActiveSupport::TestCase
         assert_equal(dmail, user.dmails.last.body)
       end
     end
-
-    should "not validate if the creator is the user" do
-      user = FactoryBot.create(:gold_user)
-      feedback = build(:user_feedback, creator: user, user: user)
-      feedback.save
-      assert_equal(["You cannot submit feedback for yourself"], feedback.errors.full_messages)
-    end
-
-    should "not validate if the creator is not gold" do
-      user = FactoryBot.create(:user)
-      gold = FactoryBot.create(:gold_user)
-      member = FactoryBot.create(:user)
-
-      feedback = FactoryBot.create(:user_feedback, creator: gold, user: user)
-      assert(feedback.errors.empty?)
-
-      feedback = build(:user_feedback, creator: member, user: user)
-      feedback.save
-      assert_equal(["You must be gold"], feedback.errors.full_messages)
-    end
   end
 end

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -11,50 +11,11 @@ class WikiPageTest < ActiveSupport::TestCase
   end
 
   context "A wiki page" do
-    context "that is locked" do
-      should "not be editable by a member" do
-        CurrentUser.user = FactoryBot.create(:moderator_user)
-        @wiki_page = FactoryBot.create(:wiki_page, :is_locked => true)
-        CurrentUser.user = FactoryBot.create(:user)
-        @wiki_page.update(body: "hello")
-        assert_equal(["Is locked and cannot be updated"], @wiki_page.errors.full_messages)
-      end
-
-      should "be editable by a moderator" do
-        CurrentUser.user = FactoryBot.create(:moderator_user)
-        @wiki_page = FactoryBot.create(:wiki_page, :is_locked => true)
-        CurrentUser.user = FactoryBot.create(:moderator_user)
-        @wiki_page.update(body: "hello")
-        assert_equal([], @wiki_page.errors.full_messages)
-      end
-    end
-
-    context "updated by a moderator" do
-      setup do
-        @user = FactoryBot.create(:moderator_user)
-        CurrentUser.user = @user
-        @wiki_page = FactoryBot.create(:wiki_page)
-      end
-
-      should "allow the is_locked attribute to be updated" do
-        @wiki_page.update(is_locked: true)
-        @wiki_page.reload
-        assert_equal(true, @wiki_page.is_locked?)
-      end
-    end
-
     context "updated by a regular user" do
       setup do
         @user = FactoryBot.create(:user)
         CurrentUser.user = @user
         @wiki_page = FactoryBot.create(:wiki_page, :title => "HOT POTATO", :other_names => "foo*bar baz")
-      end
-
-      should "not allow the is_locked attribute to be updated" do
-        @wiki_page.update(is_locked: true)
-        assert_equal(["Is locked and cannot be updated"], @wiki_page.errors.full_messages)
-        @wiki_page.reload
-        assert_equal(false, @wiki_page.is_locked?)
       end
 
       should "normalize its title" do


### PR DESCRIPTION
Refactor authorization logic to use Pundit (https://github.com/varvet/pundit).

Previously access control logic was spread out in multiple locations:

* Controller `member_only` / `<role>_only` before actions.
* Controller `check_privilege` methods.
* Controller strong parameter helper methods (`<model>_params`).
* Model helper methods (`editable_by?` et al).
* Model validation methods.
* Ad-hoc checks in views (`if CurrentUser.is_member? ...`).

This had several problems:

* It was hard to see what the rules were for a given object.
* Privilege checks in views were often inconsistent with checks inside models and controllers.
* Privilege checks inside models created hidden dependencies on the current user. It's bad for models to depend on the current user because the current user doesn't always exist (for example, during tests, during background jobs, or when working inside the rails console).
* Privilege checks inside validations make unit testing more difficult. Rules like "you can't comment or upload in the first week" or "you can only flag 1 post per day" constantly create problems that we have to work around during tests.

This refactor things so that (almost) all access control logic now lives inside policy files in `app/policies`.