### PR TITLE
fix ruffle-mirror version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postcss-loader": "^5.0.0",
     "postcss-preset-env": "^6.7.0",
     "rails-erb-loader": "^5.5.0",
-    "ruffle-mirror": "^2021.3.31",
+    "ruffle-mirror": "2021.3.31",
     "sass": "^1.32.5",
     "sass-loader": "^11.0.0",
     "spark-md5": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8355,7 +8355,7 @@ fsevents@~2.3.2:
     postcss-loader: ^5.0.0
     postcss-preset-env: ^6.7.0
     rails-erb-loader: ^5.5.0
-    ruffle-mirror: ^2021.3.31
+    ruffle-mirror: 2021.3.31
     sass: ^1.32.5
     sass-loader: ^11.0.0
     spark-md5: ^3.0.0


### PR DESCRIPTION
[app/javascript/packs/flash.js](https://github.com/danbooru/danbooru/blob/master/app/javascript/packs/flash.js) imports `node_modules/ruffle-mirror/ea72e7bd92c6a211ab42071518cef232.wasm` whose filename varies across versions.