### PR TITLE
Fix initial upload points bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ApplicationRecord
   attribute :favorite_count, default: 0
   attribute :per_page, default: 20
   attribute :theme, default: :light
-  attribute :upload_points, default: 1000
+  attribute :upload_points, default: Danbooru.config.initial_upload_points.to_i
   attribute :bit_prefs, default: 0
 
   has_bit_flags BOOLEAN_ATTRIBUTES, :field => "bit_prefs"


### PR DESCRIPTION
Yep, wow, me again. #4963. I'm ashamed to be on my third PR for this. Missed a hardcoded int last time, so new users were still given the default starting upload points. This time I built my own images and let it run for a week on my selfhosted instance because I would have probably died if another issue came up after this.