### PR TITLE
Baraag: fix image regex

### DIFF
--- a/app/logical/sources/strategies/mastodon.rb
+++ b/app/logical/sources/strategies/mastodon.rb
@@ -17,7 +17,7 @@
 module Sources::Strategies
   class Mastodon < Base
     HOST = %r{\Ahttps?://(?:www\.)?(?<domain>pawoo\.net|baraag\.net)}i
-    IMAGE = %r{\Ahttps?://(?:img\.pawoo\.net|baraag\.net)/media_attachments/files/(\d+/\d+/\d+)}
+    IMAGE = %r{\Ahttps?://(?:img\.pawoo\.net|baraag\.net(?:/system(?:/cache)?)?)/media_attachments/files/((?:\d+/)+\d+)}
     NAMED_PROFILE = %r{#{HOST}/@(?<artist_name>\w+)}i
     ID_PROFILE = %r{#{HOST}/web/accounts/(?<account_id>\d+)}
 
@@ -35,6 +35,7 @@ module Sources::Strategies
     def file_host
       case site_name
       when "pawoo.net" then "img.pawoo.net"
+      when "baraag.net" then "baraag.net/system"
       else site_name
       end
     end

--- a/test/unit/sources/mastodon_test.rb
+++ b/test/unit/sources/mastodon_test.rb
@@ -101,14 +101,20 @@ module Sources
       setup do
         skip "Baraag keys not set" unless Danbooru.config.baraag_client_id
         @url = "https://baraag.net/@bardbot/105732813175612920"
-        @site = Sources::Strategies.find(@url)
+        @site1 = Sources::Strategies.find(@url)
+
+        @img = "https://baraag.net/system/media_attachments/files/105/803/948/862/719/091/original/54e1cb7ca33ec449.png"
+        @ref = "https://baraag.net/@Nakamura/105803949565505009"
+        @site2 = Sources::Strategies.find(@img, @ref)
       end
 
       should "work" do
-        assert_equal("https://baraag.net/@bardbot", @site.profile_url)
-        assert_equal(["https://baraag.net/system/media_attachments/files/105/732/803/241/495/700/original/556e1eb7f5ca610f.png"], @site.image_urls)
-        assert_equal("bardbot", @site.artist_name)
-        assert_equal("🍌", @site.dtext_artist_commentary_desc)
+        assert_equal("https://baraag.net/@bardbot", @site1.profile_url)
+        assert_equal(["https://baraag.net/system/media_attachments/files/105/732/803/241/495/700/original/556e1eb7f5ca610f.png"], @site1.image_urls)
+        assert_equal("bardbot", @site1.artist_name)
+        assert_equal("🍌", @site1.dtext_artist_commentary_desc)
+
+        assert_equal([@img], @site2.image_urls)
       end
     end
 


### PR DESCRIPTION
Fixes a bug for Baraag.net that caused the batch bookmarklet to always pick the first picture in multi-image posts.