### PR TITLE
Lofter: raise timeout for file download

### DIFF
--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -235,9 +235,14 @@ module Sources
       end
       memoize :http
 
+      # The http timeout to download a file. Overrideable by each site
+      def download_timeout
+        30
+      end
+
       # A http client for downloading files.
       def http_downloader
-        http.timeout(30).max_size(Danbooru.config.max_file_size).use(:spoof_referrer).use(:unpolish_cloudflare)
+        http.timeout(download_timeout).max_size(Danbooru.config.max_file_size).use(:spoof_referrer).use(:unpolish_cloudflare)
       end
       memoize :http_downloader
 

--- a/app/logical/sources/strategies/lofter.rb
+++ b/app/logical/sources/strategies/lofter.rb
@@ -96,6 +96,10 @@ module Sources
       def artist_name
         urls.map { |u| u[PROFILE_URL, :artist_name] || u[PAGE_URL, :artist_name] }.compact.first
       end
+
+      def download_timeout
+        60
+      end
     end
   end
 end


### PR DESCRIPTION
There's infrequent reports of uploads failing with a timeout error for large images with Lofter. Currently one such case is https://kllia.lofter.com/post/2d278a_1c78bbaef. In my personal deployment it downloads the file in less than 5 seconds, but on Danbooru and Testbooru it fails with a timeout error, so it seems to be a regional issue. Raising the timeout might help.

We probably don't want to raise the timeout too much across the bar, so imo it makes sense to have a customizable option that can be raised by the individual strategies where necessary.