### PR TITLE
remove references to locks

### DIFF
--- a/app/logical/autocomplete_service.rb
+++ b/app/logical/autocomplete_service.rb
@@ -15,7 +15,6 @@ class AutocompleteService
     child: %w[any none] + POST_STATUSES,
     parent: %w[any none] + POST_STATUSES,
     rating: %w[safe questionable explicit],
-    locked: %w[rating note status],
     embedded: %w[true false],
     filetype: %w[jpg png gif swf zip webm mp4],
     commentary: %w[true false translated untranslated],

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -34,7 +34,7 @@ class PostQueryBuilder
   METATAGS = %w[
     user approver commenter comm noter noteupdater artcomm commentaryupdater
     flagger appealer upvote downvote fav ordfav favgroup ordfavgroup pool
-    ordpool note comment commentary id rating locked source status filetype
+    ordpool note comment commentary id rating source status filetype
     disapproved parent child search embedded md5 width height mpixels ratio
     score favcount filesize date age order limit tagcount pixiv_id pixiv
     unaliased exif duration

--- a/test/system/autocomplete_test.rb
+++ b/test/system/autocomplete_test.rb
@@ -42,7 +42,6 @@ class AutocompleteTest < ApplicationSystemTestCase
       should "work for static metatags" do
         assert_metatag_autocomplete_equals(%w[any none], "child")
         assert_metatag_autocomplete_equals(%w[any none], "parent")
-        assert_metatag_autocomplete_equals(%w[rating note status], "locked")
         assert_metatag_autocomplete_equals(%w[safe questionable explicit], "rating")
         assert_metatag_autocomplete_equals(%w[gif jpg mp4 png swf webm zip], "filetype")
         assert_metatag_autocomplete_equals(%w[active any banned deleted flagged modqueue pending unmoderated], "status")

--- a/test/unit/autocomplete_service_test.rb
+++ b/test/unit/autocomplete_service_test.rb
@@ -174,10 +174,6 @@ class AutocompleteServiceTest < ActiveSupport::TestCase
         assert_autocomplete_equals(["rating:questionable"], "rating:q", :tag_query)
         assert_autocomplete_equals(["rating:explicit"], "rating:e", :tag_query)
 
-        assert_autocomplete_equals(["locked:rating"], "locked:r", :tag_query)
-        assert_autocomplete_equals(["locked:status"], "locked:s", :tag_query)
-        assert_autocomplete_equals(["locked:note"], "locked:n", :tag_query)
-
         assert_autocomplete_equals(["embedded:true"], "embedded:t", :tag_query)
         assert_autocomplete_equals(["embedded:false"], "embedded:f", :tag_query)
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -414,8 +414,6 @@ class PostTest < ActiveSupport::TestCase
         should allow_value("touhou child:1").for(:tag_string)
         should allow_value("touhou source:foo").for(:tag_string)
         should allow_value("touhou rating:z").for(:tag_string)
-        should allow_value("touhou locked:rating").for(:tag_string)
-        should allow_value("touhou -locked:rating").for(:tag_string)
 
         # \u3000 = ideographic space, \u00A0 = no-break space
         should allow_value("touhou\u3000foo").for(:tag_string)
@@ -676,7 +674,7 @@ class PostTest < ActiveSupport::TestCase
 
         context "for a rating" do
           context "that is valid" do
-            should "update the rating if the post is unlocked" do
+            should "update the rating" do
               @post.update(tag_string: "aaa rating:e")
               @post.reload
               assert_equal("e", @post.rating)
@@ -1364,7 +1362,7 @@ class PostTest < ActiveSupport::TestCase
       end
     end
 
-    context "A rating unlocked post" do
+    context "A post" do
       setup { @post = FactoryBot.create(:post) }
       subject { @post }
 


### PR DESCRIPTION
The ability to lock posts was removed a few weeks ago, so these bits are no longer needed. `locked:note` etc. searches also cause an error currently.