### PR TITLE
Optimize Sources::Strategies.find()

### DIFF
--- a/app/logical/sources/strategies.rb
+++ b/app/logical/sources/strategies.rb
@@ -3,24 +3,24 @@ module Sources
     def self.all
       [
         Strategies::Pixiv,
-        Strategies::Fanbox,
-        Strategies::NicoSeiga,
         Strategies::Twitter,
+        Strategies::Tumblr,
+        Strategies::NicoSeiga,
         Strategies::Stash, # must come before DeviantArt
         Strategies::DeviantArt,
-        Strategies::Tumblr,
-        Strategies::ArtStation,
-        Strategies::Nijie,
-        Strategies::Mastodon,
         Strategies::Moebooru,
+        Strategies::Nijie,
+        Strategies::ArtStation,
         Strategies::HentaiFoundry,
+        Strategies::Fanbox,
+        Strategies::Mastodon,
         Strategies::Weibo,
         Strategies::Newgrounds
       ]
     end
 
     def self.find(url, referer = nil, default: Strategies::Null)
-      strategy = all.map { |strategy| strategy.new(url, referer) }.detect(&:match?)
+      strategy = all.lazy.map { |s| s.new(url, referer) }.detect(&:match?)
       strategy || default&.new(url, referer)
     end
 


### PR DESCRIPTION
Right now, whenever a source is evaluated, it goes through all the match functions in each strategy, even if the first strategy matches the url. 

Using [lazy.map](https://ruby-doc.org/core-2.7.0/Enumerator/Lazy.html) the function instead aborts the moment it finds a match.
Lazy enumerators are slightly slower if the match is at the end of the array, as the following tests report, so performance worsens for last two or three strategies and unmatched posts, but on danbooru Pixiv alone makes up [2.82M posts](https://danbooru.donmai.us/counts/posts?tags=pixiv%3Aany+status%3Aany), with another 550k from Twitter, so the performance gain is ultimately positive because the vast majority of posts is matched by the first few strategies (I reordered them so they match usage).

For the last year, for example, 532k out of 587k posts were from either pixiv or twitter.

A simple test:

```ruby
url = "https://www.pixiv.net/artworks/65425764"
start = Time.now
1000.times { Sources::Strategies.find(url) }
finish = Time.now

puts finish - start
```

For a pixiv url (top of the array):
Before: 0.66
After: 0.20

For a nijie url (middle of the array, close to 10k posts)
Before: 0.94
After: 0.76

For pawoo (third last) (varies a lot between runs, pretty much no gain)
Before: 1.04
After: 1.02

For a newgrounds url: 
Before: 1.14
After: 1.23

For unmatched urls such as a gelbooru link I got identical results to the newgrounds case.

Adding fictitious sources until the count of supported sites was twice as many as the current ones, for newgrounds the numbers became 2.4 vs 2.6 for before/after, while for pixiv it became 1.2 vs 0.2, so as the number of supported sites grows peformance will benefit more and more from this commit. (I say this mostly because I wrote or plan to write several branches for supporting sites such as naver, fc2 and lofter)