### PR TITLE
Fix text in batch bookmarklet

### DIFF
--- a/app/views/uploads/batch.html.erb
+++ b/app/views/uploads/batch.html.erb
@@ -30,7 +30,7 @@
           </div>
         <% end %>
 
-        <p><%= link_to "Open all links in new windows", "#", :id => "link" %></p>
+        <p><%= link_to "Open all links in new tabs", "#", :id => "link" %></p>
       </section>
     <% end %>
   </div>


### PR DESCRIPTION
Modern browsers open links in tabs, not windows