### PR TITLE
Add ability to use parent post's artist commentary

### DIFF
--- a/app/javascript/src/javascripts/uploads.js.erb
+++ b/app/javascript/src/javascripts/uploads.js.erb
@@ -24,6 +24,11 @@ Upload.initialize_all = function() {
     this.initialize_submit();
     $("#similar-button").click();
 
+    $("#clear-artist-commentary").on("click.danbooru", function(e) {
+      Upload.clear_commentary();
+      e.preventDefault();
+    });
+
     $("#toggle-artist-commentary").on("click.danbooru", function(e) {
       Upload.toggle_commentary();
       e.preventDefault();
@@ -160,6 +165,10 @@ Upload.fetch_data_manual = function(e) {
 
   e.preventDefault();
 }
+
+Upload.clear_commentary = function() {
+  $("#upload_artist_commentary_title,#upload_artist_commentary_desc,#upload_translated_commentary_title,#upload_translated_commentary_desc").val("");
+};
 
 Upload.toggle_commentary = function() {
   if ($(".artist-commentary").is(":visible")) {

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -418,6 +418,11 @@ div#c-posts {
       margin-bottom: 0.5em;
       padding: 0.5em;
 
+      .commentary-from-parent {
+        font-size: 80%;
+        color: var(--muted-text-color);
+      }
+
       #original-artist-commentary, #translated-artist-commentary {
         max-height: 20em;
         overflow-y: auto;

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1465,7 +1465,7 @@ class Post < ApplicationRecord
   include IqdbMethods
   include ValidationMethods
 
-  has_bit_flags ["has_embedded_notes", "has_cropped"]
+  has_bit_flags ["has_embedded_notes", "has_cropped", "use_parent_commentary"]
 
   def safeblocked?
     CurrentUser.safe_mode? && (rating != "s" || Danbooru.config.safe_mode_restricted_tags.any? { |tag| tag.in?(tag_array) })

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -79,7 +79,8 @@ class PostPolicy < ApplicationPolicy
   def permitted_attributes
     [
       :tag_string, :old_tag_string, :parent_id, :old_parent_id,
-      :source, :old_source, :rating, :old_rating, :has_embedded_notes,
+      :source, :old_source, :rating, :old_rating,
+      :has_embedded_notes, :use_parent_commentary,
       (:is_rating_locked if can_lock_rating?),
       (:is_note_locked if can_lock_notes?),
       (:is_status_locked if can_lock_status?),

--- a/app/views/artist_commentaries/_show.html.erb
+++ b/app/views/artist_commentaries/_show.html.erb
@@ -1,4 +1,10 @@
-<h2>Artist's commentary</h2>
+<%# artist_commentary, from_parent %>
+
+<h2>Artist's commentary
+  <% if from_parent %>
+    <span class="commentary-from-parent">(from parent)</span>
+  <% end %>
+</h2>
 
 <menu id="commentary-sections">
   <% if artist_commentary.original_present? && artist_commentary.translated_present? %>

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -24,6 +24,8 @@
   <fieldset class="inline-fieldset">
     <label>Notes</label>
     <%= f.input :has_embedded_notes, label: "Embed notes", as: :boolean, boolean_style: :inline, disabled: post.is_note_locked? %>
+    <label>Commentary</label>
+    <%= f.input :use_parent_commentary, label: "Use parent's", as: :boolean, boolean_style: :inline %>
   </fieldset>
 
   <% if policy(post).can_lock_rating? || policy(post).can_lock_notes? || policy(post).can_lock_status? %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -83,9 +83,13 @@
     <% end %>
   </section>
 
-  <% if @post.artist_commentary && @post.artist_commentary.any_field_present? %>
+  <% if @post.use_parent_commentary && @post.parent&.artist_commentary&.any_field_present? %>
+    <div id="artist-commentary" class="child-commentary">
+      <%= render "artist_commentaries/show", :artist_commentary => @post.parent.artist_commentary, :from_parent => true %>
+    </div>
+  <% elsif @post.artist_commentary&.any_field_present? %>
     <div id="artist-commentary">
-      <%= render "artist_commentaries/show", :artist_commentary => @post.artist_commentary %>
+      <%= render "artist_commentaries/show", :artist_commentary => @post.artist_commentary, :from_parent => false %>
     </div>
   <% end %>
 
@@ -135,9 +139,15 @@
 <% end %>
 
 <% if policy(ArtistCommentary).create_or_update? %>
-  <div id="add-commentary-dialog" title="Add artist commentary" style="display: none;">
-    <%= render "artist_commentaries/form", post: @post, artist_commentary: @post.artist_commentary || ArtistCommentary.new(post: @post) %>
-  </div>
+  <% if (@post.use_parent_commentary && @post.parent&.artist_commentary.any_field_present?) %>
+    <div id="add-commentary-dialog" title="Modify artist commentary (parent)" style="display: none;">
+      <%= render "artist_commentaries/form", post: @post.parent, artist_commentary: @post.parent.artist_commentary %>
+    </div>
+  <% else %>
+    <div id="add-commentary-dialog" title="Add artist commentary" style="display: none;">
+      <%= render "artist_commentaries/form", post: @post, artist_commentary: @post.artist_commentary || ArtistCommentary.new(post: @post) %>
+    </div>
+  <% end %>
 <% end %>
 
 <% if policy(FavoriteGroup).create? %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -43,7 +43,7 @@
 
         <div class="input upload_artist_commentary_container">
           <strong>Commentary</strong>
-          <a href="#" id="toggle-artist-commentary">show »</a>
+          (<a href="#" id="clear-artist-commentary">clear</a>) <a href="#" id="toggle-artist-commentary">show »</a>
 
           <div class="artist-commentary" style="display: none;">
             <%= f.input :artist_commentary_title, as: :string, label: "Original Title", input_html: { size: 60, value: params[:artist_commentary_title] } %>


### PR DESCRIPTION
Fixes #4450.

I'm not sure that linking commentary outside of a parent/child relationship needs to be handled at this time, especially since doing so though would not be so simple. I'd say let's see how the users do with this change, and address any shortfalls later on if there are any.