### PR TITLE
docker-compose: do db:seed before server start

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       - /tmp
     depends_on:
       - postgres
-    command: ["bash", "-c", "bin/rails db:prepare && bin/rails server -b 0.0.0.0"]
+    command: ["bash", "-c", "bin/rails db:prepare && bin/rails db:seed && bin/rails server -b 0.0.0.0"]
 
   cron:
     user: root


### PR DESCRIPTION
This is needed to create DanbooruBot and enable uploads, among other things.

Fixes #5011.