### PR TITLE
sources: factor out Source::URL::Tumblr

### DIFF
--- a/app/logical/source/url.rb
+++ b/app/logical/source/url.rb
@@ -30,6 +30,7 @@ module Source
       Source::URL::Newgrounds,
       Source::URL::Plurk,
       Source::URL::Skeb,
+      Source::URL::Tumblr,
       Source::URL::TwitPic,
       Source::URL::Weibo,
     ]

--- a/app/logical/sources/strategies/tumblr.rb
+++ b/app/logical/sources/strategies/tumblr.rb
@@ -1,73 +1,39 @@
 # frozen_string_literal: true
 
-# https://marmaladica.tumblr.com/post/188237914346/saved
-# https://66.media.tumblr.com/2c6f55531618b4335c67e29157f5c1fc/tumblr_pz4a44xdVj1ssucdno1_1280.png
-# https://66.media.tumblr.com/11700cab20d65d5a6acc470e284dbd3a/tumblr_pz4a44xdVj1ssucdno2_1280.png
-#
-# https://emlan.tumblr.com/post/189469423572/kuro-attempts-to-buy-a-racy-book-at-comiket-but
-# https://66.media.tumblr.com/168dabd09d5ad69eb5fedcf94c45c31a/3dbfaec9b9e0c2e3-72/s640x960/bf33a1324f3f36d2dc64f011bfeab4867da62bc8.png
-# https://66.media.tumblr.com/5a2c3fe25c977e2281392752ab971c90/3dbfaec9b9e0c2e3-92/s500x750/4f92bbaaf95c0b4e7970e62b1d2e1415859dd659.png
-#
-# https://superboin.tumblr.com/post/141169066579/photoset_iframe/superboin/tumblr_o45miiAOts1u6rxu8/500/false
-#
-# https://make-do5.tumblr.com/post/619663949657423872 (extremely high res, extractable)
-
+# @see Source::URL::Tumblr
 module Sources::Strategies
   class Tumblr < Base
-    SIZES = %w[1280 640 540 500h 500 400 250 100]
-
-    BASE_URL = %r{\Ahttps?://(?:[^/]+\.)*tumblr\.com}i
-    DOMAIN = /(data|(?:\d+\.)?media)\.tumblr\.com/i
-    MD5 = /(?<md5>[0-9a-f]{32})/i
-    FILENAME = /(?<filename>(?:tumblr_(?:inline_)?)?[a-z0-9]+(?:_r[0-9]+)?)/i
-    EXT = /(?<ext>\w+)/
-
-    # old: https://66.media.tumblr.com/2c6f55531618b4335c67e29157f5c1fc/tumblr_pz4a44xdVj1ssucdno1_1280.png
-    # new: https://66.media.tumblr.com/168dabd09d5ad69eb5fedcf94c45c31a/3dbfaec9b9e0c2e3-72/s640x960/bf33a1324f3f36d2dc64f011bfeab4867da62bc8.png
-    OLD_IMAGE = %r{\Ahttps?://#{DOMAIN}/(?<dir>#{MD5}/)?#{FILENAME}_(?<size>\w+)\.#{EXT}\z}i
-
-    IMAGE = %r{\Ahttps?://#{DOMAIN}/}i
-    VIDEO = %r{\Ahttps?://(?:vtt|ve|va\.media)\.tumblr\.com/}i
-    POST = %r{\Ahttps?://(?<blog_name>[^.]+)\.tumblr\.com/(?:post|image)/(?<post_id>\d+)}i
-
     def self.enabled?
       Danbooru.config.tumblr_consumer_key.present?
     end
 
-    def domains
-      ["tumblr.com"]
+    def match?
+      Source::URL::Tumblr === parsed_url
     end
 
     def site_name
-      "Tumblr"
-    end
-
-    def image_url
-      return image_urls.first unless url.match?(IMAGE) || url.match?(VIDEO)
-      find_largest(url)
+      parsed_url.site_name
     end
 
     def image_urls
-      list = []
+      return [find_largest(parsed_url)].compact if parsed_url.asset_url?
+
+      assets = []
 
       case post[:type]
       when "photo"
-        list += post[:photos].map do |photo|
+        assets += post[:photos].map do |photo|
           sizes = [photo[:original_size]] + photo[:alt_sizes]
           biggest = sizes.max_by { |x| x[:width] * x[:height] }
           biggest[:url]
         end
 
       when "video"
-        list += [post[:video_url]]
-
-      # api response is blank (work is deleted or we were given a direct image with no referer url)
-      when nil
-        list += [url] if url.match?(IMAGE) || url.match?(VIDEO)
+        assets += [post[:video_url]]
       end
 
-      list += inline_images
-      list.map { |url| find_largest(url) }
+      assets += inline_images
+      assets.map { |url| find_largest(url) }
     end
 
     def preview_urls
@@ -77,21 +43,11 @@ module Sources::Strategies
     end
 
     def page_url
-      return nil unless blog_name.present? && post_id.present?
-      "https://#{blog_name}.tumblr.com/post/#{post_id}"
-    end
-
-    def canonical_url
-      page_url
+      parsed_url.page_url || parsed_referer&.page_url || post_url_from_image_html&.page_url
     end
 
     def profile_url
-      return nil if artist_name.blank?
-      "https://#{artist_name}.tumblr.com"
-    end
-
-    def artist_name
-      post[:blog_name] || blog_name
+      parsed_url.profile_url || parsed_referer&.profile_url || post_url_from_image_html&.profile_url
     end
 
     def artist_commentary_title
@@ -138,50 +94,35 @@ module Sources::Strategies
     end
 
     def normalize_for_source
-      return unless blog_name.present? && post_id.present?
-
-      "https://#{blog_name}.tumblr.com/post/#{post_id}"
+      parsed_url.page_url
     end
 
     def dtext_artist_commentary_desc
       DText.from_html(artist_commentary_desc).strip
     end
 
-    # Look for the biggest available version on media.tumblr.com. A bigger
-    # version may or may not exist.
-    #
-    # https://40.media.tumblr.com/de018501416a465d898d24ad81d76358/tumblr_nfxt7voWDX1rsd4umo1_r23_1280.jpg
-    # => https://media.tumblr.com/de018501416a465d898d24ad81d76358/tumblr_nfxt7voWDX1rsd4umo1_r23_raw.jpg
-    #
-    # https://68.media.tumblr.com/ee02048f5578595badc95905e17154b4/tumblr_inline_ofbr4452601sk4jd9_250.gif
-    # => https://media.tumblr.com/ee02048f5578595badc95905e17154b4/tumblr_inline_ofbr4452601sk4jd9_500.gif
-    #
-    # https://25.media.tumblr.com/tumblr_m2dxb8aOJi1rop2v0o1_500.png
-    # => https://media.tumblr.com/tumblr_m2dxb8aOJi1rop2v0o1_1280.png
-    #
-    # http://media.tumblr.com/0DNBGJovY5j3smfeQs8nB53z_400.jpg
-    # => https://media.tumblr.com/0DNBGJovY5j3smfeQs8nB53z_500.jpg
-    #
-    # http://media.tumblr.com/tumblr_m24kbxqKAX1rszquso1_1280.jpg
-    # => https://media.tumblr.com/tumblr_m24kbxqKAX1rszquso1_1280.jpg
-    def find_largest(url, sizes: SIZES)
-      if url =~ OLD_IMAGE
-        candidates = sizes.map do |size|
-          "https://media.tumblr.com/#{$~[:dir]}#{$~[:filename]}_#{size}.#{$~[:ext]}"
-        end
-
-        candidates.find do |candidate|
-          http_exists?(candidate)
-        end
-      elsif url =~ %r{/s\d+x\d+/(\w+\.\w+)\z}i
-        max_size = Integer.sqrt(Danbooru.config.max_image_resolution)
-        url = url.gsub(%r{/s\d+x\d+/\w+\.\w+\z}i, "/s#{max_size}x#{max_size}/#{$1}")
-
-        resp = http.cache(1.minute).headers(accept: "text/html").get(url).parse
-        resp.at("img[src*='/s#{max_size}x#{max_size}/']")["src"]
+    def find_largest(image_url)
+      parsed_image = Source::URL.parse(image_url)
+      if parsed_image.full_image_url.present?
+        image_url_html(parsed_image.full_image_url)&.at("img[src*='/#{parsed_image.directory}/']")&.[](:src)
+      elsif parsed_image.variants.present?
+        # Look for the biggest available version on media.tumblr.com. A bigger
+        # version may or may not exist.
+        parsed_image.variants.find { |variant| http_exists?(variant) }
       else
-        url
+        parsed_image.original_url
       end
+    end
+
+    def post_url_from_image_html
+      extracted = image_url_html(parsed_url)&.at("[href*='/post/']")&.[](:href)
+      Source::URL.parse(extracted)
+    end
+
+    def image_url_html(image_url)
+      resp = http.cache(1.minute).headers(accept: "text/html").get(image_url)
+      return nil if resp.code != 200
+      resp.parse
     end
 
     def inline_images
@@ -189,21 +130,21 @@ module Sources::Strategies
       html.css("img").map { |node| node["src"] }
     end
 
-    def blog_name
-      urls.map { |url| url[POST, :blog_name] }.compact.first
+    def artist_name
+      parsed_url.blog_name || parsed_referer&.blog_name || post_url_from_image_html&.blog_name
     end
 
-    def post_id
-      urls.map { |url| url[POST, :post_id] }.compact.first
+    def work_id
+      parsed_url.work_id || parsed_referer&.work_id || post_url_from_image_html&.work_id
     end
 
     def api_response
       return {} unless self.class.enabled?
-      return {} unless blog_name.present? && post_id.present?
+      return {} unless artist_name.present? && work_id.present?
 
       response = http.cache(1.minute).get(
-        "https://api.tumblr.com/v2/blog/#{blog_name}/posts",
-        params: { id: post_id, api_key: Danbooru.config.tumblr_consumer_key }
+        "https://api.tumblr.com/v2/blog/#{artist_name}/posts",
+        params: { id: work_id, api_key: Danbooru.config.tumblr_consumer_key }
       )
 
       return {} if response.code != 200


### PR DESCRIPTION
Also adds support for fetching source data from direct image urls when possible.

Example: https://64.media.tumblr.com/7c4d2c6843466f92c3dd0516e749ec35/tumblr_orwwptNBCE1wsfqepo2_540.jpg