### PR TITLE
favorite_groups: make search[order]=updated_at work

### DIFF
--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -43,6 +43,8 @@ class FavoriteGroup < ApplicationRecord
         q = q.order(name: :asc, id: :desc)
       when "created_at"
         q = q.order(id: :desc)
+      when "updated_at"
+        q = q.order(updated_at: :desc)
       when "post_count"
         q = q.order(Arel.sql("cardinality(post_ids) desc")).order(id: :desc)
       else


### PR DESCRIPTION
The UI offers an option to sort by modification date but it doesn't do anything, might've been left out after a rewrite. This PR implements it.