### PR TITLE
Moderation Reports: add link for moderators to navbar

### DIFF
--- a/app/javascript/src/styles/common/page_header.scss
+++ b/app/javascript/src/styles/common/page_header.scss
@@ -46,7 +46,8 @@ header#top {
       color: var(--login-link-color);
     }
 
-    li.forum-updated a {
+    li.forum-updated a,
+    li.reports-pending a {
       font-style: italic;
     }
   }

--- a/app/views/layouts/_main_links.html.erb
+++ b/app/views/layouts/_main_links.html.erb
@@ -13,6 +13,7 @@
   <%= nav_link_to("Wiki", wiki_page_path("help:home")) %>
   <%= nav_link_to("Forum", forum_topics_path, :class => (CurrentUser.has_forum_been_updated? ? "forum-updated" : nil)) %>
   <% if CurrentUser.is_moderator? %>
+    <%= nav_link_to("Reports", moderation_reports_path, :class => (ModerationReport.where(status: "pending").present? ? "reports-pending" : nil)) %>
     <%= nav_link_to("Dashboard", moderator_dashboard_path) %>
   <% end %>
   <%= nav_link_to("More »", site_map_path) %>


### PR DESCRIPTION
It turns italic and is styleable when there's pending reports just like the forum link.

This is so that we can actually check at a glance if there's new reports without having to have a bookmark to the report page or using distill.