### PR TITLE
Nijie: get correct image when using batch bookmarklet

### DIFF
--- a/app/logical/sources/strategies/nijie.rb
+++ b/app/logical/sources/strategies/nijie.rb
@@ -86,6 +86,7 @@ module Sources
 
       def image_url
         return to_full_image_url(url) if url =~ IMAGE_URL || url =~ DOJIN_URL
+        return url if url =~ IMAGE_BASE_URL
         image_urls.first
       end
 

--- a/test/unit/sources/nijie_test.rb
+++ b/test/unit/sources/nijie_test.rb
@@ -362,5 +362,15 @@ module Sources
         assert_equal(bad_source3, Sources::Strategies.normalize_source(bad_source3))
       end
     end
+
+    context "an unsupported image url" do
+      should "not break the bookmarklet" do
+        image_url = "https://pic.nijie.net/01/nijie_picture/diff/main/201207181053373205_0.jpg"
+        ref = "https://nijie.info/view_popup.php?id=18858&#diff_1"
+        source = Sources::Strategies.find(image_url, ref)
+
+        assert_equal(image_url, source.image_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
Reported on discord. We weren't correctly falling back to the generic image domain for unsupported pictures.