### PR TITLE
Replace hard tabs with spaces in .rb files

### DIFF
--- a/app/logical/sandbox.rb
+++ b/app/logical/sandbox.rb
@@ -362,13 +362,13 @@ class Sandbox
     # https://github.com/torvalds/linux/blob/master/include/uapi/linux/sched.h
     bitmask :unshare_flags, [
       :clone_time,      7,  # 0x00000080, New time namespace
-      :clone_newns,	    17, # 0x00020000,	New mount (filesystem) namespace
+      :clone_newns,     17, # 0x00020000, New mount (filesystem) namespace
       :clone_newcgroup, 25, # 0x02000000, New cgroup namespace
-      :clone_newuts,	  26, # 0x04000000,	New utsname (hostname) namespace
-      :clone_newipc,	  27, # 0x08000000,	New ipc namespace
-      :clone_newuser,	  28, # 0x10000000, New user namespace
-      :clone_newpid,	  29, # 0x20000000,	New pid namespace
-      :clone_newnet,	  30, # 0x40000000,	New network namespace
+      :clone_newuts,    26, # 0x04000000, New utsname (hostname) namespace
+      :clone_newipc,    27, # 0x08000000, New ipc namespace
+      :clone_newuser,   28, # 0x10000000, New user namespace
+      :clone_newpid,    29, # 0x20000000, New pid namespace
+      :clone_newnet,    30, # 0x40000000, New network namespace
     ]
 
     # https://github.com/torvalds/linux/blob/master/include/uapi/linux/mount.h

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -174,23 +174,23 @@ module Danbooru
     # How long pending posts stay in the modqueue before being deleted.
     def moderation_period
       3.days
-		end
+    end
 
-		# Upload points can be earned or lost by users. They punish and reward users by adding and removing upload slots.
-		# 1000 points is enough for 10 uploads. See app/logical/upload_limit.rb for details on the level system.
-		def initial_upload_points
-			1000
-		end
+    # Upload points can be earned or lost by users. They punish and reward users by adding and removing upload slots.
+    # 1000 points is enough for 10 uploads. See app/logical/upload_limit.rb for details on the level system.
+    def initial_upload_points
+      1000
+    end
 
-		# The cap on how many upload points a user can earn.
-		def maximum_upload_points
-			10_000
-		end
+    # The cap on how many upload points a user can earn.
+    def maximum_upload_points
+      10_000
+    end
 
-		# These slots are added to the ones earned by upload levels and guaranteed to all users, even those at level 0.
-		def extra_upload_slots
-			5
-		end
+    # These slots are added to the ones earned by upload levels and guaranteed to all users, even those at level 0.
+    def extra_upload_slots
+      5
+    end
 
     # https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration
     # https://guides.rubyonrails.org/configuring.html#configuring-action-mailer


### PR DESCRIPTION
Noticed inconsistent indentation when editing the config. `sandbox.rb` was the only other file I found wrongly using tabs.