### PR TITLE
nijie: extract post ID from new image URL

### DIFF
--- a/app/logical/source/url/nijie.rb
+++ b/app/logical/source/url/nijie.rb
@@ -11,6 +11,7 @@
 # * https://pic.nijie.net/03/nijie_picture/236014_20170620101426_0.png (page: https://www.nijie.info/view.php?id=218856)
 #
 # * https://pic.nijie.net/07/nijie/17/95/728995/illust/0_0_403fdd541191110c_c25585.jpg
+# * https://pic.nijie.net/06/nijie/17/14/236014/illust/218856_1_7646cf57f6f1c695_f2ed81.png (page: https://nijie.info/view.php?id=218856)
 #
 # Unhandled:
 #
@@ -75,8 +76,10 @@ class Source::URL::Nijie < Source::URL
       @user_id = params[:id]
 
     # https://pic.nijie.net/07/nijie/17/95/728995/illust/0_0_403fdd541191110c_c25585.jpg
+    # https://pic.nijie.net/06/nijie/17/14/236014/illust/218856_1_7646cf57f6f1c695_f2ed81.png
     in _, /^\d{2}$/, "nijie", /^\d{2}$/, /^\d{2}$/, user_id, "illust", _ if image_url?
       @user_id = user_id
+      parse_filename
 
     # https://pic01.nijie.info/nijie_picture/diff/main/218856_0_236014_20170620101329.png (page: http://nijie.info/view.php?id=218856)
     # https://pic01.nijie.info/nijie_picture/diff/main/218856_1_236014_20170620101330.png
@@ -115,6 +118,11 @@ class Source::URL::Nijie < Source::URL
     # 287736_161475_20181112032855_1.png
     in /^\d+$/ => work_id, /^\d+$/ => user_id, /^\d{14}$/ => timestamp, /^\d+$/
       @work_id, @user_id = work_id, user_id
+
+    # 0_0_403fdd541191110c_c25585.jpg
+    # 218856_1_7646cf57f6f1c695_f2ed81.png
+    in /^\d+$/ => work_id, /^\d+$/, /^\h+$/, /^\h+$/
+      @work_id = work_id if work_id.to_i != 0
 
     else
     end

--- a/app/logical/source/url/nijie.rb
+++ b/app/logical/source/url/nijie.rb
@@ -75,7 +75,7 @@ class Source::URL::Nijie < Source::URL
       @user_id = params[:id]
 
     # https://pic.nijie.net/07/nijie/17/95/728995/illust/0_0_403fdd541191110c_c25585.jpg
-    in _, "nijie_picture", /^\d{2}$/, "nijie", /^\d{2}$/, /^\d{2}$/, user_id, "illust", _ if image_url?
+    in _, /^\d{2}$/, "nijie", /^\d{2}$/, /^\d{2}$/, user_id, "illust", _ if image_url?
       @user_id = user_id
 
     # https://pic01.nijie.info/nijie_picture/diff/main/218856_0_236014_20170620101329.png (page: http://nijie.info/view.php?id=218856)


### PR DESCRIPTION
Turns recent image URLs such as <https://pic.nijie.net/06/nijie/17/14/236014/illust/218856_1_7646cf57f6f1c695_f2ed81.png> into  post URLs (<https://nijie.info/view.php?id=218856>) on post pages. It seems like the post ID is included only if the image is from a multi-image post and is not the first item in the gallery.