### PR TITLE
tumblr: pick biggest image based on resolution

### DIFF
--- a/app/logical/sources/strategies/tumblr.rb
+++ b/app/logical/sources/strategies/tumblr.rb
@@ -46,7 +46,11 @@ module Sources::Strategies
 
       case post[:type]
       when "photo"
-        list += post[:photos].map { |photo| photo[:original_size][:url] }
+        list += post[:photos].map do |photo|
+          sizes = [photo[:original_size]] + photo[:alt_sizes]
+          biggest = sizes.max_by { |x| x[:width] * x[:height] }
+          biggest[:url]
+        end
 
       when "video"
         list += [post[:video_url]]


### PR DESCRIPTION
`photo[:alt_sizes]` may contain a bigger image than
`photo[:original_size]`

fixes #4324