### PR TITLE
Search: "Fix" negated ordered metatags

### DIFF
--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -118,9 +118,13 @@ class PostQueryBuilder
 
   def metatags_match(metatags, relation)
     metatags.each do |metatag|
-      metatag.name = metatags_without_ord[metatag.name] if metatag.negated && metatags_without_ord.key?(metatag.name)
+      metatag_name = if metatag.negated && metatags_without_ord.key?(metatag.name)
+        metatags_without_ord[metatag.name]
+      else
+        metatag.name
+      end
 
-      clause = metatag_matches(metatag.name, metatag.value, quoted: metatag.quoted)
+      clause = metatag_matches(metatag_name, metatag.value, quoted: metatag.quoted)
       clause = clause.negate_relation if metatag.negated
       relation = relation.and_relation(clause)
     end

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -117,24 +117,19 @@ class PostQueryBuilder
   end
 
   def metatags_match(metatags, relation)
-    fix_negated_ordered_metatags(metatags)
-    metatags.each do |metatag|
-      clause = metatag_matches(metatag.name, metatag.value, quoted: metatag.quoted)
-      clause = clause.negate_relation if metatag.negated
-      relation = relation.and_relation(clause)
-    end
-
-    relation
-  end
-  
-  def fix_negated_ordered_metatags(metatag)
     metatags.each do |metatag|
       if metatag.negated
         metatag.name = "fav" if metatag.name == "ordfav"
         metatag.name = "favgroup" if metatag.name == "ordfavgroup"
         metatag.name = "pool" if metatag.name == "ordpool"
       end
+      
+      clause = metatag_matches(metatag.name, metatag.value, quoted: metatag.quoted)
+      clause = clause.negate_relation if metatag.negated
+      relation = relation.and_relation(clause)
     end
+
+    relation
   end
 
   def metatag_matches(name, value, quoted: false)

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -118,11 +118,7 @@ class PostQueryBuilder
 
   def metatags_match(metatags, relation)
     metatags.each do |metatag|
-      if metatag.negated
-        metatag.name = "fav" if metatag.name == "ordfav"
-        metatag.name = "favgroup" if metatag.name == "ordfavgroup"
-        metatag.name = "pool" if metatag.name == "ordpool"
-      end
+      metatag.name = metatags_without_ord[metatag.name] if metatag.negated && metatags_without_ord.key?(metatag.name)
 
       clause = metatag_matches(metatag.name, metatag.value, quoted: metatag.quoted)
       clause = clause.negate_relation if metatag.negated
@@ -130,6 +126,14 @@ class PostQueryBuilder
     end
 
     relation
+  end
+
+  def metatags_without_ord
+    {
+      "ordfav" => "fav",
+      "ordfavgroup" => "favgroup",
+      "ordpool" => "pool",
+    }
   end
 
   def metatag_matches(name, value, quoted: false)

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -123,7 +123,7 @@ class PostQueryBuilder
         metatag.name = "favgroup" if metatag.name == "ordfavgroup"
         metatag.name = "pool" if metatag.name == "ordpool"
       end
-      
+
       clause = metatag_matches(metatag.name, metatag.value, quoted: metatag.quoted)
       clause = clause.negate_relation if metatag.negated
       relation = relation.and_relation(clause)

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -117,6 +117,7 @@ class PostQueryBuilder
   end
 
   def metatags_match(metatags, relation)
+    fix_negated_ordered_metatags(metatags)
     metatags.each do |metatag|
       clause = metatag_matches(metatag.name, metatag.value, quoted: metatag.quoted)
       clause = clause.negate_relation if metatag.negated
@@ -124,6 +125,16 @@ class PostQueryBuilder
     end
 
     relation
+  end
+  
+  def fix_negated_ordered_metatags(metatag)
+    metatags.each do |metatag|
+      if metatag.negated
+        metatag.name = "fav" if metatag.name == "ordfav"
+        metatag.name = "favgroup" if metatag.name == "ordfavgroup"
+        metatag.name = "pool" if metatag.name == "ordpool"
+      end
+    end
   end
 
   def metatag_matches(name, value, quoted: false)

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -118,13 +118,9 @@ class PostQueryBuilder
 
   def metatags_match(metatags, relation)
     metatags.each do |metatag|
-      metatag_name = if metatag.negated && metatags_without_ord.key?(metatag.name)
-        metatags_without_ord[metatag.name]
-      else
-        metatag.name
-      end
+      metatag_name = metatags_without_ord[metatag.name] if metatag.negated && metatags_without_ord.key?(metatag.name)
 
-      clause = metatag_matches(metatag_name, metatag.value, quoted: metatag.quoted)
+      clause = metatag_matches(metatag_name || metatag.name, metatag.value, quoted: metatag.quoted)
       clause = clause.negate_relation if metatag.negated
       relation = relation.and_relation(clause)
     end


### PR DESCRIPTION
Fixes #4918 by guessing that the user wanted to search for the non "ord" version of the negated tags.

`-ordfav:USER` → `-fav:USER`
`-ordfavgroup:ID` → `-favgroup:ID`
`-ordpool:ID` → `-pool:ID`

**Note:** It doesn't fix `-order:rank` and other negated `order` searches.