### PR TITLE
Weibo: use proxy for upload previews

### DIFF
--- a/app/logical/sources/strategies/weibo.rb
+++ b/app/logical/sources/strategies/weibo.rb
@@ -90,6 +90,10 @@ module Sources
         image_urls.map { |img| img.gsub(%r{.cn/\w+/(\w+)}, '.cn/orj360/\1') }
       end
 
+      def headers
+        { "Referer" => "https://weibo.com" }
+      end
+
       def page_url
         if api_response.present?
           artist_id = api_response["user"]["id"]


### PR DESCRIPTION
Fixes weibo previews not being shown in the batch upload page.

Example: http://danbooru.donmai.us/uploads/batch?batch%5Burl%5D=https%3A%2F%2Fwww.weibo.com%2F5362351387%2FJvzzbhnrc&commit=Fetch