### PR TITLE
Safebooru: update restricted tags

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -258,7 +258,7 @@ module Danbooru
 
     # Tags that are not visible in safe mode.
     def safe_mode_restricted_tags
-      restricted_tags + %w[censored condom nipples nude penis pussy sexually_suggestive]
+      restricted_tags + %w[sex_toy condom nipples nude penis pussy sexually_suggestive]
     end
 
     # Tags that are only visible to Gold+ users.


### PR DESCRIPTION
* remove "censored": this should be already handled by rating, as censored genitals, sexual acts etc should always be q when they're explicit enough that they're being censored. There's also a lot of false positives in keeping this in, such as identity censor, censored foods/innocuous items for comedy's sake, etc.

* add "sex_toy" - this is a recently populated tag since all types of sex toys now implicate it, and adding this also makes sure we cover the "sexual items" part of censored content that might be rating:safe but not something we want on safebooru, and would filter through if "censored" is not completely restricted

Fixes #4582