### PR TITLE
Nijie: fix login

### DIFF
--- a/app/logical/sources/strategies/nijie.rb
+++ b/app/logical/sources/strategies/nijie.rb
@@ -180,23 +180,37 @@ module Sources
       end
 
       def page
-        return nil if page_url.blank?
+        return nil if page_url.blank? || client.blank?
 
-        http = Danbooru::Http.new
-        form = { email: Danbooru.config.nijie_login, password: Danbooru.config.nijie_password }
-
-        # XXX `retriable` must come after `cache` so that retries don't return cached error responses.
-        response = http.cache(1.hour).use(retriable: { max_retries: 20 }).post("https://nijie.info/login_int.php", form: form)
-        DanbooruLogger.info "Nijie login failed (#{url}, #{response.status})" if response.status != 200
-        return nil unless response.status == 200
-
-        response = http.cookies(R18: 1).cache(1.minute).get(page_url)
+        response = client.cache(1.minute).get(page_url)
         return nil unless response.status == 200
 
         response&.parse
       end
-
       memoize :page
+
+      def client
+        http = Danbooru::Http.new.timeout(60)
+
+        cookie = Cache.get("nijie-session-cookie", 1.week) do
+          login_page = http.use(retriable: { max_retries: 20 }).get("https://nijie.info/login.php").parse
+          form = {
+            email: Danbooru.config.nijie_login,
+            password: Danbooru.config.nijie_password,
+            url: login_page.at("input[name='url']")["value"],
+            save: "on",
+            ticket: ""
+          }
+          response = http.use(retriable: { max_retries: 20 }).post("https://nijie.info/login_int.php", form: form)
+          DanbooruLogger.info "Nijie login failed (#{url}, #{response.status})" if response.status != 200
+          return nil unless response.status == 200
+
+          response.cookies.select { |c| c.name == "NIJIEIJIEID" }.compact.first
+        end
+
+        http.cookies(NIJIEIJIEID: cookie, R18: 1)
+      end
+      memoize :client
     end
   end
 end

--- a/test/unit/sources/nijie_test.rb
+++ b/test/unit/sources/nijie_test.rb
@@ -292,6 +292,18 @@ module Sources
       end
     end
 
+    context "a post requiring login" do
+      should "not fail" do
+        site = Sources::Strategies.find("https://nijie.info/view.php?id=203688")
+
+        urls = %w[
+          https://pic.nijie.net/01/nijie_picture/676327_20170216212803_0.jpg
+          https://pic.nijie.net/04/nijie_picture/diff/main/676327_20170216212806_0.jpg
+        ]
+        assert_equal(urls, site.image_urls)
+      end
+    end
+
     context "normalizing for source" do
       should "normalize correctly" do
         source1 = "https://pic01.nijie.info/nijie_picture/diff/main/218856_0_236014_20170620101329.png"


### PR DESCRIPTION
Fixes a regression in 6e6ce6e62f79f0c97251d4e1012009f8c138e021 that broke logging in.

Fixes #4543.

Also raises nijie timeout to 60 seconds because the site is often hella slow.