### PR TITLE
Don't display artist wiki when it is deleted

### DIFF
--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -8,7 +8,7 @@
     <% if @artist.is_banned? && !policy(@artist).can_view_banned? %>
       <p>The artist requested removal of this page.</p>
     <% else %>
-      <% if @artist.wiki_page.present? %>
+      <% if @artist.wiki_page.present? && !@artist.wiki_page.is_deleted %>
         <div class="prose">
           <%= format_text(@artist.wiki_page.body, :disable_mentions => true) %>
         </div>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -28,7 +28,7 @@
       <%= format_text(@wiki_page.body) %>
     <% end %>
 
-    <% if @wiki_page.artist %>
+    <% if @wiki_page.artist.present? && !@wiki_page.artist.is_deleted %>
       <p><%= link_to "View artist", @wiki_page.artist %></p>
     <% end %>
 


### PR DESCRIPTION
Fixes #4526. It also fixes the reverse situation, i.e. a wiki's artist is deleted.