### PR TITLE
Add length limit to character wiki pages

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -16,6 +16,8 @@ class WikiPage < ApplicationRecord
 
   validates :title, tag_name: true, presence: true, uniqueness: true, if: :title_changed?
   validates :body, presence: true, unless: -> { is_deleted? || other_names.present? }
+  validates :body, length: { maximum: 2_000 }, if: ->(rec) { body_changed? && rec.tag&.category == 4 }
+
   validate :validate_rename
   validate :validate_other_names
 


### PR DESCRIPTION
This is my proposal that fixes #4961. It sets the max length at 2000 and raises an error only if the body is changed, because we don't want to force someone who was just adding translated tags to deal with it.

There are 466 character wikis which go over this limit, so it will only affect a small portion of them.