### PR TITLE
Adds suport for using the image_url parameter with IQDB

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -3,7 +3,7 @@ class IqdbQueriesController < ApplicationController
 
   def show
     # XXX allow bare search params for backwards compatibility.
-    search_params.merge!(params.slice(:url, :image_url, :post_id, :limit, :similarity, :high_similarity).permit!)
+    search_params.merge!(params.slice(:url, :image_url, :file_url, :post_id, :limit, :similarity, :high_similarity).permit!)
 
     @high_similarity_matches, @low_similarity_matches, @matches = IqdbProxy.search(search_params)
     respond_with(@matches, template: "iqdb_queries/show")

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -25,7 +25,10 @@ class IqdbProxy
       file = download(params[:url], :preview_url)
       results = query(file: file, limit: limit)
     elsif params[:image_url].present?
-      file = download(params[:image_url], :image_url)
+      file = download(params[:image_url], :url)
+      results = query(file: file, limit: limit)
+    elsif params[:file_url].present?
+      file = download(params[:file_url], :file_url)
       results = query(file: file, limit: limit)
     elsif params[:post_id].present?
       url = Post.find(params[:post_id]).preview_file_url


### PR DESCRIPTION
Mentioned as an item that needed fixing in issue #4328.

Basically, there was no support for the **image_url** parameter. In addition to fixing that, it adds in support for a **file_url** parameter, which always selects the largest available size.

So all told, the parameters will be:

- `url` - The preview URL size
- `file_url` - The download/largest URL size
- `image_url` - The size as specified by the input URL