### PR TITLE
Mastodon: fix strategy raising an exception for direct links

### DIFF
--- a/app/logical/mastodon_api_client.rb
+++ b/app/logical/mastodon_api_client.rb
@@ -7,27 +7,31 @@ class MastodonApiClient
 
     return if access_token.blank?
 
-    begin
-      @json = JSON.parse(access_token.get("/api/v1/statuses/#{id}").body)
-    rescue StandardError
+    if id.blank?
       @json = {}
+    else
+      begin
+        @json = JSON.parse(access_token.get("/api/v1/statuses/#{id}").body)
+      rescue StandardError
+        @json = {}
+      end
     end
   end
 
   def profile_url
-    json.dig("account", "url")
+    json&.dig("account", "url")
   end
 
   def account_name
-    json.dig("account", "username")
+    json&.dig("account", "username")
   end
 
   def display_name
-    json.dig("account", "display_name")
+    json&.dig("account", "display_name")
   end
 
   def account_id
-    json.dig("account", "id")
+    json&.dig("account", "id")
   end
 
   def image_url
@@ -35,17 +39,17 @@ class MastodonApiClient
   end
 
   def image_urls
-    json["media_attachments"].to_a.map {|x| x["url"]}
+    json&.dig("media_attachments").to_a.map {|x| x["url"]}
   end
 
   def tags
-    json["tags"].to_a.map { |tag| [tag["name"], tag["url"]] }
+    json&.dig("tags").to_a.map { |tag| [tag["name"], tag["url"]] }
   end
 
   def commentary
     commentary = ""
     commentary << "<p>#{json["spoiler_text"]}</p>" if json["spoiler_text"].present?
-    commentary << json["content"]
+    commentary << json["content"] if json["content"].present?
     commentary
   end
 

--- a/app/logical/sources/strategies/mastodon.rb
+++ b/app/logical/sources/strategies/mastodon.rb
@@ -124,7 +124,6 @@ module Sources::Strategies
     end
 
     def api_response
-      return {} if status_id_from_url.blank?
       MastodonApiClient.new(site_name, status_id_from_url)
     end
     memoize :api_response

--- a/test/unit/sources/mastodon_test.rb
+++ b/test/unit/sources/mastodon_test.rb
@@ -143,5 +143,20 @@ module Sources
         assert_equal(bad_source3, Sources::Strategies.normalize_source(bad_source3))
       end
     end
+
+    context "A deleted or invalid source" do
+      setup do
+        @site1 = Sources::Strategies.find("https://pawoo.net/@nantokakun/105643037682139899") # 404
+        @site2 = Sources::Strategies.find("https://img.pawoo.net/media_attachments/files/001/297/997/original/c4272a09570757c2.png")
+
+        assert_nothing_raised { @site1.to_h }
+        assert_nothing_raised { @site2.to_h }
+      end
+
+      should "still find the artist" do
+        @artist = FactoryBot.create(:artist, name: "nantokakun", url_string: "https://pawoo.net/@nantokakun")
+        assert_equal([@artist], @site1.artists)
+      end
+    end
   end
 end


### PR DESCRIPTION
This bug has been present for a long time, but it was only reported recently. It would only become visible to end users if you tried to make an artist page directly after uploading a post with only the direct link, otherwise it would fail silently.

Also updates the tests and catches an exception for certain 404 urls.