### PR TITLE
mod dashboard: minor cleanup

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -210,14 +210,16 @@ module ApplicationHelper
     html = ""
     html << link_to_user(user)
 
-    if positive_or_negative == :positive
-      html << " [" + link_to("+", new_user_feedback_path(:user_feedback => {:category => "positive", :user_id => user.id})) + "]"
+    if CurrentUser.is_gold? && user != CurrentUser.user
+      if positive_or_negative == :positive
+        html << " [" + link_to("+", new_user_feedback_path(:user_feedback => {:category => "positive", :user_id => user.id})) + "]"
 
-      unless user.is_gold?
-        html << " [" + link_to("promote", edit_admin_user_path(user)) + "]"
+        if CurrentUser.is_moderator? && !user.is_builder?
+          html << " [" + link_to("promote", edit_admin_user_path(user)) + "]"
+        end
+      else
+        html << " [" + link_to("&ndash;".html_safe, new_user_feedback_path(:user_feedback => {:category => "negative", :user_id => user.id})) + "]"
       end
-    else
-      html << " [" + link_to("&ndash;".html_safe, new_user_feedback_path(:user_feedback => {:category => "negative", :user_id => user.id})) + "]"
     end
 
     html.html_safe


### PR DESCRIPTION
* only show the [+] and [-] feedback buttons to gold users
* only show the [promote] button to moderators, and only when targetting users
  builder or below
* don't show either button if the target is the current user
* closes #4924 