### PR TITLE
Nijie: fetch full commentary rather than truncated preview

### DIFF
--- a/app/logical/sources/strategies/nijie.rb
+++ b/app/logical/sources/strategies/nijie.rb
@@ -114,7 +114,7 @@ module Sources
       end
 
       def artist_commentary_desc
-        page&.search('meta[property="og:description"]')&.attr("content")&.value
+        page&.search('#illust_text > p')&.text
       end
 
       def tags

--- a/test/unit/sources/nijie_test.rb
+++ b/test/unit/sources/nijie_test.rb
@@ -94,6 +94,17 @@ module Sources
       end
     end
 
+    context "For long commentaries that may be truncated" do
+      should "get the full commentary" do
+        site = Sources::Strategies.find("http://nijie.info/view.php?id=266532")
+        title = "ラミアの里"
+        desc = "サークルaskot様より販売されました「ラミアの里 ～ラミアはぁれむで搾られて～」にて前回に引き続きフラウのイラストを担当させて頂きました。\r\n前作を知らなくても問題なく愉しめる内容となっております。体験版もありますので気になりましたら是非ダウンロードしてみて下さい。\r\nDLsite【http://www.dlsite.com/maniax/work/=/product_id/RJ226998.html】"
+
+        assert_equal(title, site.artist_commentary_title)
+        assert_equal(desc, site.artist_commentary_desc)
+      end
+    end
+
     context "The source site for a nijie referer url" do
       setup do
         @site = Sources::Strategies.find("http://pic.nijie.net/03/nijie_picture/728995_20170505014820_0.jpg", "https://nijie.info/view_popup.php?id=213043")


### PR DESCRIPTION
Reported by Zurreak on discord.

Examples: 
http://nijie.info/view.php?id=370424 ([Link to source.json](https://danbooru.donmai.us/source.json?url=http://nijie.info/view.php?id=370424))
http://nijie.info/view.php?id=266532 ([Link to source.json](https://danbooru.donmai.us/source.json?url=http://nijie.info/view.php?id=266532))

The og:description property is truncated with "..." after a certain length.
We have a few of these truncated commentaries on site:  `https://danbooru.donmai.us/artist_commentaries?commit=Search&search%5Bpost_tags_match%5D=source:*nijie.info*+&search%5Boriginal_description_regex%5D=\.\.\.$&limit=1000`. They'll have to be fixed manually afterwards.

Since the title field is limited to 100 characters, it's never truncated, so that can be left as it is.