### PR TITLE
User profiles: use name instead of id in links to post edits

### DIFF
--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -82,7 +82,7 @@ class UserPresenter
   end
 
   def post_version_count(template)
-    template.link_to(user.post_update_count, template.post_versions_path(:search => {:updater_id => user.id}))
+    template.link_to(user.post_update_count, template.post_versions_path(:search => {:updater_name => user.name}))
   end
 
   def note_version_count(template)

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -112,7 +112,7 @@
         <td>
           <%= presenter.upload_count(self) %>
           <% if presenter.has_uploads? %>
-            (<%= link_to "tag changes report", post_versions_path(search: { updater_id: user.id, version: 1 }, type: "current") %>)
+            (<%= link_to "tag changes report", post_versions_path(search: { updater_name: user.name, version: 1 }, type: "current") %>)
           <% end %>
           <% if CurrentUser.is_moderator? %>
             [<%= link_to "sample", posts_path(:tags => "user:#{user.name} order:random limit:#{PostSets::Post::MAX_PER_PAGE}") %>]


### PR DESCRIPTION
It's a real pain when you're looking at a user and are trying to see if they're doing something bad or want to view their edits in detail for certain tags, but you have to navigate back to the expanded search form or add the user name manually again because the URL you get from their profile uses the ID, but the field in the search form uses the name, so it's not automatically populated.
![image](https://user-images.githubusercontent.com/12946050/110881061-faaea700-82df-11eb-8a30-c927e224b65f.png)

This makes it so that when you click on an user's edits from their profile, you get the name properly autofilled.