### PR TITLE
Upload page: show artist tag if it exists even if artist_name is empty in source

### DIFF
--- a/app/components/source_data_component/source_data_component.html.erb
+++ b/app/components/source_data_component/source_data_component.html.erb
@@ -5,20 +5,7 @@
   <% if @source.present? %>
     <table class="source-data-content mt-2">
       <tbody>
-        <% if @source.artist_name.blank? %>
-          <tr>
-            <th>Artist</th>
-            <td><em>None</em></td>
-          </tr>
-        <% elsif @source.artists.empty? %>
-          <tr>
-            <th>Artist</th>
-            <td>
-              <%= external_link_to @source.profile_url, @source.artist_name %>
-              (<%= link_to "Create new artist", new_artist_path(artist: { source: @source.canonical_url }) %>)
-            </td>
-          </tr>
-        <% else %>
+        <% if @source.artists.present? %>
           <% @source.artists.each do |artist| %>
             <tr>
               <th>Artist</th>
@@ -30,6 +17,21 @@
                     <%= external_link_to artist_url.url, external_site_icon(artist_url.site_name), title: artist_url.url %>
                   <% end %>
                 </ul>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <% if @source.artist_name.blank? %>
+            <tr>
+              <th>Artist</th>
+              <td><em>None</em></td>
+            </tr>
+          <% else %>
+            <tr>
+              <th>Artist</th>
+              <td>
+                <%= external_link_to @source.profile_url, @source.artist_name %>
+                (<%= link_to "Create new artist", new_artist_path(artist: { source: @source.canonical_url }) %>)
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION
Right now, even if an artist for weibo is matched, it won't show the box under "fetch source data", this one: 
![image](https://user-images.githubusercontent.com/12946050/124343154-b8c8aa00-dbc9-11eb-8ab8-f90c62610341.png)


This is because the faulty logic aborts early if the artist_name field in the source is blank, even if an artist tag exists.