### PR TITLE
BURs: don't check for category when implicating empty tags

### DIFF
--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -99,7 +99,10 @@ class TagImplication < TagRelationship
       end
     end
 
+    # Require tags to have the same category. Doesn't apply when either tag is empty,
+    # because they could have been populated from a previous update script.
     def tag_categories_are_compatible
+      return if antecedent_tag.empty? || consequent_tag.empty?
       if antecedent_tag.category != consequent_tag.category
         errors.add(:base, "Can't imply a #{antecedent_tag.category_name.downcase} tag to a #{consequent_tag.category_name.downcase} tag")
       end


### PR DESCRIPTION
The default category for empty tags is general, so implications are otherwise always going to be rejected when the tag is created via BUR beforehand.

Ref: https://danbooru.donmai.us/forum_topics/18013?page=2#forum_post_182107