### PR TITLE
Updates the BUR form to reference the new commands

### DIFF
--- a/app/helpers/bulk_update_requests_helper.rb
+++ b/app/helpers/bulk_update_requests_helper.rb
@@ -1,6 +1,6 @@
 module BulkUpdateRequestsHelper
   def bur_script_example
-    <<~EOS
+    <<~BUR
       create alias bunny -> rabbit
       remove alias bunny -> rabbit
 
@@ -9,7 +9,11 @@ module BulkUpdateRequestsHelper
 
       rename bunny -> rabbit
 
+      update bunny_focus -> animal_focus bunny
+
+      nuke bunny
+
       category touhou -> copyright
-    EOS
+    BUR
   end
 end

--- a/app/views/bulk_update_requests/_form.html.erb
+++ b/app/views/bulk_update_requests/_form.html.erb
@@ -2,9 +2,10 @@
   <%= error_messages_for("bulk_update_request") %>
 
   <p>
-    Request aliases or implications using the format shown below. An alias makes the first tag a
-    synonym for the second tag. An implication makes the first tag automatically add the second tag.
-    A mass update replaces the first tag with the second tag without making it a permanent alias.
+    Request aliases or implications using the format shown below. An <b>alias</b> makes the first tag a
+    synonym for the second tag. An <b>implication</b> makes the first tag automatically add the second tag.
+    A <b>rename</b> replaces the first tag with the second tag without making it a permanent alias.
+    An <b>update</b> moves multiple tags and pools at once.
   </p>
 
   <p>


### PR DESCRIPTION
The BUR form was never updated to show rename or nuke. 

Also since I was editing the file anyway I fixed the rubocop warning for meaningful heredoc delimiters.