### PR TITLE
Add ability to search on status of parent/child

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -9,6 +9,7 @@ Autocomplete.ORDER_METATAGS = <%= PostQueryBuilder::ORDER_METATAGS.to_json.html_
 Autocomplete.DISAPPROVAL_REASONS = <%= PostDisapproval::REASONS.to_json.html_safe %>;
 /* eslint-enable */
 
+Autocomplete.MISC_STATUSES = ["deleted", "active", "pending", "flagged", "banned", "modqueue", "unmoderated"];
 Autocomplete.TAG_PREFIXES = "-|~|" + Object.keys(Autocomplete.TAG_CATEGORIES).map(category => category + ":").join("|");
 Autocomplete.METATAGS_REGEX = Autocomplete.METATAGS.concat(Object.keys(Autocomplete.TAG_CATEGORIES)).join("|");
 Autocomplete.TERM_REGEX = new RegExp(`([-~]*)(?:(${Autocomplete.METATAGS_REGEX}):)?(\\S*)$`, "i");
@@ -268,9 +269,7 @@ Autocomplete.render_item = function(list, item) {
 
 Autocomplete.static_metatags = {
   order: Autocomplete.ORDER_METATAGS,
-  status: [
-    "any", "deleted", "active", "pending", "flagged", "banned", "modqueue", "unmoderated"
-  ],
+  status: ["any"].concat(Autocomplete.MISC_STATUSES),
   rating: [
     "safe", "questionable", "explicit"
   ],
@@ -280,12 +279,8 @@ Autocomplete.static_metatags = {
   embedded: [
     "true", "false"
   ],
-  child: [
-    "any", "none"
-  ],
-  parent: [
-    "any", "none"
-  ],
+  child: ["any", "none"].concat(Autocomplete.MISC_STATUSES),
+  parent: ["any", "none"].concat(Autocomplete.MISC_STATUSES),
   filetype: [
     "jpg", "png", "gif", "swf", "zip", "webm", "mp4"
   ],

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -307,6 +307,8 @@ class PostQueryBuilder
       Post.where(parent: nil)
     when "any"
       Post.where.not(parent: nil)
+    when /pending|flagged|modqueue|deleted|banned|active|unmoderated/
+      Post.where.not(parent: nil).where(parent: status_matches(parent))
     when /\A\d+\z/
       Post.where(id: parent).or(Post.where(parent: parent))
     else
@@ -320,6 +322,8 @@ class PostQueryBuilder
       Post.where(has_children: false)
     when "any"
       Post.where(has_children: true)
+    when /pending|flagged|modqueue|deleted|banned|active|unmoderated/
+      Post.where(has_children: true).where(children: status_matches(child))
     else
       Post.none
     end

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -277,6 +277,19 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([child, parent], "-child:garbage")
     end
 
+    should "return posts when using the status of the parent/child" do
+      parent_of_deleted = create(:post)
+      deleted = create(:post, is_deleted: true, tag_string: "parent:#{parent_of_deleted.id}")
+      child_of_deleted = create(:post, tag_string: "parent:#{deleted.id}")
+      all = [child_of_deleted, deleted, parent_of_deleted]
+
+      assert_tag_match([child_of_deleted], "parent:deleted")
+      assert_tag_match(all - [child_of_deleted], "-parent:deleted")
+
+      assert_tag_match([parent_of_deleted], "child:deleted")
+      assert_tag_match(all - [parent_of_deleted], "-child:deleted")
+    end
+
     should "return posts for the favgroup:<name> metatag" do
       post1 = create(:post)
       post2 = create(:post)


### PR DESCRIPTION
Fixes #4474. 

Besides searching for the status of parent, it also adds the ability to search by status of child.