### PR TITLE
Upload limit: don't display progress in tooltip when maxed out

### DIFF
--- a/app/logical/upload_limit.rb
+++ b/app/logical/upload_limit.rb
@@ -30,6 +30,10 @@ class UploadLimit
     end
   end
 
+  def maxed?
+    user.upload_points >= MAXIMUM_POINTS
+  end
+
   def used_upload_slots
     pending = user.posts.pending
     early_deleted = user.posts.deleted.where("created_at >= ?", 3.days.ago)

--- a/app/views/users/_upload_limit.html.erb
+++ b/app/views/users/_upload_limit.html.erb
@@ -4,7 +4,11 @@
   none
 <% else %>
   <%= link_to user.upload_limit.used_upload_slots, posts_path(tags: "user:#{user.name} status:pending") %> /
-  <%= tag.abbr user.upload_limit.upload_slots, title: "#{pluralize(user.upload_limit.approvals_for_next_level - user.upload_limit.approvals_on_current_level, "approved post")} needed for next level (progress: #{user.upload_limit.approvals_on_current_level} / #{user.upload_limit.approvals_for_next_level}) " %>
+  <% if user.upload_limit.maxed? %>
+    <%= tag.abbr user.upload_limit.upload_slots, title: "Maximum amount of upload slots reached." %>
+  <% else %>
+    <%= tag.abbr user.upload_limit.upload_slots, title: "#{pluralize(user.upload_limit.approvals_for_next_level - user.upload_limit.approvals_on_current_level, "approved post")} needed for next level (progress: #{user.upload_limit.approvals_on_current_level} / #{user.upload_limit.approvals_for_next_level}) " %>
+  <% end %>
 <% end %>
 
 (<%= link_to_wiki "help", "about:upload_limits" %>)


### PR DESCRIPTION
Fixes #4564.
Looks like this: 
![image](https://user-images.githubusercontent.com/12946050/89850850-659dd100-db8b-11ea-9108-224069a7cb68.png)
