### PR TITLE
Fix blog.fc2 urls matching wrong artists

### DIFF
--- a/app/logical/artist_finder.rb
+++ b/app/logical/artist_finder.rb
@@ -44,6 +44,7 @@ module ArtistFinder
     "fantia.jp/fanclubs", # https://fantia.jp/fanclubs/1711
     "fav.me", # http://fav.me/d9y1njg
     /blog-imgs-\d+(?:-origin)?\.fc2\.com/i,
+    %r{blog\.fc2\.com(/\w)+/?}i, # http://blog71.fc2.com/a/abk00/file/20080220194219.jpg
     "furaffinity.net",
     "furaffinity.net/user", # http://www.furaffinity.net/user/achthenuts
     "gelbooru.com", # http://gelbooru.com/index.php?page=account&s=profile&uname=junou

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -20,9 +20,9 @@ class ArtistUrl < ApplicationRecord
       nil
     else
       url = url.sub(%r!^https://!, "http://")
-      url = url.sub(%r!^http://blog\d+\.fc2!, "http://blog.fc2")
       url = url.sub(%r!^http://blog-imgs-\d+\.fc2!, "http://blog.fc2")
       url = url.sub(%r!^http://blog-imgs-\d+-\w+\.fc2!, "http://blog.fc2")
+      url = url.sub(%r!^http://blog\d*\.fc2\.com/(?:\w/){,3}(\w+)!, "http://\\1.blog.fc2.com")
       url = url.sub(%r!^http://pictures.hentai-foundry.com//!, "http://pictures.hentai-foundry.com/")
 
       # the strategy won't always work for twitter because it looks for a status


### PR DESCRIPTION
Fixes #4551. 

This allows us to get rid of the tons of horrible fc2 urls structured like "https://blog.fc2.com/a/a/a/aaaaaaaaaako/" (just look at the [/a/ entries](https://danbooru.donmai.us/artist_urls?commit=Search&search%5Border%5D=id&search%5Burl_matches%5D=%2Afc2.com%2Fa%2F%2A)) that have plagued the artist urls for years, and merge them all into a standard "https://artist_name.blog.fc2.com".
