### PR TITLE
Mass updates: make the destination search clickable

### DIFF
--- a/app/logical/bulk_update_request_processor.rb
+++ b/app/logical/bulk_update_request_processor.rb
@@ -213,7 +213,7 @@ class BulkUpdateRequestProcessor
       when :create_alias, :create_implication, :remove_alias, :remove_implication, :rename
         "#{command.to_s.tr("_", " ")} [[#{args[0]}]] -> [[#{args[1]}]]"
       when :mass_update
-        "mass update {{#{args[0]}}} -> #{args[1]}"
+        "mass update {{#{args[0]}}} -> {{#{args[1]}}}"
       when :nuke
         query = PostQueryBuilder.new(args[0])
 


### PR DESCRIPTION
Adds {{}} syntax to the destination of mass updates too.