### PR TITLE
Add svg favicon

### DIFF
--- a/app/views/layouts/blank.html.erb
+++ b/app/views/layouts/blank.html.erb
@@ -4,7 +4,8 @@
   <%= NewRelic::Agent.browser_timing_header rescue "" %>
   <meta charset="utf-8">
   <title><%= page_title %></title>
-  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" sizes="16x16" type="image/x-icon">
+  <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml">
   <link rel="top" title="<%= Danbooru.config.app_name %>" href="/">
   <%= csrf_meta_tag %>
   <%= raw Danbooru.config.custom_html_header_content %>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -5,7 +5,8 @@
   <meta charset="utf-8">
   <title><%= page_title %></title>
 
-  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" sizes="16x16" type="image/x-icon">
+  <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml">
   <%= render_meta_links @current_item if @current_item.respond_to?(:paginate) %>
   <%= tag.link rel: "canonical", href: canonical_url %>
   <%= tag.link rel: "search", type: "application/opensearchdescription+xml", href: opensearch_url(format: :xml, version: 2), title: "Search posts" %>

--- a/app/views/robots/index.text.erb
+++ b/app/views/robots/index.text.erb
@@ -72,6 +72,7 @@ Allow: <%= privacy_policy_path %>
 Allow: <%= not_found_path %>
 Allow: /sitemap.xml
 Allow: /favicon.ico
+Allow: /favicon.svg
 
 Sitemap: <%= sitemap_url(format: :xml, sitemap: "artists") %>
 Sitemap: <%= sitemap_url(format: :xml, sitemap: "forum_topics") %>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" height="16" width="16" version="1.1">
+	<defs>
+		<linearGradient id="bg" gradientTransform="rotate(85)">
+			<stop offset="49%" stop-color="#ba9570" />
+			<stop offset="67%" stop-color="#a4815f" />
+		</linearGradient>
+	</defs>
+	<g>
+		<path d="M 1.5,14.5 V 4.25 L 4.25,1.5 H 14.5 v 10.25 l -2.75,2.75 z" fill="url(#bg)" stroke="black" stroke-width="1" />
+		<path d="m 1.5,4.5 h 10 v 10" stroke="black" stroke-width="1" fill="none" />
+		<path d="m 14.5,1.5 -3,3" stroke="black" stroke-width="1" />
+	</g>
+</svg>

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -5,7 +5,8 @@
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="10">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" sizes="16x16" type="image/x-icon">
+    <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml">
 
     <style type="text/css">
       body {


### PR DESCRIPTION
Was using it for a while in my browser extension. Hand-crafted approximation of `favicon.ico` with brute-forced gradient angles and stops to get a lowest dssim score (0.00510548).

Dropped `shortcut` in `rel` since it is deprecated by html5 ([spec](https://html.spec.whatwg.org/multipage/links.html#rel-icon), [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)).