### PR TITLE
Tag Aliases: automatically remove redundant implications

### DIFF
--- a/test/unit/tag_alias_test.rb
+++ b/test/unit/tag_alias_test.rb
@@ -286,5 +286,12 @@ class TagAliasTest < ActiveSupport::TestCase
       assert_equal(4, tag1.reload.category)
       assert_equal(3, tag2.reload.category)
     end
+
+    should "automatically remove a redundant implication" do
+      ti = create(:tag_implication, antecedent_name: "new_asuka", consequent_name: "asuka", status: "active")
+      create(:tag_alias, antecedent_name: "new_asuka", consequent_name: "asuka", status: "active")
+
+      assert_equal("deleted", ti.reload.status)
+    end
   end
 end


### PR DESCRIPTION
Ref: https://danbooru.donmai.us/forum_topics/18277, https://danbooru.donmai.us/forum_topics/18278

When aliasing a to b, remove an eventual implication from a to b as well.

Not sure if there's a simple way to get both implication directions in a single line, I couldn't find any way without having to use raw SQL.