### PR TITLE
Show deleted posts for favorite groups

### DIFF
--- a/app/views/favorite_groups/_secondary_links.html.erb
+++ b/app/views/favorite_groups/_secondary_links.html.erb
@@ -8,7 +8,7 @@
   <% if @favorite_group && !@favorite_group.new_record? %>
     <li>|</li>
     <%= subnav_link_to "Show", favorite_group_path(@favorite_group) %>
-    <%= subnav_link_to "Posts", posts_path(:tags => "favgroup:#{@favorite_group.id}") %>
+    <%= subnav_link_to "Posts", posts_path(:tags => "favgroup:#{@favorite_group.id} status:any") %>
     <% if policy(@favorite_group).update? %>
       <%= subnav_link_to "Edit", edit_favorite_group_path(@favorite_group) %>
       <%= subnav_link_to "Delete", favorite_group_path(@favorite_group), :method => :delete, :data => {:confirm => "Are you sure you want to delete this favorite group?"} %>

--- a/app/views/favorite_groups/show.html.erb
+++ b/app/views/favorite_groups/show.html.erb
@@ -5,7 +5,7 @@
   <div id="a-show">
     <h1>
       Favorite Group:
-      <%= link_to @favorite_group.pretty_name, posts_path(:tags => "favgroup:#{@favorite_group.id}") %>
+      <%= link_to @favorite_group.pretty_name, posts_path(:tags => "favgroup:#{@favorite_group.id} status:any") %>
     </h1>
 
     Creator: <%= link_to_user @favorite_group.creator %>
@@ -18,7 +18,7 @@
       <% if @favorite_group.post_count == 0 %>
         <%= render "post_sets/blank" %>
       <% else %>
-        <%= post_previews_html(@posts, favgroup_id: @favorite_group.id) %>
+        <%= post_previews_html(@posts, favgroup_id: @favorite_group.id, show_deleted: true) %>
 
         <%= numbered_paginator(@posts) %>
       <% end %>


### PR DESCRIPTION
also link to the proper post search with `status:any`

fixes #4347

I don't particularly care for this change but someone requested it, so why not

---

Alternative:
* make `favgroup:` return everything even without `status:any`
   * more complicated