### PR TITLE
Limit the width of usernames in tables

### DIFF
--- a/app/javascript/src/styles/common/tables.scss
+++ b/app/javascript/src/styles/common/tables.scss
@@ -76,3 +76,11 @@ table.table-sm {
 table.table-md {
   th, td { padding: 0.5rem; }
 }
+
+td > .user {
+  display: inline-block;
+  max-width: max(15vw, 150px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+}


### PR DESCRIPTION
Fixes the layout issues caused very long usernames in the forum and elsewhere.

I'm not sure if this should go in `tables.scss` but it seemed the most logical to me.
I think a shorter username limit (suggested in the Discord) wouldn't be a replacement for this, as names using many wide characters could still cause issues on smaller screens.