### PR TITLE
Add missing associated attributes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,8 +35,10 @@ class ApplicationController < ActionController::Base
       return
     end
 
+    model = options[0]&.delete(:model)
     if subject.respond_to?(:includes) && (request.format.json? || request.format.xml?)
-      associations = ParameterBuilder.includes_parameters(params[:only], model_name)
+      model ||= model_name
+      associations = ParameterBuilder.includes_parameters(params[:only], model)
       subject = subject.includes(associations)
     end
 

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -4,7 +4,7 @@ class EmailsController < ApplicationController
   def index
     @email_addresses = authorize EmailAddress.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @email_addresses = @email_addresses.includes(:user)
-    respond_with(@email_addresses)
+    respond_with(@email_addresses, model: "EmailAddress")
   end
 
   def show

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -82,4 +82,8 @@ class EmailAddress < ApplicationRecord
       id == verifier.verified(key)
     end
   end
+
+  def self.available_includes
+    [:user]
+  end
 end

--- a/app/models/forum_topic_visit.rb
+++ b/app/models/forum_topic_visit.rb
@@ -10,4 +10,8 @@ class ForumTopicVisit < ApplicationRecord
     q = search_attributes(params, :id, :created_at, :updated_at, :user, :forum_topic_id, :last_read_at)
     q.apply_default_order(params)
   end
+
+  def self.available_includes
+    [:forum_topic]
+  end
 end

--- a/app/models/forum_topic_visit.rb
+++ b/app/models/forum_topic_visit.rb
@@ -7,7 +7,7 @@ class ForumTopicVisit < ApplicationRecord
   end
 
   def self.search(params)
-    q = search_attributes(params, :id, :created_at, :updated_at, :user, :forum_topic_id, :last_read_at)
+    q = search_attributes(params, :id, :created_at, :updated_at, :user, :forum_topic, :last_read_at)
     q.apply_default_order(params)
   end
 

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -168,8 +168,4 @@ class SavedSearch < ApplicationRecord
   def disable_labels=(value)
     user.update(disable_categorized_saved_searches: true) if value.to_s.truthy?
   end
-
-  def self.available_includes
-    [:user]
-  end
 end

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -150,4 +150,8 @@ class TagImplication < TagRelationship
       end
     end
   end
+
+  def self.available_includes
+    super + [:child_implications, :parent_implications]
+  end
 end

--- a/app/models/user_event.rb
+++ b/app/models/user_event.rb
@@ -37,6 +37,10 @@ class UserEvent < ApplicationRecord
     q
   end
 
+  def self.available_includes
+    [:user, :user_session]
+  end
+
   concerning :ConstructorMethods do
     class_methods do
       # Build an event but don't save it yet. The caller is expected to update the user, which will save the event.


### PR DESCRIPTION
I noticed that I had missed the `parent_implications` and `child_implications` associations because I didn't thank that the `tag_implication` had additional relationships beyond those in the `tag_relationship` model. I didn't add those to a **search_attributes** call in the **search** function because it already has `implied_to` and `implied_from` which should cover most of that.

Beyond that, I also added in a few other related items.

- Searched for other missing usable associations and added those.
- Removed unncessary associations. 
- Converts non-converted ID fields to the association names instead.