### PR TITLE
Fix parameter hash detection

### DIFF
--- a/app/logical/concerns/searchable.rb
+++ b/app/logical/concerns/searchable.rb
@@ -2,7 +2,7 @@ module Searchable
   extend ActiveSupport::Concern
 
   def parameter_hash?(params)
-    params.present? && params.respond_to?(:each)
+    params.present? && params.respond_to?(:each_value)
   end
 
   def parameter_depth(params)


### PR DESCRIPTION
Parameter arrays are causing errors because they also respond to `each`.

https://danbooru.donmai.us/artist_urls.json?search%5Bnormalized_url_lower_array%5D%5B%5D=http%3A%2F%2Ftwitter.com%2Fkozomeeeee%2F&only=normalized_url%2Cartist%5Bid%2Cname%2Cis_deleted%2Cis_banned%2Cother_names%2Curls%5Bnormalized_url%2Cis_active%5D%5D&limit=1000
```json
{
  "success": false,
  "message": "undefined method `values' for [\"http://twitter.com/kozomeeeee/\"]:Array\nDid you mean?  values_at",
  "backtrace": ["app/logical/concerns/searchable.rb:9:in `parameter_depth'","app/logical/concerns/searchable.rb:10:in `block in parameter_depth'","app/logical/concerns/searchable.rb:10:in `map'","app/logical/concerns/searchable.rb:10:in `parameter_depth'","app/logical/concerns/searchable.rb:151:in `search_attributes'","app/logical/concerns/searchable.rb:392:in `search'","app/models/artist_url.rb:43:in `search'","app/models/application_record.rb:20:in `paginated_search'","app/controllers/artist_urls_controller.rb:5:in `index'"]
}
```

I changed it to `each_value` since Hash-like objects will respond to that whereas arrays do not.