### PR TITLE
Fix ordering of user levels in user search

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -240,8 +240,8 @@ class User < ApplicationRecord
 
       def level_hash
         return {
-          "Member" => Levels::MEMBER,
           "Restricted" => Levels::RESTRICTED,
+          "Member" => Levels::MEMBER,
           "Gold" => Levels::GOLD,
           "Platinum" => Levels::PLATINUM,
           "Builder" => Levels::BUILDER,


### PR DESCRIPTION
Fixes Member appearing before Restricted in the user search. This thing:
![image](https://user-images.githubusercontent.com/12946050/108135656-c1a45d80-70b8-11eb-9bde-12dba72f5c30.png)
