### PR TITLE
Show or hide post vote buttons when (un)favoriting

### DIFF
--- a/app/views/favorites/_update.js.erb
+++ b/app/views/favorites/_update.js.erb
@@ -4,6 +4,14 @@ $("#score-for-post-<%= @post.id %>").text(<%= @post.score %>);
 $("#favcount-for-post-<%= @post.id %>").text(<%= @post.fav_count %>);
 $(".fav-buttons").toggleClass("fav-buttons-false").toggleClass("fav-buttons-true");
 
+<% if @post.can_be_voted_by?(CurrentUser.user) %>
+  $("#vote-links-for-post-<%= @post.id %>").show();
+  $("#unvote-link-for-post-<%= @post.id %>").hide();
+<% else %>
+  $("#vote-links-for-post-<%= @post.id %>").hide();
+  $("#unvote-link-for-post-<%= @post.id %>").show();
+<% end %>
+
 <% if policy(@post).can_view_favlist? %>
   var fav_count = <%= @post.fav_count %>;
   $("#favlist").html("<%= j post_favlist(@post) %>");


### PR DESCRIPTION
Not sure if this is at all the proper way to do this, but it seems to work(?)

When favoriting/unfavoriting a post, it would also be upvoted/"un"voted internally but the upvote/downvote/undo vote buttons would stay shown/hidden as they were before unlike when pressing those buttons.

For example when you want change from favorite to merely upvoted you would have to reload the page in between.

Condition taken from here: https://github.com/danbooru/danbooru/blob/6d615001e4fcfdeb123f0f64cc47f3f30a044fed/app/views/posts/partials/show/_information.html.erb#L29

JS taken from: https://github.com/danbooru/danbooru/blob/6d615001e4fcfdeb123f0f64cc47f3f30a044fed/app/views/post_votes/create.js.erb#L4-L5
and https://github.com/danbooru/danbooru/blob/6d615001e4fcfdeb123f0f64cc47f3f30a044fed/app/views/post_votes/destroy.js.erb#L4-L5