### PR TITLE
Upload page: disallow swf uploads in javascript too

### DIFF
--- a/app/javascript/src/javascripts/uploads.js.erb
+++ b/app/javascript/src/javascripts/uploads.js.erb
@@ -197,7 +197,7 @@ Upload.initialize_dropzone = function() {
     maxFilesize: Upload.MAX_FILE_SIZE,
     maxThumbnailFilesize: Upload.MAX_FILE_SIZE,
     timeout: 0,
-    acceptedFiles: "image/jpeg,image/png,image/gif,video/mp4,video/webm,.swf",
+    acceptedFiles: "image/jpeg,image/png,image/gif,video/mp4,video/webm",
     previewTemplate: $("#dropzone-preview-template").html(),
     init: function() {
       $(".fallback").hide();


### PR DESCRIPTION
Reported on discord. Right now you can still add flash files to the upload form (though their upload will fail at the processing stage, obviously). 