### PR TITLE
Fix the tag matches option

### DIFF
--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -33,7 +33,7 @@ class PostVersion < ApplicationRecord
     end
 
     def tag_matches(string)
-      tag = string.split(/\S+/)[0]
+      tag = string.match(/\S+/)[0]
       return all if tag.nil?
       tag = "*#{tag}*" unless tag =~ /\*/
       where_ilike(:tags, tag)

--- a/test/functional/post_versions_controller_test.rb
+++ b/test/functional/post_versions_controller_test.rb
@@ -41,6 +41,13 @@ class PostVersionsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal @post.versions[1].id, response.parsed_body[0]["id"].to_i
       end
+
+      should "list all versions for search[tag_matches]" do
+        get post_versions_path, as: :json, params: { search: { tag_matches: "tagme" }}
+        assert_response :success
+        assert_equal @post.versions[0].id, response.parsed_body[0]["id"].to_i
+        assert_equal 1, response.parsed_body.length
+      end
     end
 
     context "undo action" do


### PR DESCRIPTION
Fixes #4533. The issue was the split function was mistakenly used instead of the match function.