### PR TITLE
Fix invalid artist URLs being allowed

### DIFF
--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -120,9 +120,18 @@ class ArtistUrl < ApplicationRecord
     end
   end
 
+  def validate_scheme(uri)
+    errors[:url] << "'#{uri}' must begin with http:// or https:// " unless uri.scheme.in?(%w[http https])
+  end
+
+  def validate_hostname(uri)
+    errors[:url] << "'#{uri}' has a hostname '#{uri.host}' that does not contain a dot" unless uri.host&.include?('.')
+  end
+
   def validate_url_format
     uri = Addressable::URI.parse(url)
-    errors[:url] << "'#{uri}' must begin with http:// or https:// " if !uri.scheme.in?(%w[http https])
+    validate_scheme(uri)
+    validate_hostname(uri)
   rescue Addressable::URI::InvalidURIError => error
     errors[:url] << "'#{uri}' is malformed: #{error}"
   end

--- a/test/unit/artist_url_test.rb
+++ b/test/unit/artist_url_test.rb
@@ -24,10 +24,18 @@ class ArtistUrlTest < ActiveSupport::TestCase
     end
 
     should "disallow invalid urls" do
-      url = FactoryBot.build(:artist_url, url: "www.example.com")
+      urls = [
+        FactoryBot.build(:artist_url, url: "www.example.com"),
+        FactoryBot.build(:artist_url, url: ":www.example.com"),
+        FactoryBot.build(:artist_url, url: "http://http://www.example.com"),
+      ]
 
-      assert_equal(false, url.valid?)
-      assert_match(/must begin with http/, url.errors.full_messages.join)
+      assert_equal(false, urls[0].valid?)
+      assert_match(/must begin with http/, urls[0].errors.full_messages.join)
+      assert_equal(false, urls[1].valid?)
+      assert_match(/is malformed/, urls[1].errors.full_messages.join)
+      assert_equal(false, urls[2].valid?)
+      assert_match(/that does not contain a dot/, urls[2].errors.full_messages.join)
     end
 
     should "always add a trailing slash when normalized" do


### PR DESCRIPTION
Fixes #4192. The problem was that the Addressable parser does not catch all invalid URL cases.

I used the following page in part of my search for a regex URL validator.

https://mathiasbynens.be/demo/url-regex

The one provided by **diegoperini** seemed to be the best.

https://gist.github.com/dperini/729294

One of the responders there mentioned creating a Ruby gem, which seems like the easiest to incorporate and maintain.

https://github.com/amogil/url_regex