### PR TITLE
Fix note body size

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -533,7 +533,7 @@ class Note {
 
       this.display_text(response.body);
       this.initialize();
-      this.$note_body.show();
+      this.$note_body.css('display', 'flex');
     }
 
     on_mouseover(e) {

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -513,7 +513,7 @@ class Note {
       text = text.replace(/<tn>/g, '<p class="tn">');
       text = text.replace(/<\/tn>/g, '</p>');
       text = text.replace(/\n/g, '<br>');
-      if (!text.match(/^\s*<.*>.*$/g)) {
+      if (!text.match(/^\s*<.*>.*$/g) || text.match(/^\s*<.*>.*<\/.*>\s*.+/g)) {
           text = "<span>" + text + "</span>";
       }
 

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -513,7 +513,7 @@ class Note {
       text = text.replace(/<tn>/g, '<p class="tn">');
       text = text.replace(/<\/tn>/g, '</p>');
       text = text.replace(/\n/g, '<br>');
-      if (!text.match(/^\s*<.*>.*$/g) || text.match(/^\s*<.*>.*<\/.*>\s*.+/g)) {
+      if (!text.match(/^\s*<.*>.*$/g) || text.match(/^\s*<.*>.*<\/.*>\s*[^\s]+/g)) {
           text = "<span>" + text + "</span>";
       }
 

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -513,6 +513,9 @@ class Note {
       text = text.replace(/<tn>/g, '<p class="tn">');
       text = text.replace(/<\/tn>/g, '</p>');
       text = text.replace(/\n/g, '<br>');
+      if (!text.match(/^<.*>.*$/g)) {
+          text = "<span>" + text + "</span>";
+      }
 
       if (this.note.embed) {
         this.note.box.$inner_border.html(text);

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -427,7 +427,7 @@ class Note {
         this.resized = true;
       }
 
-      this.$note_body.show();
+      this.$note_body.css('display', 'flex');
       this.initialize();
     }
 

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -513,7 +513,7 @@ class Note {
       text = text.replace(/<tn>/g, '<p class="tn">');
       text = text.replace(/<\/tn>/g, '</p>');
       text = text.replace(/\n/g, '<br>');
-      if (!text.match(/^<.*>.*$/g)) {
+      if (!text.match(/^\s*<.*>.*$/g)) {
           text = "<span>" + text + "</span>";
       }
 

--- a/app/javascript/src/styles/specific/notes.scss.erb
+++ b/app/javascript/src/styles/specific/notes.scss.erb
@@ -60,6 +60,7 @@
     .tn {
       font-size: 0.8em;
       color: var(--note-tn-color);
+	  margin-bottom: 0;
     }
 
     ruby {

--- a/app/javascript/src/styles/specific/notes.scss.erb
+++ b/app/javascript/src/styles/specific/notes.scss.erb
@@ -10,6 +10,7 @@
   div.note-body {
     display: none;
     position: absolute;
+	justify-content: center;
     font-size: 14px;
     border: 1px solid var(--note-body-border-color);
     background: var(--note-body-background);

--- a/app/javascript/src/styles/specific/notes.scss.erb
+++ b/app/javascript/src/styles/specific/notes.scss.erb
@@ -10,7 +10,7 @@
   div.note-body {
     display: none;
     position: absolute;
-	justify-content: center;
+    justify-content: center;
     font-size: 14px;
     border: 1px solid var(--note-body-border-color);
     background: var(--note-body-background);
@@ -61,7 +61,7 @@
     .tn {
       font-size: 0.8em;
       color: var(--note-tn-color);
-	  margin-bottom: 0;
+      margin-bottom: 0;
     }
 
     ruby {


### PR DESCRIPTION
Fixes #1640

I know this is a low priority bug, but it is one that is easy to solve with a method I happened to discover. I think judging this PR just by looking at the diff without any explanation is enough, but I'm presenting a full documentation.

## Main change

For some reason, browsers calculate smaller text elements as tall as the normal line height but display them in the correct size. You can check this in the browsers' devtools, where you'll find empty space that even the browser has no idea where it came from.

However, using a flexbox as the parent completely gets rid of this problem:

```diff
 .note-body {
-    display: block;
+    display: flex;
 }
```

Complication: This introduced a problem that HTML tags would behave like flex childs (flex children?) and would extrude in a single line and get jammed. Leaving it like this would be unacceptable.

## Retaining the current style

### Make the children behave as before

If the note is not already enclosed in a tag, like the default `<em>Click to edit</em>`, the text is wrapped into a `<span>` tag. 

The regex `/^\s*<.*>.*$/g` checks if it starts with a tag (because people sometimes leave out the closing tag) and if yes, it also matches `/^\s*<.*>.*<\/.*>\s*[^\s]+/g` to check for early tag closure, like a bold starting word.

This whole check is only needed because the original problem of `<small>`'s visual–computational size mismatch appears again if it is wrapped in anything other than a `flex` or an `inline`.

### <tn>Translation notes

If  `<p>` elements are wrapped in a flexbox, they have a `margin-bottom` by default that leaves a very distracting gap of nothingness in translation notes. For this reason, I had to touch the `.tn` class in the notes Sass.

### Pixel perfection

In [notes.js](https://github.com/danbooru/danbooru/blob/master/app/javascript/src/javascripts/notes.js), the note width is just some pixels wider than needed. For this, I have abused the flexbox's `justify-content: center;` that balances the empty space on the left side and the right side.

## Fancy pants

I have seen very fancy translation notes on Danbooru that utilize more styling in the tags than actual displayed text. Changing the type of the parent element might change how they look, but if the tags are properly made, an extra parent should not have any impact. If someone knows of highly advanced notes, it would be best to try them out beforehand. *(Put down the post ID in a comment if you don't have a testing environment.)*

## Testing

I really wanted to keep notes how they look, so I made sure to test it with everything I had on hand.

* PC
  * Chrome 91.0.4472.106
  * Edge 91.0.864.48
  * Firefox 89.0
  * Opera 77.0.4054.80
* Android
  * Chrome 91.0.4472.101
  * Firefox 89.1.1
  * DuckDuckGo 5.88.0

All of these browsers render the notes correctly. Well, Internet Explorer doesn't, but notes are not displayed in IE by default, so I consider it a pass.