### PR TITLE
Add million scale to humanized number helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,7 +103,9 @@ module ApplicationHelper
   end
 
   def humanized_number(number)
-    if number >= 10_000
+    if number >= 1_000_000
+      format("%.1fM", number / 1_000_000.0)
+    elsif number >= 10_000
       "#{number / 1_000}k"
     elsif number >= 1_000
       format("%.1fk", number / 1_000.0)


### PR DESCRIPTION
There's now [11 tags](https://danbooru.donmai.us/tags?commit=Search&search%5Bhide_empty%5D=yes&search%5Border%5D=count) above 1M posts, and several users with edits in the millions, which currently look like this:

![image](https://user-images.githubusercontent.com/12946050/135453241-f1f214f3-35e0-4d67-8cb6-74669b38cec1.png)
![image](https://user-images.githubusercontent.com/12946050/135453585-b0ad2313-15ec-43ac-bcf1-1dc6d24c3a39.png)


It makes sense to print these high numbers in a nicer way:
![image](https://user-images.githubusercontent.com/12946050/135453547-a7d612dd-9cdd-461d-ba41-a9316f5457a3.png)
![image](https://user-images.githubusercontent.com/12946050/135453663-17062bd4-0911-4507-84ae-c0ac5d78507b.png)

Worth noting that the [official notation](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes) dictates that kilo is lowercase while Mega is uppercase.