### PR TITLE
Sources: get correct mastodon page url

### DIFF
--- a/app/logical/sources/strategies/mastodon.rb
+++ b/app/logical/sources/strategies/mastodon.rb
@@ -85,7 +85,7 @@ module Sources::Strategies
     end
 
     def artist_name_from_url
-      url[NAMED_PROFILE, :artist_name]
+      urls.map { |url| url[NAMED_PROFILE, :artist_name] }.compact.first
     end
 
     def other_names
@@ -93,7 +93,7 @@ module Sources::Strategies
     end
 
     def account_id
-      url[ID_PROFILE, :account_id] || api_response.account_id
+      urls.map { |url| url[ID_PROFILE, :account_id] }.compact.first || api_response.account_id
     end
 
     def status_id_from_url

--- a/test/unit/sources/mastodon_test.rb
+++ b/test/unit/sources/mastodon_test.rb
@@ -95,6 +95,10 @@ module Sources
       should "fetch the source data" do
         assert_equal("evazion", @site.artist_name)
       end
+
+      should "correctly get the page url" do
+        assert_equal(@ref, @site.page_url)
+      end
     end
 
     context "A baraag url" do


### PR DESCRIPTION
Accidental regression in 5366b0781ee4989d3d4fadb90445feaa89fea62e. Since we were not checking the referer, it's saving all sources as /web/statuses rather than the normal form. A minor issue, but still.