### PR TITLE
Tag script field: use full available width

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -13,7 +13,7 @@
           <option value="remove-fav">Unfavorite</option>
         </select>
       </form>
-      <input id="tag-script-field" data-autocomplete="tag-edit" placeholder="Enter tag script" style="display: none; margin-top: 0.5em;">
+      <input id="tag-script-field" data-autocomplete="tag-edit" placeholder="Enter tag script" style="display: none; margin-top: 0.5em; width: 100%;">
     </section>
   <% end %>
 


### PR DESCRIPTION
When unset the width is inconsistent across browsers. 
In Firefox I measured 203px while in Chrome it is only 162px.