### PR TITLE
Uploads: Check if strategy is enabled before use

### DIFF
--- a/app/logical/sources/strategies/deviant_art.rb
+++ b/app/logical/sources/strategies/deviant_art.rb
@@ -77,6 +77,10 @@ module Sources
 
       FAVME = %r{\Ahttps?://(?:www\.)?fav\.me/d(?<base36_deviation_id>[a-z0-9]+)\z}i
 
+      def self.enabled?
+        Danbooru.config.deviantart_client_id.present? && Danbooru.config.deviantart_client_secret.present?
+      end
+
       def domains
         ["deviantart.net", "deviantart.com", "fav.me"]
       end

--- a/app/logical/sources/strategies/nico_seiga.rb
+++ b/app/logical/sources/strategies/nico_seiga.rb
@@ -50,6 +50,10 @@ module Sources
 
       PROFILE_PAGE = %r{\Ahttps?://seiga\.nicovideo\.jp/user/illust/(?<artist_id>\d+)}i
 
+      def self.enabled?
+        Danbooru.config.nico_seiga_login.present? && Danbooru.config.nico_seiga_password.present?
+      end
+
       def domains
         ["nicoseiga.jp", "nicovideo.jp"]
       end

--- a/app/logical/sources/strategies/nijie.rb
+++ b/app/logical/sources/strategies/nijie.rb
@@ -64,6 +64,10 @@ module Sources
       DIR = %r{(?:\d+/)?(?:__rs_\w+/)?nijie_picture(?:/diff/main)?}
       IMAGE_URL = %r{#{IMAGE_BASE_URL}/#{DIR}/#{Regexp.union(FILENAME1, FILENAME2, FILENAME3)}\.\w+\z}i
 
+      def self.enabled?
+        Danbooru.config.nijie_login.present? && Danbooru.config.nijie_password.present?
+      end
+
       def domains
         ["nijie.info", "nijie.net"]
       end

--- a/app/logical/sources/strategies/pawoo.rb
+++ b/app/logical/sources/strategies/pawoo.rb
@@ -24,6 +24,10 @@ module Sources::Strategies
     STATUS1 = %r{\A#{HOST}/web/statuses/(?<status_id>\d+)}
     STATUS2 = %r{\A#{NAMED_PROFILE}/(?<status_id>\d+)}
 
+    def self.enabled?
+      Danbooru.config.pawoo_client_id.present? && Danbooru.config.pawoo_client_secret.present?
+    end
+
     def domains
       ["pawoo.net"]
     end

--- a/app/logical/sources/strategies/pixiv.rb
+++ b/app/logical/sources/strategies/pixiv.rb
@@ -65,6 +65,10 @@ module Sources
       STACC_PAGE = %r{\A#{WEB}/stacc/#{MONIKER}/?\z}i
       NOVEL_PAGE = %r{(?:\Ahttps?://www\.pixiv\.net/novel/show\.php\?id=(\d+))}
 
+      def self.enabled?
+        Danbooru.config.pixiv_login.present? && Danbooru.config.pixiv_password.present?
+      end
+
       def self.to_dtext(text)
         if text.nil?
           return nil

--- a/app/logical/upload_service/preprocessor.rb
+++ b/app/logical/upload_service/preprocessor.rb
@@ -64,6 +64,8 @@ class UploadService
     end
 
     def start!
+      raise NotImplementedError, "No login credentials configured for #{strategy.site_name}." unless strategy.class.enabled?
+
       if Utils.is_downloadable?(source)
         if Post.system_tag_match("source:#{canonical_source}").where.not(id: original_post_id).exists?
           raise ActiveRecord::RecordNotUnique, "A post with source #{canonical_source} already exists"

--- a/app/logical/upload_service/utils.rb
+++ b/app/logical/upload_service/utils.rb
@@ -72,6 +72,8 @@ class UploadService
       raise "No file or source URL provided" if upload.source_url.blank?
 
       strategy = Sources::Strategies.find(upload.source_url, upload.referer_url)
+      raise NotImplementedError, "No login credentials configured for #{strategy.site_name}." unless strategy.class.enabled?
+
       file = strategy.download_file!
 
       if strategy.data[:ugoira_frame_data].present?


### PR DESCRIPTION
Avoid returning bare API traceback from pixiv et al when login details are not configured, and instead raise a generic error with the site's name.

There already was a skeleton implementation for this so I just added the missing functions for all relevant strategies.

Fixes #4545.