### PR TITLE
Autotag source_request & warn for sourceless uploads

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -24,6 +24,7 @@ class Post < ApplicationRecord
   validate :has_artist_tag
   validate :has_copyright_tag
   validate :has_enough_tags
+  validate :has_source
   validate :post_is_not_its_own_parent
   validate :updater_can_change_rating
   validate :uploader_is_not_limited, on: :create
@@ -551,6 +552,10 @@ class Post < ApplicationRecord
 
       if !is_png?
         tags -= ["animated_png"]
+      end
+
+      if source.blank? && !(has_tag?("commissioner_upload") || has_tag?("self_upload"))
+        tags << "source_request"
       end
 
       return tags
@@ -1432,6 +1437,14 @@ class Post < ApplicationRecord
       if tags.count(&:general?) < 10
         self.warnings[:base] << "Uploads must have at least 10 general tags. Read [[howto:tag]] for guidelines on tagging your uploads"
       end
+    end
+
+    def has_source
+      return if !new_record?
+      return unless source.blank?
+      return if has_tag?("commissioner_upload") || has_tag?("self_upload")
+
+      self.warnings[:base] << "A source is required. Read [[help:image_source]] for guidelines on sourcing your uploads"
     end
   end
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1536,6 +1536,16 @@ class PostTest < ActiveSupport::TestCase
           post = FactoryBot.create(:post, tag_string: "tagme")
           assert_match(/Uploads must have at least \d+ general tags/, post.warnings.full_messages.join)
         end
+
+        should "warn when an upload doesn't have a source" do
+          post = FactoryBot.create(:post, tag_string: "tagme", source: "")
+          assert_match(/A source is required/, post.warnings.full_messages.join)
+        end
+
+        should "not warn when a sourceless upload has an allowed tag" do
+          post = FactoryBot.create(:post, tag_string: "self_upload", source: "")
+          assert_no_match(/A source is required/, post.warnings.full_messages.join)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #4569. 

Adds a warning similar to the others when someone uploads with no source and doesn't use self_upload/commissioner_upload.