### PR TITLE
Fix duration check for uploads from twitter

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -55,7 +55,7 @@ class Upload < ApplicationRecord
     end
 
     def validate_video_duration(record)
-      if !record.uploader.is_admin? && record.file.is_video? && record.file.duration > MAX_VIDEO_DURATION
+      if !record.uploader.is_admin? && record.file.is_video? && record.file.duration.to_i > MAX_VIDEO_DURATION
         record.errors.add(:base, "video must not be longer than #{MAX_VIDEO_DURATION.seconds.inspect}")
       end
     end


### PR DESCRIPTION
Some twitter videos near the max duration had some stray milliseconds that made the check fail.

For example https://twitter.com/kivo_some_18/status/1152167154059321344?s=20 (nsfw) has 140.053333 duration.

I'm not sure if the fault is on twitter. Testing several videos with exactly 140 seconds of duration, the duration for us always ended up being 140.053333 seconds. In any case, rounding down solves this issue.