### PR TITLE
Uploads preprocessing: get rid of same-source existence check

### DIFF
--- a/app/logical/upload_service/preprocessor.rb
+++ b/app/logical/upload_service/preprocessor.rb
@@ -66,20 +66,6 @@ class UploadService
     def start!
       raise NotImplementedError, "No login credentials configured for #{strategy.site_name}." unless strategy.class.enabled?
 
-      if Utils.is_downloadable?(source)
-        if Post.system_tag_match("source:#{canonical_source}").where.not(id: original_post_id).exists?
-          raise ActiveRecord::RecordNotUnique, "A post with source #{canonical_source} already exists"
-        end
-
-        if Upload.where(source: source, status: "completed").exists?
-          raise ActiveRecord::RecordNotUnique, "A completed upload with source #{source} already exists"
-        end
-
-        if Upload.where(source: source).where("status like ?", "error%").exists?
-          raise ActiveRecord::RecordNotUnique, "An errored upload with source #{source} already exists"
-        end
-      end
-
       params[:rating] ||= "q"
       params[:tag_string] ||= "tagme"
       upload = Upload.create!(params)


### PR DESCRIPTION
Fixes #4409. 

I really tried to understand why these lines are in the code but for the life of me I couldn't figure it out. The github blame function only goes back to 3 years ago when the preprocessor.rb file was created.

These lines are not needed to stop duplicate uploads, because the md5 check does the same. At first I thought they stopped duplicate preprocessing, but after some tests I realized those were being created regardless of the lines being there. 
The only thing they do from what I could tell is stop replacements if the same source already exists, which basically breaks replacements in many cases unless you empty the source field before replacing and fix it afterwards (which is slowly making me insane with all the e-hentai replacements being cockblocked by this). And this check doesn't really make sense for us because the same source can be applied to many different posts, since most sites we support have multiple images per url.


I also tried running tests but I can't seem to configure post versioning properly on my instance, every test that didn't rely on the missing services didn't change in output from what I could see though.