### PR TITLE
Foundation: add support for unconventional account names

### DIFF
--- a/app/logical/sources/strategies/foundation.rb
+++ b/app/logical/sources/strategies/foundation.rb
@@ -6,15 +6,22 @@
 # * https://foundation.app/@mochiiimo/~/97376
 # * https://foundation.app/@huwari/~/88982 (video)
 #
+# Even if the username is wrong, the ID is still fetched correctly. Example:
+# * https://foundation.app/@asdasdasd/~/97376
+#
 # Profile URLs
 #
+# Profile urls seem to accept any character in them, even no character at all:
 # * https://foundation.app/@mochiiimo
+# * https://foundation.app/@ <- This seems to be a novelty account.
+#                               Probably not worth supporting it given its
+#                               uniqueness and chance for headaches
 
 module Sources
   module Strategies
     class Foundation < Base
       BASE_URL    = %r{\Ahttps?://(www\.)?foundation\.app}i
-      PROFILE_URL = %r{#{BASE_URL}/@(?<artist_name>\w+)}i
+      PROFILE_URL = %r{#{BASE_URL}/@(?<artist_name>[^/]+)/?}i
       PAGE_URL    = %r{#{PROFILE_URL}/~/(?<illust_id>\d+)}i
 
       IMAGE_HOST  = /f8n-ipfs-production\.imgix\.net/

--- a/test/unit/sources/foundation_test.rb
+++ b/test/unit/sources/foundation_test.rb
@@ -49,5 +49,17 @@ module Sources
         assert_nothing_raised { @image3.to_h }
       end
     end
+
+    context "non-alphanumeric usernames" do
+      should "still work" do
+        case1 = Sources::Strategies.find("https://foundation.app/@brandon.dalmer/~/6792")
+        case2 = Sources::Strategies.find("https://foundation.app/@~/~/6792")
+        image = "https://f8n-ipfs-production.imgix.net/QmVnpe39qodMjTe8v3fijPfB1tjwhT8hgobtgLPtsangqc/nft.png"
+        assert_nothing_raised { case1.to_h }
+        assert_nothing_raised { case2.to_h }
+        assert_equal(image, case1.image_url)
+        assert_equal(image, case2.image_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
While indexing foundation.app I found some weird account names. Turns out \w+ is not enough to catch all the possible cases.