### PR TITLE
Fix ugoira regenerations

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1324,7 +1324,7 @@ class Post < ApplicationRecord
 
         ModAction.log("<@#{user.name}> regenerated IQDB for post ##{id}", :post_regenerate_iqdb, user)
       else
-        media_file = MediaFile.open(file, frame_data: pixiv_ugoira_frame_data)
+        media_file = MediaFile.open(file, frame_data: pixiv_ugoira_frame_data&.data.to_a)
         UploadService::Utils.process_resizes(self, nil, id, media_file: media_file)
 
         purge_cached_urls!


### PR DESCRIPTION
Currently ugoira with broken samples can't be regenerated, since the PixivUgoiraFrameData object is passed rather than the actual data itself (.data). This causes an error:

```
undefined method `each' for #<PixivUgoiraFrameData:0x0000555740d784c0>
/var/www/danbooru/releases/20210815100842/app/logical/media_file/ugoira.rb:64:in `block (2 levels) in convert'
/var/www/danbooru/releases/20210815100842/app/logical/media_file/ugoira.rb:62:in `open'
/var/www/danbooru/releases/20210815100842/app/logical/media_file/ugoira.rb:62:in `block in convert'
/var/www/danbooru/releases/20210815100842/app/logical/media_file/ugoira.rb:40:in `convert'
/var/www/danbooru/releases/20210815100842/app/logical/upload_service/utils.rb:25:in `generate_resizes'
/var/www/danbooru/releases/20210815100842/app/logical/upload_service/utils.rb:37:in `process_resizes'
/var/www/danbooru/releases/20210815100842/app/models/post.rb:1328:in `regenerate!'
/var/www/danbooru/releases/20210815100842/app/jobs/regenerate_post_job.rb:7:in `perform' 
```