### PR TITLE
Add option to search for wikis that don't link to a specific wiki

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -53,7 +53,11 @@ class WikiPage < ApplicationRecord
     end
 
     def linked_to(title)
-      where(id: DtextLink.wiki_page.wiki_link.where(link_target: title).select(:model_id))
+      where(dtext_links: DtextLink.wiki_page.wiki_link.where(link_target: normalize_title(title)))
+    end
+
+    def not_linked_to(title)
+      where.not(dtext_links: DtextLink.wiki_page.wiki_link.where(link_target: normalize_title(title)))
     end
 
     def default_order
@@ -80,6 +84,10 @@ class WikiPage < ApplicationRecord
 
       if params[:linked_to].present?
         q = q.linked_to(params[:linked_to])
+      end
+
+      if params[:not_linked_to].present?
+        q = q.not_linked_to(params[:not_linked_to])
       end
 
       if params[:hide_deleted].to_s.truthy?
@@ -146,6 +154,7 @@ class WikiPage < ApplicationRecord
   end
 
   def self.normalize_title(title)
+    return if title.blank?
     title.downcase.delete_prefix("~").gsub(/[[:space:]]+/, "_").gsub(/__/, "_").gsub(/\A_|_\z/, "")
   end
 

--- a/app/views/wiki_pages/search.html.erb
+++ b/app/views/wiki_pages/search.html.erb
@@ -4,6 +4,8 @@
       <%= f.input :title_normalize, label: "Title", hint: "Use * for wildcard searches", input_html: { "data-autocomplete": "wiki-page" } %>
       <%= f.input :other_names_match, label: "Other names", hint: "Use * for wildcard searches" %>
       <%= f.input :body_matches, label: "Body" %>
+      <%= f.input :linked_to, hint: "Which wikis link to the specified wiki.", input_html: { "data-autocomplete": "wiki-page" } %>
+      <%= f.input :not_linked_to, hint: "Which wikis do not link to the specified wiki.", input_html: { "data-autocomplete": "wiki-page" } %>
       <%= f.input :other_names_present, as: :select %>
       <%= f.input :hide_deleted, as: :select, include_blank: false %>
       <%= f.input :order, collection: [%w[Name title], %w[Date time], %w[Posts post_count]], include_blank: false %>


### PR DESCRIPTION
I encountered the need for this usecase the other day when searching for meta-wikis that don't currently link to the [list of meta-wikis](https://danbooru.donmai.us/wiki_pages/list_of_meta-wikis) wiki page. Beyond that specific usecase, it can also be used for other umbrella wikis to find wikis that don't currently have links so that they can be added.

In regards to those type of scenarios, both the linked to and not linked to search parameters were added to the wiki search page to aid the normal user.