### PR TITLE
Pixiv: don't add auto-generated usernames to the other names field

### DIFF
--- a/app/logical/sources/strategies/pixiv.rb
+++ b/app/logical/sources/strategies/pixiv.rb
@@ -162,7 +162,9 @@ module Sources
       end
 
       def other_names
-        [artist_name, moniker].compact.uniq
+        other_names = [artist_name]
+        other_names << moniker unless moniker&.starts_with?("user_")
+        other_names.compact.uniq
       end
 
       def artist_commentary_title

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -303,6 +303,11 @@ module Sources
           assert_includes(source.profile_urls, "https://www.pixiv.net/users/696859")
           assert_includes(source.profile_urls, "https://www.pixiv.net/stacc/uroobnad")
         end
+
+        should "not add pixiv-generated 'user_' usernames to the other names field" do
+          source = get_source("https://www.pixiv.net/en/artworks/88487025")
+          assert_equal(["éé"], source.other_names)
+        end
       end
 
       context "parsing illust ids" do


### PR DESCRIPTION
Fixes #4743.