### PR TITLE
Add search for a list of any changed tags

### DIFF
--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -32,6 +32,10 @@ class PostVersion < ApplicationRecord
       end
     end
 
+    def changed_tags_include_any(tags)
+      where_array_includes_any(:added_tags, tags).or(where_array_includes_any(:removed_tags, tags))
+    end
+
     def tag_matches(string)
       tag = string.match(/\S+/)[0]
       return all if tag.nil?
@@ -43,8 +47,12 @@ class PostVersion < ApplicationRecord
       q = super
       q = q.search_attributes(params, :updater_id, :post_id, :tags, :added_tags, :removed_tags, :rating, :rating_changed, :parent_id, :parent_changed, :source, :source_changed, :version)
 
-      if params[:changed_tags]
-        q = q.changed_tags_include_all(params[:changed_tags].scan(/[^[:space:]]+/))
+      if params[:all_changed_tags]
+        q = q.changed_tags_include_all(params[:all_changed_tags].scan(/[^[:space:]]+/))
+      end
+
+      if params[:any_changed_tags]
+        q = q.changed_tags_include_any(params[:any_changed_tags].scan(/[^[:space:]]+/))
       end
 
       if params[:tag_matches]

--- a/app/views/post_versions/index.html.erb
+++ b/app/views/post_versions/index.html.erb
@@ -13,7 +13,8 @@
       <%= f.input :updater_name, label: "Updater", input_html: { "data-autocomplete": "user", value: params.dig(:search, :updater_name) } %>
       <%= f.input :added_tags_include_all, label: "Added Tags", input_html: { "data-autocomplete": "tag-query", value: params.dig(:search, :added_tags_include_all) } %>
       <%= f.input :removed_tags_include_all, label: "Removed Tags", input_html: { "data-autocomplete": "tag-query", value: params.dig(:search, :removed_tags_include_all) } %>
-      <%= f.input :changed_tags, label: "Changed Tags", input_html: { "data-autocomplete": "tag-query", value: params.dig(:search, :changed_tags) } %>
+      <%= f.input :all_changed_tags, label: "All Changed Tags", input_html: { "data-autocomplete": "tag-query", value: params.dig(:search, :all_changed_tags) }, hint: "All tags must appear in either tag adds or removes" %>
+      <%= f.input :any_changed_tags, label: "Any Changed Tags", input_html: { "data-autocomplete": "tag-query", value: params.dig(:search, :any_changed_tags) }, hint: "Any tag must appear in either tag adds or removes" %>
       <%= f.submit "Search" %>
       <%= link_to "Advanced", search_post_versions_path(params.except(:controller, :action, :index, :commit, :type).permit!), class: "advanced-search-link" %>
     <% end %>

--- a/app/views/post_versions/search.html.erb
+++ b/app/views/post_versions/search.html.erb
@@ -7,7 +7,8 @@
       <%= f.input :updater_name, label: "Updater", input_html: { value: params.dig(:search, :updater_name), "data-autocomplete": "user" } %>
       <%= f.input :added_tags_include_all, label: "Added tags", input_html: { value: params.dig(:search, :added_tags_include_all), "data-autocomplete": "tag-query" } %>
       <%= f.input :removed_tags_include_all, label: "Removed tags", input_html: { value: params.dig(:search, :removed_tags_include_all), "data-autocomplete": "tag-query" } %>
-      <%= f.input :changed_tags, label: "Changed tags", input_html: { value: params.dig(:search, :changed_tags), "data-autocomplete": "tag-query" } %>
+      <%= f.input :all_changed_tags, label: "All Changed Tags", input_html: { "data-autocomplete": "tag-query", value: params.dig(:search, :all_changed_tags) }, hint: "All tags must appear in either tag adds or removes" %>
+      <%= f.input :any_changed_tags, label: "Any Changed Tags", input_html: { "data-autocomplete": "tag-query", value: params.dig(:search, :any_changed_tags) }, hint: "Any tag must appear in either tag adds or removes" %>
       <%= f.input :post_id, input_html: { value: params.dig(:search, :post_id) } %>
       <%= f.input :parent_id, input_html: { value: params.dig(:search, :parent_id) } %>
       <%= f.input :rating, input_html: { value: params.dig(:search, :rating) } %>


### PR DESCRIPTION
This will facilitate users being able to monitor tag changes from a list of tags they are interested in. Currently, the only way to do this is 2 separate queries on the added_tags and removed_tags.

For the record, I would be able to use this with my [EventListener userscript](https://github.com/BrokenEagle/JavaScripts/blob/master/eventlistener.user.js). Currently, the user can only search for a list of added tags, a list of removed tags, but not both at the same time unless a tag from both lists appears on the post version, which limits its use.