### PR TITLE
Fix lofter strategy due to changes in their image urls

### DIFF
--- a/app/logical/sources/strategies/lofter.rb
+++ b/app/logical/sources/strategies/lofter.rb
@@ -23,7 +23,6 @@ module Sources
       PROFILE_URL = %r{\Ahttps?://(?<artist_name>[\w-]+).lofter.com}i
       PAGE_URL =    %r{#{PROFILE_URL}/post/(?<illust_id>[\w-]+)}i
       IMAGE_HOST =  %r{\Ahttps?://imglf\d\.(?:nosdn\d?\.12\d|lf127)\.net}i
-      IMAGE_URL =   %r{#{IMAGE_HOST}/img/\w+\.\w+}i
 
       def domains
         ["lofter.com", "lf127.net"]
@@ -39,7 +38,7 @@ module Sources
       end
 
       def image_url
-        if url =~ IMAGE_URL
+        if url =~ IMAGE_HOST
           get_full_version(url)
         else
           image_urls.first

--- a/test/unit/sources/lofter_test.rb
+++ b/test/unit/sources/lofter_test.rb
@@ -47,12 +47,9 @@ module Sources
     context "A different CSS schema" do
       should "still find all the data" do
         source1 = Sources::Strategies.find("https://yuli031458.lofter.com/post/3163d871_1cbdc5f6d")
-        source2 = Sources::Strategies.find("https://ssucrose.lofter.com/post/1d30f3e4_1cc58e9f0")
 
         assert_equal(["https://imglf5.lf127.net/img/Mm55d3lNK2tJUWpNTjVLN0MvaTRDc1UvQUFLMGszOHRvSjV6S3VSa1lwa3BDWUtVOWpBTHBnPT0.jpg"], source1.image_urls)
         assert_not_empty(source1.tags)
-
-        assert_equal(["https://imglf5.lf127.net/img/d052Q09DWkVNMVJwZm9rNURwNHdPcjlzRFlQc1BmTXArSG9TdXdJZnlCbUpEYnZJTHUwTGRRPT0.jpg"], source2.image_urls)
       end
     end
 


### PR DESCRIPTION
Lofter changed their image url schema so we should just check for the domain instead of the whole image url, otherwise it becomes a cat and mouse game.

Also removes a test that had become broken due to a link going 404.