### PR TITLE
SpamDetector: raise autoban duration to 100 years.

### DIFF
--- a/app/logical/spam_detector.rb
+++ b/app/logical/spam_detector.rb
@@ -11,7 +11,7 @@ class SpamDetector
   # window, automatically ban them forever.
   AUTOBAN_THRESHOLD = 10
   AUTOBAN_WINDOW = 1.hour
-  AUTOBAN_DURATION = 999_999
+  AUTOBAN_DURATION = 100.years
 
   attr_accessor :record, :user, :user_ip, :content, :comment_type
 


### PR DESCRIPTION
This is to match the max duration usable by mods in the site.
The previous value of 999999 seconds only amounted to 11 days: see [this user]( https://danbooru.donmai.us/users/851640) for example.