### PR TITLE
Fix url fields in forms not having the same length as other text inputs

### DIFF
--- a/app/javascript/src/styles/common/simple_form.scss
+++ b/app/javascript/src/styles/common/simple_form.scss
@@ -30,7 +30,7 @@ form.simple_form {
   div.input {
     margin-bottom: 1em;
 
-    input[type=text], input[type=file], input[type=password], input[type=email] {
+    input[type=text], input[type=file], input[type=password], input[type=email], input[type=url] {
       width: 100%;
       max-width: 25em;
     }
@@ -44,7 +44,7 @@ form.simple_form {
       }
     }
 
-    &.field_with_errors  {
+    &.field_with_errors {
       input, select, textarea {
         border: 1px solid var(--form-input-validation-error-border-color);
       }


### PR DESCRIPTION
Reported on discord. There's a few pages on the site where this missing CSS makes the form look weird. Among them:

[/iqdb_queries](https://danbooru.donmai.us/iqdb_queries):
![image](https://user-images.githubusercontent.com/12946050/130955586-240fb16d-c59d-4f5d-9121-995d3433868e.png)

[/artist_urls](https://danbooru.donmai.us/artist_urls):
![image](https://user-images.githubusercontent.com/12946050/130955676-cf74f261-b6d1-4a08-800d-09055c7d5f37.png)
