### PR TITLE
Add embed wiki to delete dialog

### DIFF
--- a/app/views/posts/partials/show/_delete_dialog.html.erb
+++ b/app/views/posts/partials/show/_delete_dialog.html.erb
@@ -1,4 +1,6 @@
 <div class="delete-post-dialog-body">
+  <%= embed_wiki("help:delete_notice") %>
+
   <%= edit_form_for(post, method: :delete, remote: true) do |f| %>
     <input type="hidden" name="commit" value="Delete">
     <%= f.input :reason, as: :dtext, inline: true, input_html: { value: "" } %>


### PR DESCRIPTION
I've noticed that several approvers (mods included) don't realize that deleting a pending posts takes 5 uploads slots, and what's worse some don't realize that they should not delete posts just because they're status:banned.

Just like the flag and appeal notice, having an embed wiki in this dialog could help preventing these mistakes.