### PR TITLE
Don't mark cosplay/style tags as low post count

### DIFF
--- a/app/components/tag_list_component.rb
+++ b/app/components/tag_list_component.rb
@@ -36,7 +36,7 @@ class TagListComponent < ApplicationComponent
   end
 
   def is_underused_tag?(tag)
-    tag.post_count <= 1 && tag.general?
+    tag.post_count <= 1 && tag.general? && tag.name !~ /_\((cosplay|style)\)\z/
   end
 
   def humanized_post_count(tag)


### PR DESCRIPTION
There's 4629 of these tags with a single post as of the opening of this pull request. Doesn't make much sense for us to mark them as low post count since they're legitimate even when there's a single post, just like their corresponding character tags.