### PR TITLE
remove unused confirm_ban route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,6 @@ Rails.application.routes.draw do
           post :expunge
           get :confirm_move_favorites
           post :move_favorites
-          get :confirm_ban
           post :ban
           post :unban
         end


### PR DESCRIPTION
The associated action was removed in e29e9eda499686acfb77d2b7a2e55eac78e2be19 so this route causes an error in development and a blank page in production.