### PR TITLE
Add wiki page redirects

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -42,7 +42,7 @@ class WikiPagesController < ApplicationController
       if @redirect.blank? || params["redirect"] == "false"
         respond_with(@wiki_page)
       else
-        redirect_to wiki_page_path(@redirect, redirect: false)
+        redirect_to wiki_page_path(@redirect, redirect: false, from: @wiki_page.title)
       end
     end
   end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -38,7 +38,12 @@ class WikiPagesController < ApplicationController
     elsif @wiki_page.blank?
       raise ActiveRecord::RecordNotFound
     else
-      respond_with(@wiki_page)
+      @redirect = @wiki_page.wiki_redirect
+      if @redirect.blank? || params["redirect"] == "false"
+        respond_with(@wiki_page)
+      else
+        redirect_to wiki_page_path(@redirect, redirect: false)
+      end
     end
   end
 

--- a/app/helpers/wiki_pages_helper.rb
+++ b/app/helpers/wiki_pages_helper.rb
@@ -3,4 +3,12 @@ module WikiPagesHelper
     names_html = wiki_page.other_names.map {|name| link_to(name, "http://www.pixiv.net/search.php?s_mode=s_tag_full&word=#{u(name)}", :class => "wiki-other-name")}
     names_html.join(" ").html_safe
   end
+
+  def wiki_page_redirect(wiki_page)
+    if wiki_page.wiki_redirect.present?
+      "yes"
+    elsif wiki_page.redirect_title
+      "no wiki"
+    end
+  end
 end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -178,6 +178,11 @@ class WikiPage < ApplicationRecord
     WikiPage.is_meta_wiki?(title)
   end
 
+  def wiki_redirect
+    match = body.match(/\A#redirect \[\[([^\]]+)\]\]\z/i)
+    match ? WikiPage.find_by(title: WikiPage.normalize_title(match[1])) : nil
+  end
+
   def wiki_page_changed?
     saved_change_to_title? || saved_change_to_body? || saved_change_to_is_locked? || saved_change_to_is_deleted? || saved_change_to_other_names?
   end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -178,9 +178,15 @@ class WikiPage < ApplicationRecord
     WikiPage.is_meta_wiki?(title)
   end
 
+  def redirect_title
+    @redirect_title ||= begin
+      match = body.match(/\A#redirect \[\[([^\]]+)\]\]\z/i)
+      match ? WikiPage.normalize_title(match[1]) : nil
+    end
+  end
+
   def wiki_redirect
-    match = body.match(/\A#redirect \[\[([^\]]+)\]\]\z/i)
-    match ? WikiPage.find_by(title: WikiPage.normalize_title(match[1])) : nil
+    redirect_title ? WikiPage.find_by(title: redirect_title) : nil
   end
 
   def wiki_page_changed?

--- a/app/views/wiki_pages/index.html.erb
+++ b/app/views/wiki_pages/index.html.erb
@@ -4,9 +4,12 @@
   <h1>Wiki</h1>
   <%= render "search" %>
 
-  <%= table_for @wiki_pages, width: "100%" do |t| %>
-    <% t.column "Title" do |wiki_page| %>
+  <%= table_for @wiki_pages, class: "striped autofit", width: "100%" do |t| %>
+    <% t.column "Title", td: {class: "col-expand"} do |wiki_page| %>
       <span class="<%= tag_class(wiki_page.tag) %>"><%= link_to_wiki wiki_page.title %></span>
+    <% end %>
+    <% t.column "Redirect", width: "8%" do |wiki_page| %>
+      <%= wiki_page_redirect(wiki_page) %>
     <% end %>
     <% t.column "Last edited", width: "10%" do |wiki_page| %>
       <%= time_ago_in_words_tagged(wiki_page.updated_at) %>

--- a/app/views/wiki_pages/index.html.erb
+++ b/app/views/wiki_pages/index.html.erb
@@ -9,8 +9,13 @@
     <% t.column "Title" do |wiki_page| %>
       <span class="<%= tag_class(wiki_page.tag) %>"><%= link_to_wiki wiki_page.title %></span>
     <% end %>
-    <% t.column "Last edited" do |wiki_page| %>
+    <% t.column "Last edited", width: "10%" do |wiki_page| %>
       <%= time_ago_in_words_tagged(wiki_page.updated_at) %>
+    <% end %>
+    <% t.column column: "control", width: "5%" do |wiki_page| %>
+      <% if policy(wiki_page).update? %>
+        <%= link_to "Edit", edit_artist_path(wiki_page) %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/wiki_pages/index.html.erb
+++ b/app/views/wiki_pages/index.html.erb
@@ -2,7 +2,6 @@
 
 <% content_for(:content) do %>
   <h1>Wiki</h1>
-
   <%= render "search" %>
 
   <%= table_for @wiki_pages, width: "100%" do |t| %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -17,6 +17,10 @@
     <% end %>
   </h1>
 
+  <% if params[:redirect] == "false" && params[:from].present? %>
+    <div id="wiki-page-redirect">(Redirected from <%= link_to(params[:from], wiki_page_path(params[:from], redirect: false), class: "wiki-link") %>)</div>
+  <% end %>
+
   <div id="wiki-page-body" class="prose">
     <% if @wiki_page.other_names.present? %>
       <p><%= wiki_page_other_names_list(@wiki_page) %></p>

--- a/test/functional/wiki_pages_controller_test.rb
+++ b/test/functional/wiki_pages_controller_test.rb
@@ -69,6 +69,9 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
     context "show action" do
       setup do
         @wiki_page = as(@user) { create(:wiki_page) }
+        @redirect_to = as(@user) { create(:wiki_page, title: "blah") }
+        @redirect_from = as(@user) { create(:wiki_page, title: "blahblah", body: "#REDIRECT [[blah]]") }
+        @extra_redirect = as(@user) { create(:wiki_page, body: "#REDIRECT [[blahblah]]") }
       end
 
       should "redirect to the title for an id" do
@@ -77,6 +80,14 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
 
         get wiki_page_path(@wiki_page.id), as: :json
         assert_response :success
+      end
+
+      should "redirect for #REDIRECT wikis" do
+        get wiki_page_path(@redirect_from.title)
+        assert_redirected_to wiki_page_path(@redirect_to.title, redirect: false)
+
+        get wiki_page_path(@extra_redirect.title)
+        assert_redirected_to wiki_page_path(@redirect_from.title, redirect: false)
       end
 
       should "distinguish between an id and a title" do


### PR DESCRIPTION
Fixes #4664.

- As mentioned on Wikipedia, "The capitalization of the word REDIRECT doesn't matter."
    - https://en.wikipedia.org/wiki/Wikipedia:Redirect#Editing_the_source_directly
    - Likewise, the capitalization and use of underscores/spaces does not matter since the title gets normalized.
- Only 1 redirect is allowed to prevent infinite loops.
- The `redirect=false` parameter can be used to go to the wiki directly. 
- Added edit links to the index to allow for easier editing.
    - Plus this now matches the controls already being done for artists.