### PR TITLE
Update: INSTALL.debian

### DIFF
--- a/INSTALL.debian
+++ b/INSTALL.debian
@@ -77,7 +77,7 @@ chsh -s /bin/bash danbooru
 usermod -G danbooru,sudo danbooru
 
 # Set up Postgres
-export PG_VERSION=`pg_config --version | egrep -o '[0-9]{1,}\.[0-9]{1,}'`
+export PG_VERSION=`pg_config --version | egrep -o '[0-9]{1,}\.[0-9]{1,}[^-]'`
 if verlte 9.5 $PG_VERSION ; then
 	# only do this on postgres 9.5 and above
 

--- a/INSTALL.debian
+++ b/INSTALL.debian
@@ -48,6 +48,7 @@ apt-get -y install zlib1g-dev libglib2.0-dev
 apt-get -y install $LIBSSL_DEV_PKG build-essential automake libxml2-dev libxslt-dev ncurses-dev sudo libreadline-dev flex bison ragel redis git curl libcurl4-openssl-dev sendmail-bin sendmail nginx ssh coreutils ffmpeg mkvtoolnix
 apt-get -y install libpq-dev postgresql-client
 apt-get -y install liblcms2-dev $LIBJPEG_TURBO_DEV_PKG libexpat1-dev libgif-dev libpng-dev libexif-dev
+apt-get -y install gcc g++
 
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
gcc, g ++ is required to building

Add [^ -] to exclude duplicate.
Example:
PostgreSQL 11.9 (Debian 11.9-0+deb10u1)