### PR TITLE
Reorder feedback type dropdown search

### DIFF
--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -6,7 +6,7 @@
       <%= f.input :user_name, input_html: { value: params.dig(:search, :user_name), "data-autocomplete": "user" } %>
       <%= f.input :creator_name, input_html: { value: params.dig(:search, :creator_name), "data-autocomplete": "user" } %>
       <%= f.input :body_matches, label: "Message", input_html: { value: params.dig(:search, :body_matches) } %>
-      <%= f.input :category, collection: %w[positive negative neutral], include_blank: true, selected: params.dig(:search, :category) %>
+      <%= f.input :category, collection: %w[positive neutral negative], include_blank: true, selected: params.dig(:search, :category) %>
       <% if policy(UserFeedback).can_view_deleted? %>
         <%= f.input :is_deleted, label: "Deleted", collection: %w[Yes No], include_blank: true, selected: params.dig(:search, :is_deleted) %>
       <% end %>


### PR DESCRIPTION
This is a minor cherrypick, but it always annoys me.

On the [feedback creation page](https://danbooru.donmai.us/user_feedbacks/new) they're already ordered correctly.