### PR TITLE
IQDB direct url lookup: send the thumbnail instead of the full size

### DIFF
--- a/app/logical/iqdb_client.rb
+++ b/app/logical/iqdb_client.rb
@@ -53,7 +53,7 @@ class IqdbClient
       strategy = Sources::Strategies.find(url)
       download_url = strategy.send(type)
       file = strategy.download_file!(download_url)
-      file
+      file.preview(Danbooru.config.small_image_width, Danbooru.config.small_image_width)
     end
 
     # Transform the JSON returned by IQDB to add the full post data for each


### PR DESCRIPTION
This makes the url lookup perform in the same way as file regeneration.

Fixes #4859.