### PR TITLE
Sources: fix artist_name not being caught in skeb and weibo

### DIFF
--- a/app/logical/sources/strategies/skeb.rb
+++ b/app/logical/sources/strategies/skeb.rb
@@ -83,7 +83,7 @@ module Sources
       end
 
       def artist_name
-        url[PROFILE_URL, :artist_name]
+        urls.map { |u| u[PROFILE_URL, :artist_name] }.compact.first
       end
 
       def display_name

--- a/app/logical/sources/strategies/weibo.rb
+++ b/app/logical/sources/strategies/weibo.rb
@@ -137,6 +137,10 @@ module Sources
         "https://www.weibo.com/p/#{artist_long_id}"
       end
 
+      def artist_name
+        api_response&.dig("user", "screen_name")
+      end
+
       def artist_commentary_desc
         return if api_response.blank?
 


### PR DESCRIPTION
Both skeb and weibo weren't displaying the artist box in the upload page because of this property.