### PR TITLE
Update artist finder blacklist

### DIFF
--- a/app/logical/artist_finder.rb
+++ b/app/logical/artist_finder.rb
@@ -8,6 +8,7 @@ module ArtistFinder
     "www.artstation.com", # http://www.artstation.com/serafleur/
     %r{cdn[ab]?\.artstation\.com/p/assets/images/images}i, # https://cdna.artstation.com/p/assets/images/images/001/658/068/large/yang-waterkuma-b402.jpg?1450269769
     "ask.fm", # http://ask.fm/mikuroko_396
+    "baraag.net",
     "bcyimg.com",
     "bcyimg.com/drawer", # https://img9.bcyimg.com/drawer/32360/post/178vu/46229ec06e8111e79558c1b725ebc9e6.jpg
     "bcy.net",

--- a/app/logical/artist_finder.rb
+++ b/app/logical/artist_finder.rb
@@ -83,8 +83,8 @@ module ArtistFinder
     "pixiv.net", # https://www.pixiv.net/member.php?id=10442390
     "pixiv.net/stacc", # https://www.pixiv.net/stacc/aaaninja2013
     "pixiv.net/fanbox/creator", # https://www.pixiv.net/fanbox/creator/310630
-    "pixiv.net/users", # https://www.pixiv.net/users/555603
-    "pixiv.net/en/users", # https://www.pixiv.net/en/users/555603
+    %r{pixiv.net/(?:en/)?users}i, # https://www.pixiv.net/users/555603
+    %r{pixiv.net/(?:en/)?artworks}i, # https://www.pixiv.net/en/artworks/85241178
     "i.pximg.net",
     "plurk.com", # http://www.plurk.com/a1amorea1a1
     "privatter.net",

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -164,6 +164,13 @@ class ArtistTest < ActiveSupport::TestCase
       assert_artist_not_found("http://i2.pixiv.net/img28/img/kyang692/35563903.jpg")
     end
 
+    should "ignore /en/ pixiv url matches" do
+      a1 = FactoryBot.create(:artist, :name => "vvv", :url_string => "https://www.pixiv.net/en/users/32072927/artworks")
+      a2 = FactoryBot.create(:artist, :name => "c01a", :url_string => "https://www.pixiv.net/en/users/31744504")
+      assert_artist_not_found("https://www.pixiv.net/en/artworks/85241178")
+      assert_artist_not_found("https://www.pixiv.net/en/users/85241178")
+    end
+
     should "find matches by url" do
       a1 = FactoryBot.create(:artist, :name => "rembrandt", :url_string => "http://rembrandt.com/x/test.jpg")
       a2 = FactoryBot.create(:artist, :name => "subway", :url_string => "http://subway.com/x/test.jpg")


### PR DESCRIPTION
Fixes #4621. 

Also adds blacklist for https://baraag.net and updated tests for /en/ pixiv links.