### PR TITLE
Post sidebar: ignore metatags for the tag history link

### DIFF
--- a/app/views/posts/partials/index/_related.html.erb
+++ b/app/views/posts/partials/index/_related.html.erb
@@ -11,8 +11,8 @@
 
     <li><%= link_to "Deleted", posts_path(tags: "#{params[:tags]} status:deleted"), rel: "nofollow" %></li>
     <li><%= link_to "Random", random_posts_path(tags: params[:tags]), id: "random-post", "data-shortcut": "r", rel: "nofollow" %></li>
-    <% if post_set.query.is_simple_tag? %>
-      <li><%= link_to "History", post_versions_path(search: { changed_tags: params[:tags] }), rel: "nofollow" %></li>
+    <% if post_set.normalized_query.has_single_tag? %>
+      <li><%= link_to "History", post_versions_path(search: { changed_tags: post_set.normalized_query.tags.first.name }), rel: "nofollow" %></li>
     <% end %>
     <li><%= link_to "Count", posts_counts_path(tags: params[:tags]), rel: "nofollow" %></li>
   </ul>


### PR DESCRIPTION
Fixes #4692. 

Makes the logic for displaying the tag history behave similarly to the one for showing the wiki in https://github.com/danbooru/danbooru/blob/054ac51d471b192cdc5136b82bb1a5c939bd7332/app/logical/post_sets/post.rb#L27-L28

Basically we still want to display the link if someone searches for the negated tag or with additional metatags like status.