### PR TITLE
Posts sidebar: add link to tag discussions in forums

### DIFF
--- a/app/views/posts/partials/index/_related.html.erb
+++ b/app/views/posts/partials/index/_related.html.erb
@@ -13,6 +13,7 @@
     <li><%= link_to "Random", random_posts_path(tags: params[:tags]), id: "random-post", "data-shortcut": "r", rel: "nofollow" %></li>
     <% if post_set.normalized_query.has_single_tag? %>
       <li><%= link_to "History", post_versions_path(search: { changed_tags: post_set.normalized_query.tags.first.name }), rel: "nofollow" %></li>
+      <li><%= link_to "Discussions", forum_posts_path(search: { linked_to: post_set.normalized_query.tags.first.name }), rel: "nofollow" %></li>
     <% end %>
     <li><%= link_to "Count", posts_counts_path(tags: params[:tags]), rel: "nofollow" %></li>
   </ul>


### PR DESCRIPTION
Just like it's done in wikis. I often find myself in need of this link when browsing posts.
![image](https://user-images.githubusercontent.com/12946050/122781141-d0da2880-d2af-11eb-97d2-541cae035531.png)
