### PR TITLE
Search: fix unmatched wildcards

### DIFF
--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -82,11 +82,15 @@ class PostQueryBuilder
     negated_tags = negated_tags.map(&:name)
     optional_tags = optional_tags.map(&:name)
     required_tags = required_tags.map(&:name)
-
-    negated_tags += negated_wildcard_tags.flat_map { |tag| Tag.wildcard_matches(tag.name).limit(MAX_WILDCARD_TAGS).pluck(:name) }
-    optional_tags += optional_wildcard_tags.flat_map { |tag| Tag.wildcard_matches(tag.name).limit(MAX_WILDCARD_TAGS).pluck(:name) }
-    optional_tags += required_wildcard_tags.flat_map { |tag| Tag.wildcard_matches(tag.name).limit(MAX_WILDCARD_TAGS).pluck(:name) }
-
+    
+    matched_negated_wildcard_tags = negated_wildcard_tags.flat_map { |tag| Tag.wildcard_matches(tag.name).limit(MAX_WILDCARD_TAGS).pluck(:name) }
+    matched_optional_wildcard_tags = optional_wildcard_tags.flat_map { |tag| Tag.wildcard_matches(tag.name).limit(MAX_WILDCARD_TAGS).pluck(:name) }
+    matched_required_wildcard_tags = required_wildcard_tags.flat_map { |tag| Tag.wildcard_matches(tag.name).limit(MAX_WILDCARD_TAGS).pluck(:name) }
+    
+    negated_tags += (matched_negated_wildcard_tags.empty? && !negated_wildcard_tags.empty?) ? negated_wildcard_tags.map(&:name) : matched_negated_wildcard_tags
+    optional_tags += (matched_optional_wildcard_tags.empty? && !optional_wildcard_tags.empty?) ? optional_wildcard_tags.map(&:name) : matched_optional_wildcard_tags
+    optional_tags += (matched_required_wildcard_tags.empty? && !required_wildcard_tags.empty?) ? required_wildcard_tags.map(&:name) : matched_required_wildcard_tags
+    
     tsquery << "!(#{negated_tags.sort.uniq.map(&:to_escaped_for_tsquery).join(" | ")})" if negated_tags.present?
     tsquery << "(#{optional_tags.sort.uniq.map(&:to_escaped_for_tsquery).join(" | ")})" if optional_tags.present?
     tsquery << "(#{required_tags.sort.uniq.map(&:to_escaped_for_tsquery).join(" & ")})" if required_tags.present?


### PR DESCRIPTION
Fixes #4435 by using the wildcard itself in queries where it would not have matched anything.

I am not familiar with Ruby, so this may need some refactoring. If so, please lend me a helping hand.

## Behavior before

If wildcards did not match anything, they were completely ignored. If a search was a wildcard search and it did not match anything, it was like having an empty search box which then returned everything...

| User input | Real query | Result |
| :--- | :--- | :--- |
| \*non-existent\* |  | **Posts of the index page** |
| soranamae \*non-existent\* | soranamae | **Posts of soranamae** |
| serval_\* | ~serval_girl ~serval_print ~serval_tail | *Posts of serval_\** |
| takom serval_\* | takom ~serval_girl ~serval_print ~serval_tail | *Posts of serval_\* by takom* |

## Behavior after

Wildcards add their wildcard form to the search if they are not matched. Wildcard forms cannot be present in the system, which will inevitably lead to an empty search result.

| User input | Real query | Result |
| :--- | :--- | :--- |
| \*non-existent\* | \*non-existent\* | **Nobody here but us chickens!** |
| soranamae \*non-existent\* | soranamae \*non-existent\* | **Nobody here but us chickens!** |
| serval_\* | ~serval_girl ~serval_print ~serval_tail | *Posts of serval_\** |
| takom serval_\* | takom ~serval_girl ~serval_print ~serval_tail | *Posts of serval_\* by takom* |

*Note: Matched examples are cut down to have readable tables. Important behavior change marked by* ***bold*** *text.*