### PR TITLE
Post#normalized_source: Normalize more twitter urls

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -337,7 +337,7 @@ class Post < ApplicationRecord
       end
 
       case source
-      when %r{\Ahttps?://twitter.com/[^/]+/status/(\d+)\z}i
+      when %r{\Ahttps?://(?:mobile\.)?twitter.com/[^/]+/status/(\d+)(?:/(?:photo/\d)?|\?s=\d+)?\z}i
         "https://twitter.com/i/web/status/#{$1}"
 
       when %r{\Ahttps?://lohas\.nicoseiga\.jp/priv/(\d+)\?e=\d+&h=[a-f0-9]+}i,


### PR DESCRIPTION
This normalizes the following urls:

 * https://twitter.com/ichizon7/status/1244475516180021248/photo/1 (caused by clicking on a picture) ([15k posts](https://danbooru.donmai.us/posts?tags=source%3A*twitter*%2Fphoto%2F*&ms=1 ))
 * https://twitter.com/ichizon7/status/1244475516180021248?s=20 (the number is variable, typically between 18-20 but I've seen other numbers too. Used to track the type of device it was shared from)  ([600 posts](https://danbooru.donmai.us/posts?tags=source%3A*twitter*%3Fs%3D*&ms=1)) 
 * https://mobile.twitter.com/ichizon7/status/1244475516180021248 (regularly fixed by multiple users, should be done server-side) 
 
It also normalizes urls with an ending slash (https://mobile.twitter.com/ichizon7/status/1244475516180021248/).