### PR TITLE
Fix flash dimensions

### DIFF
--- a/app/logical/media_file/flash.rb
+++ b/app/logical/media_file/flash.rb
@@ -54,4 +54,5 @@ class MediaFile::Flash < MediaFile
 
     [width, height]
   end
+  memoize :dimensions
 end

--- a/app/logical/media_file/flash.rb
+++ b/app/logical/media_file/flash.rb
@@ -5,7 +5,7 @@ class MediaFile::Flash < MediaFile
   def dimensions
     # Read the entire stream into memory because the
     # dimensions aren't stored in a standard location
-    contents = file.read.force_encoding("ASCII-8BIT")
+    contents = File.read(file.path, binmode: true).force_encoding("ASCII-8BIT")
 
     # Our 'signature' is the first 3 bytes
     # Either FWS or CWS.  CWS indicates compression


### PR DESCRIPTION
When uploading a flash file you get a ``error: NoMethodError - undefined method `unpack' for nil:NilClass``.

This is because `#dimensions` is called twice - in `#width` and in `#height` which is a problem because the first time it gets called file  is consumed by `#read` and thus the second time it gets called `#read` just returns the empty string.

This would be solved by memoizing `#dimensions` but that's not what I did since it still consumes the file and while (I think) it doesn't get used (without rewinding) right now who knows what you might want to do with it in the future.

You could `#rewind` it of course but I chose to open it again with `File.read` and not mess with `file` at all (though I doubt you have to worry about thread-safety) (like the other subclasses).

(I would prefer using [`pread(2)`](https://linux.die.net/man/2/pread) but there's no convenience method to read the whole file this way)

I also added `memoize :dimensions` because why not? It's [memoized in `MediaFile`](https://github.com/danbooru/danbooru/blob/c300b344de9875c505c6f7029b6802fd8ade6570/app/logical/media_file.rb#L116) but not in any of the subclasses. I even just tested it and the `memoize` call doesn't seem to apply when overriding a method in a subclass:
<details><summary>memoize subclass</summary>

```rb
[10] pry(main)> class Foo; extend Memoist; def foo; puts "foo"; end; memoize :foo; end
[11] pry(main)> foo = Foo.new
[12] pry(main)> foo.foo # "foo" gets printed the first time
foo
=> nil
[13] pry(main)> foo.foo # but not the second time
=> nil
[15] pry(main)> class Bar < Foo; def foo; puts "bar"; end; end
[16] pry(main)> bar = Bar.new
[17] pry(main)> bar.foo # "bar" gets printed the first time
bar
=> nil
[18] pry(main)> bar.foo # and the second time as well
bar
=> nil
```

</details>

I can modify the second commit to apply to all the other subclasses as well if you want.

Feel free to solve it any other way if you disagree on any of this.

---

On a unrelated note: while nobody seems to care these days, strictly speaking I don't think [this comment](https://github.com/danbooru/danbooru/blob/a6fac80e668ee0bbe913a3b13144f67fcd5e0287/app/logical/media_file/flash.rb#L1-L2) is enough to satisfy [these conditions](https://github.com/dim/ruby-imagespec/blob/f2f3ce8bb5b1b411f8658e66a891a095261d94c0/LICENSE#L7-L12). 