### PR TITLE
Autotag the meme tag on posts with *_(meme) tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -352,6 +352,7 @@ class Tag < ApplicationRecord
     tags += names.grep(/\A(.+)_\(cosplay\)\z/i) { "char:#{TagAlias.to_aliased([$1]).first}" }
     tags << "cosplay" if names.any?(/_\(cosplay\)\z/i)
     tags << "school_uniform" if names.any?(/_school_uniform\z/i)
+    tags << "meme" if names.any?(/_\(meme\)\z/i)
     tags.uniq
   end
 


### PR DESCRIPTION
Ref: 
https://danbooru.donmai.us/forum_topics/19617
https://danbooru.donmai.us/forum_topics/19555
https://danbooru.donmai.us/forum_topics/16575
https://danbooru.donmai.us/forum_topics/14315
https://danbooru.donmai.us/forum_topics/15431

Sure, we'll have to debate what counts as meme, but having meme be automated will likely discourage people from trying to make large meme attire tags count as memes. I think such an approach is just easier for us, given how many meme tags pop up every day.

For reference, there's now [almost 200 _(meme) tags](https://danbooru.donmai.us/tags?commit=Search&search%5Bhide_empty%5D=yes&search%5Bname_or_alias_matches%5D=%2A%28meme%29&search%5Border%5D=count),  the majority of them with less than 5 posts.