### PR TITLE
Add parent navbar

### DIFF
--- a/app/components/post_navbar_component.rb
+++ b/app/components/post_navbar_component.rb
@@ -36,7 +36,7 @@ class PostNavbarComponent < ApplicationComponent
   end
 
   def has_search_navbar?
-    !query.has_metatag?(:order, :ordfav, :ordpool) && pool_id.blank? && favgroup_id.blank? && parent_relationships.blank?
+    !query.has_metatag?(:order, :ordfav, :ordpool) && pool_id.blank? && favgroup_id.blank? && parent_id.blank?
   end
 
   def pool_id

--- a/app/components/post_navbar_component.rb
+++ b/app/components/post_navbar_component.rb
@@ -10,18 +10,14 @@ class PostNavbarComponent < ApplicationComponent
   end
 
   def render?
-    has_search_navbar? || pools.any? || favgroups.any?
+    has_search_navbar? || pools.any? || favgroups.any? || parent_relationships.any?
   end
 
   def parent_relationships
     include_deleted = post.is_deleted? || (post.parent_id.present? && post.parent.is_deleted?) || CurrentUser.user.show_deleted_children?
     relationship_groups = []
     if post.parent.present?
-      @sibling_posts = post.parent.present? ? post.parent.children : Post.none
-      @sibling_posts = @sibling_posts.undeleted unless include_deleted
-      array_when_child = @sibling_posts.to_a
-      # @sibling_posts.to_i
-      array_when_child.unshift(post.parent)
+      array_when_child = (include_deleted ? post.parent.children : post.parent.children.undeleted).to_a.unshift(post.parent)
       if array_when_child.length > 0
         relationship_groups.push(array_when_child)
       end
@@ -53,7 +49,7 @@ class PostNavbarComponent < ApplicationComponent
   end
 
   def has_search_navbar?
-    !query.has_metatag?(:order, :ordfav, :ordpool) && pool_id.blank? && favgroup_id.blank?
+    !query.has_metatag?(:order, :ordfav, :ordpool) && pool_id.blank? && favgroup_id.blank? && parent_relationships.blank?
   end
 
   def pool_id

--- a/app/components/post_navbar_component.rb
+++ b/app/components/post_navbar_component.rb
@@ -16,21 +16,8 @@ class PostNavbarComponent < ApplicationComponent
   def parent_relationships
     include_deleted = post.is_deleted? || (post.parent_id.present? && post.parent.is_deleted?) || CurrentUser.user.show_deleted_children?
     relationship_groups = []
-    if post.parent.present?
-      array_when_child = (include_deleted ? post.parent.children : post.parent.children.undeleted).to_a.unshift(post.parent)
-      if array_when_child.length > 0
-        relationship_groups.push(array_when_child)
-      end
-    end
-    if post.has_visible_children?
-      @child_posts = post.children
-      @child_posts = @child_posts.undeleted unless include_deleted
-      array_when_parent = @child_posts.to_a
-      array_when_parent.unshift(post)
-      if array_when_parent.length > 0
-        relationship_groups.push(array_when_parent)
-      end
-    end
+    relationship_groups.push((include_deleted ? post.parent.children : post.parent.children.undeleted).to_a.unshift(post.parent)) if post.parent.present?
+    relationship_groups.push((include_deleted ? post.children : post.children.undeleted).to_a.unshift(post)) if post.has_visible_children?
     @parent_relationships ||= relationship_groups
   end
 

--- a/app/components/post_navbar_component.rb
+++ b/app/components/post_navbar_component.rb
@@ -13,6 +13,25 @@ class PostNavbarComponent < ApplicationComponent
     has_search_navbar? || pools.any? || favgroups.any?
   end
 
+  def parent_relationships
+    relationship_groups = []
+    if post.parent.present?
+      array_when_child = @sibling_posts.to_a
+      array_when_child.push(post.parent)
+      if array_when_child.length > 0
+        relationship_groups.push(array_when_child)
+      end
+    end
+    if post.has_visible_children?
+      array_when_parent = @child_posts.to_a
+      array_when_parent.push(post)
+      if array_when_parent.length > 0
+        relationship_groups.push(array_when_parent)
+      end
+    end
+    @parent_relationships ||= relationship_groups
+  end
+
   def pools
     @pools ||= post.pools.undeleted.sort_by do |pool|
       [pool.id == pool_id ? 0 : 1, pool.is_series? ? 0 : 1, pool.name]
@@ -37,6 +56,10 @@ class PostNavbarComponent < ApplicationComponent
 
   def favgroup_id
     @favgroup_id ||= query.find_metatag(:favgroup, :ordfavgroup)&.to_i
+  end
+
+  def parent_id
+    @parent_id ||= query.find_metatag(:parent)&.to_i
   end
 
   def query

--- a/app/components/post_navbar_component.rb
+++ b/app/components/post_navbar_component.rb
@@ -20,7 +20,7 @@ class PostNavbarComponent < ApplicationComponent
       @sibling_posts = post.parent.present? ? post.parent.children : Post.none
       @sibling_posts = @sibling_posts.undeleted unless include_deleted
       array_when_child = @sibling_posts.to_a
-      @sibling_posts.to_i
+      # @sibling_posts.to_i
       array_when_child.unshift(post.parent)
       if array_when_child.length > 0
         relationship_groups.push(array_when_child)

--- a/app/components/post_navbar_component.rb
+++ b/app/components/post_navbar_component.rb
@@ -14,17 +14,23 @@ class PostNavbarComponent < ApplicationComponent
   end
 
   def parent_relationships
+    include_deleted = post.is_deleted? || (post.parent_id.present? && post.parent.is_deleted?) || CurrentUser.user.show_deleted_children?
     relationship_groups = []
     if post.parent.present?
+      @sibling_posts = post.parent.present? ? post.parent.children : Post.none
+      @sibling_posts = @sibling_posts.undeleted unless include_deleted
       array_when_child = @sibling_posts.to_a
-      array_when_child.push(post.parent)
+      @sibling_posts.to_i
+      array_when_child.unshift(post.parent)
       if array_when_child.length > 0
         relationship_groups.push(array_when_child)
       end
     end
     if post.has_visible_children?
+      @child_posts = post.children
+      @child_posts = @child_posts.undeleted unless include_deleted
       array_when_parent = @child_posts.to_a
-      array_when_parent.push(post)
+      array_when_parent.unshift(post)
       if array_when_parent.length > 0
         relationship_groups.push(array_when_parent)
       end

--- a/app/components/post_navbar_component/post_navbar_component.html.erb
+++ b/app/components/post_navbar_component/post_navbar_component.html.erb
@@ -72,18 +72,10 @@
     <% parent_post_id = parent_relationship.first.id %>
     <% last_post_id = parent_relationship.last.id %>
     <% this_index = parent_relationship.find_index { |relationship_element| relationship_element[:id] == post.id } || 0 %>
-    <% if post.id != parent_relationship.first.id %>
-      <% previous_post_id = parent_relationship[this_index - 1].id %>
-    <% else %>
-      <% previous_post_id = nil %>
-    <% end %>
-    <% if post.id != parent_relationship.last.id %>
-      <% next_post_id = parent_relationship[this_index + 1].id %>
-    <% else %>
-      <% next_post_id = nil %>
-    <% end %>
+    <% previous_post_id = (post.id != parent_relationship.first.id) ? parent_relationship[this_index - 1].id : nil %>
+    <% next_post_id = (post.id != parent_relationship.last.id) ? parent_relationship[this_index + 1].id : nil %>
 
-    <%= tag.li class: "favgroup-navbar", "data-selected": selected do %>
+    <%= tag.li class: "parent-navbar", "data-selected": selected do %>
       <span class="first">
         <%= link_to_unless parent_post_id == post.id, "«", post_path(parent_post_id, q: "parent:#{parent_post_id}"), rel: "nofollow" %>
       </span>
@@ -92,7 +84,7 @@
         <%= link_to_if previous_post_id, "‹ prev", post_path(previous_post_id.to_i, q: "parent:#{parent_post_id}"), rel: ["nofollow", ("prev" if selected)], "data-shortcut": ("a" if selected) %>
       </span>
 
-      <span class="favgroup-name">
+      <span class="parent-name">
         <%= link_to "Parent: #{parent_post_id}", parent_relationship.first %>
       </span>
 

--- a/app/components/post_navbar_component/post_navbar_component.html.erb
+++ b/app/components/post_navbar_component/post_navbar_component.html.erb
@@ -69,30 +69,39 @@
 
   <% parent_relationships.each do |parent_relationship| %>
     <% selected = parent_id == parent_relationship.first.id %>
-    <% first_post_id = parent_relationship.first %>
-    <% last_post_id = parent_relationship.last %>
-    <% previous_post_id = parent_relationship.previous_post_id(post.id) %>
-    <% next_post_id = parent_relationship.next_post_id(post.id) %>
+    <% parent_post_id = parent_relationship.first.id %>
+    <% last_post_id = parent_relationship.last.id %>
+    <% this_index = parent_relationship.find_index(post) || 0 %>
+    <% if parent_relationship.include? post && post != parent_relationship.first %>
+      <% previous_post_id = parent_relationship[this_index - 1].id %>
+    <% else %>
+      <% previous_post_id = nil %>
+    <% end %>
+    <% if parent_relationship.include? post && post != parent_relationship.last %>
+      <% next_post_id = parent_relationship[this_index + 1].id %>
+    <% else %>
+      <% next_post_id = nil %>
+    <% end %>
 
     <%= tag.li class: "favgroup-navbar", "data-selected": selected do %>
       <span class="first">
-        <%= link_to_unless first_post_id == post.id, "«", post_path(first_post_id, q: "parent:#{parent_relationship.first}"), rel: "nofollow" %>
+        <%= link_to_unless parent_post_id == post.id, "«", post_path(parent_post_id, q: "parent:#{parent_post_id}"), rel: "nofollow" %>
       </span>
 
       <span class="prev">
-        <%= link_to_if previous_post_id, "‹ prev", post_path(previous_post_id.to_i, q: "parent:#{parent_relationship.first}"), rel: ["nofollow", ("prev" if selected)], "data-shortcut": ("a" if selected) %>
+        <%= link_to_if previous_post_id, "‹ prev", post_path(previous_post_id.to_i, q: "parent:#{parent_post_id}"), rel: ["nofollow", ("prev" if selected)], "data-shortcut": ("a" if selected) %>
       </span>
 
       <span class="favgroup-name">
-        <%= link_to "Parent: #{parent_relationship.first}", parent_relationship.first %>
+        <%= link_to "Parent: #{parent_post_id}", parent_relationship.first %>
       </span>
 
       <span class="next">
-        <%= link_to_if next_post_id, "next ›", post_path(next_post_id.to_i, q: "parent:#{parent_relationship.first}"), rel: ["nofollow", ("next" if selected)], "data-shortcut": ("d" if selected) %>
+        <%= link_to_if next_post_id, "next ›", post_path(next_post_id.to_i, q: "parent:#{parent_post_id}"), rel: ["nofollow", ("next" if selected)], "data-shortcut": ("d" if selected) %>
       </span>
 
       <span class="last">
-        <%= link_to_unless last_post_id == post.id, "»", post_path(last_post_id, q: "parent:#{parent_relationship.first}"), rel: "nofollow" %>
+        <%= link_to_unless last_post_id == post.id, "»", post_path(last_post_id, q: "parent:#{parent_post_id}"), rel: "nofollow" %>
       </span>
     <% end %>
   <% end %>

--- a/app/components/post_navbar_component/post_navbar_component.html.erb
+++ b/app/components/post_navbar_component/post_navbar_component.html.erb
@@ -71,13 +71,13 @@
     <% selected = parent_id == parent_relationship.first.id %>
     <% parent_post_id = parent_relationship.first.id %>
     <% last_post_id = parent_relationship.last.id %>
-    <% this_index = parent_relationship.find_index(post) || 0 %>
-    <% if parent_relationship.include? post && post != parent_relationship.first %>
+    <% this_index = parent_relationship.find_index { |relationship_element| relationship_element[:id] == post.id } || 0 %>
+    <% if post.id != parent_relationship.first.id %>
       <% previous_post_id = parent_relationship[this_index - 1].id %>
     <% else %>
       <% previous_post_id = nil %>
     <% end %>
-    <% if parent_relationship.include? post && post != parent_relationship.last %>
+    <% if post.id != parent_relationship.last.id %>
       <% next_post_id = parent_relationship[this_index + 1].id %>
     <% else %>
       <% next_post_id = nil %>

--- a/app/components/post_navbar_component/post_navbar_component.html.erb
+++ b/app/components/post_navbar_component/post_navbar_component.html.erb
@@ -66,4 +66,34 @@
       </span>
     <% end %>
   <% end %>
+
+  <% parent_relationships.each do |parent_relationship| %>
+    <% selected = parent_id == parent_relationship.first.id %>
+    <% first_post_id = parent_relationship.first %>
+    <% last_post_id = parent_relationship.last %>
+    <% previous_post_id = parent_relationship.previous_post_id(post.id) %>
+    <% next_post_id = parent_relationship.next_post_id(post.id) %>
+
+    <%= tag.li class: "favgroup-navbar", "data-selected": selected do %>
+      <span class="first">
+        <%= link_to_unless first_post_id == post.id, "«", post_path(first_post_id, q: "parent:#{parent_relationship.first}"), rel: "nofollow" %>
+      </span>
+
+      <span class="prev">
+        <%= link_to_if previous_post_id, "‹ prev", post_path(previous_post_id.to_i, q: "parent:#{parent_relationship.first}"), rel: ["nofollow", ("prev" if selected)], "data-shortcut": ("a" if selected) %>
+      </span>
+
+      <span class="favgroup-name">
+        <%= link_to "Parent: #{parent_relationship.first}", parent_relationship.first %>
+      </span>
+
+      <span class="next">
+        <%= link_to_if next_post_id, "next ›", post_path(next_post_id.to_i, q: "parent:#{parent_relationship.first}"), rel: ["nofollow", ("next" if selected)], "data-shortcut": ("d" if selected) %>
+      </span>
+
+      <span class="last">
+        <%= link_to_unless last_post_id == post.id, "»", post_path(last_post_id, q: "parent:#{parent_relationship.first}"), rel: "nofollow" %>
+      </span>
+    <% end %>
+  <% end %>
 </ul>

--- a/app/components/post_navbar_component/post_navbar_component.scss
+++ b/app/components/post_navbar_component/post_navbar_component.scss
@@ -20,7 +20,7 @@
       margin: 0 1.75em;
     }
 
-    .pool-name, .favgroup-name, .search-name {
+    .pool-name, .favgroup-name, .parent-name, .search-name {
       flex: 1;
       text-align: center;
       overflow: hidden;


### PR DESCRIPTION
Fixes #4771 by creating a new navbar that tracks the parent post qualifiers similarly to how favgroups are tracked by favgroup IDs.