### PR TITLE
Pixiv: don't blacklist digital tools anymore

### DIFF
--- a/app/logical/pixiv_api_client.rb
+++ b/app/logical/pixiv_api_client.rb
@@ -8,21 +8,6 @@ class PixivApiClient
   CLIENT_SECRET = "HP3RmkgAmEGro0gn1x9ioawQE8WMfvLXDz3ZqxpK"
   CLIENT_HASH_SALT = "28c1fdd170a5204386cb1313c7077b34f83e4aaf4aa829ce78c231e05b0bae2c"
 
-  # Tools to not include in the tags list. We don't tag digital media, so
-  # including these results in bad translated tags suggestions.
-  TOOLS_BLACKLIST = %w[
-    Photoshop Illustrator Fireworks Flash Painter PaintShopPro pixiv\ Sketch
-    CLIP\ STUDIO\ PAINT IllustStudio ComicStudio RETAS\ STUDIO SAI PhotoStudio
-    Pixia NekoPaint PictBear openCanvas ArtRage Expression Inkscape GIMP
-    CGillust COMICWORKS MS_Paint EDGE AzPainter AzPainter2 AzDrawing
-    PicturePublisher SketchBookPro Processing 4thPaint GraphicsGale mdiapp
-    Paintgraphic AfterEffects drawr CLIP\ PAINT\ Lab FireAlpaca Pixelmator
-    AzDrawing2 MediBang\ Paint Krita ibisPaint Procreate Live2D
-    Lightwave3D Shade Poser STRATA AnimationMaster XSI CARRARA CINEMA4D Maya
-    3dsMax Blender ZBrush Metasequoia Sunny3D Bryce Vue Hexagon\ King SketchUp
-    VistaPro Sculptris Comi\ Po! modo DAZ\ Studio 3D-Coat
-  ]
-
   class Error < StandardError; end
   class BadIDError < Error; end
 
@@ -39,7 +24,7 @@ class PixivApiClient
       @artist_commentary_title = json["title"].to_s
       @artist_commentary_desc = json["caption"].to_s
       @tags = json["tags"].reject {|x| x =~ /^http:/}
-      @tags += json["tools"] - TOOLS_BLACKLIST
+      @tags += json["tools"]
 
       if json["metadata"]
         if json["metadata"]["zip_urls"]

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -259,10 +259,6 @@ module Sources
           assert_includes(@translated_tags, "foo")
         end
 
-        should "not translate tags for digital media" do
-          assert_equal(false, @tags.include?("Photoshop"))
-        end
-
         should "normalize 10users入り tags" do
           assert_includes(@tags, "風景10users入り")
           assert_includes(@translated_tags, "scenery")
@@ -294,7 +290,7 @@ module Sources
         should "not translate '1000users入り' to '1'" do
           FactoryBot.create(:tag, name: "1", post_count: 1)
           source = get_source("https://www.pixiv.net/member_illust.php?mode=medium&illust_id=60665428")
-          tags = %w[1000users入り Fate/GrandOrder アルジュナ(Fate) アルトリア・ペンドラゴン イシュタル(Fate) グランブルーファンタジー マシュ・キリエライト マーリン(Fate) 両儀式 手袋]
+          tags = %w[1000users入り Fate/GrandOrder アルジュナ(Fate) アルトリア・ペンドラゴン イシュタル(Fate) グランブルーファンタジー マシュ・キリエライト マーリン(Fate) 両儀式 手袋 CLIP\ STUDIO\ PAINT Photoshop]
 
           assert_equal(tags.sort, source.tags.map(&:first).sort)
           assert_equal(["fate/grand_order"], source.translated_tags.map(&:name))


### PR DESCRIPTION
This is not needed anymore. It used to be that those tags bled into the tags for when the software interface appears in the picture, but as we have translated tags for digital mediums now it should be fine.