### PR TITLE
Add monospace font

### DIFF
--- a/app/javascript/src/styles/common/fonts.css
+++ b/app/javascript/src/styles/common/fonts.css
@@ -37,6 +37,51 @@
     url("../../../../../node_modules/typopro-web/web/TypoPRO-ComicRelief/TypoPRO-ComicRelief-Bold.woff") format("woff");
 }
 
+/* https://fonts.google.com/specimen/IBM+Plex+Mono */
+@font-face {
+  font-family: "Mono";
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+  src:
+    local("IBM Plex Mono"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-200.woff2") format("woff2"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-200.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Mono";
+  font-weight: normal;
+  font-style: italic;
+  font-display: swap;
+  src:
+    local("IBM Plex Mono"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-200italic.woff2") format("woff2"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-200italic.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Mono";
+  font-weight: bold;
+  font-style: normal;
+  font-display: swap;
+  src:
+    local("IBM Plex Mono"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-700.woff2") format("woff2"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-700.woff") format("woff");
+}
+
+@font-face {
+  font-family: "Mono";
+  font-weight: bold;
+  font-style: italic;
+  font-display: swap;
+  src:
+    local("IBM Plex Mono"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-700italic.woff2") format("woff2"),
+    url("../../../../../node_modules/typeface-ibm-plex-mono/files/ibm-plex-mono-latin-700italic.woff") format("woff");
+}
+
 /* https://fonts.google.com/specimen/Rokkitt */
 @font-face {
   font-family: "Rockwell";

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "stupid-table-plugin": "^1.1.3",
     "typeface-anton": "^0.0.72",
     "typeface-archivo-narrow": "^1.0.0",
+    "typeface-ibm-plex-mono": "^0.0.61",
     "typeface-indie-flower": "^0.0.72",
     "typeface-lora": "^0.0.72",
     "typeface-petit-formal-script": "^0.0.72",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8890,6 +8890,11 @@ typeface-archivo-narrow@^1.0.0:
   resolved "https://registry.yarnpkg.com/typeface-archivo-narrow/-/typeface-archivo-narrow-1.1.3.tgz#c0855305f14ead3b27f20c541c50a8823d839357"
   integrity sha512-Nqer5J9i1QRtoL9m+g5qW+qxkkWjE4vGvjlnyE1TSJY6f6WuNGxrx4GEtShkiXJ78NdMGYIre+M5+3MnmezjZw==
 
+typeface-ibm-plex-mono@^0.0.61:
+  version "0.0.61"
+  resolved "https://registry.yarnpkg.com/typeface-ibm-plex-mono/-/typeface-ibm-plex-mono-0.0.61.tgz#ee7f12643e2bfee5c5c6915350005d6dfdaa66fd"
+  integrity sha512-4Pzza33ihcW1l9qSs6WmRRb6FxVoDvpoTws55V9rwN7zVqURFh1c/i4qWCmHJ0Dyr0c+pYgQVyb/aAwsRjv2Lg==
+
 typeface-indie-flower@^0.0.72:
   version "0.0.72"
   resolved "https://registry.yarnpkg.com/typeface-indie-flower/-/typeface-indie-flower-0.0.72.tgz#80b18841d9c789b262e6f7ff6950a4472e565f60"


### PR DESCRIPTION
Part of #4212.  Discussed on [topic #16435](https://danbooru.donmai.us/forum_topics/16435) and Discord's [#translations](https://discordapp.com/channels/310432830138089472/390639683119480863/713152504283529756).

I went with the IBM Plex Mono as suggested by Shinjidude as it looked about the right amount of robotic, plus the italic version looks pretty interesting.