### PR TITLE
sources: remove redundant comments

### DIFF
--- a/app/logical/source/url/art_station.rb
+++ b/app/logical/source/url/art_station.rb
@@ -1,30 +1,5 @@
 # frozen_string_literal: true
 
-# Page URLs:
-#
-# * https://www.artstation.com/artwork/04XA4
-# * https://www.artstation.com/artwork/cody-from-sf (old; redirects to https://www.artstation.com/artwork/3JJA)
-# * https://sa-dui.artstation.com/projects/DVERn
-# * https://dudeunderscore.artstation.com/projects/NoNmD?album_id=23041
-#
-# Profile URLs:
-#
-# * https://www.artstation.com/artist/sa-dui
-# * https://www.artstation.com/sa-dui
-# * https://sa-dui.artstation.com/
-# * https://hosi_na.artstation.com
-#
-# Image URLs
-#
-# * https://cdna.artstation.com/p/assets/images/images/005/804/224/large/titapa-khemakavat-sa-dui-srevere.jpg?1493887236
-# * https://cdnb.artstation.com/p/assets/images/images/014/410/217/smaller_square/bart-osz-bartosz1812041.jpg?1543866276
-# * https://cdna.artstation.com/p/assets/images/images/007/253/680/4k/ina-wong-demon-girl-done-ttd-comp.jpg?1504793833
-# * https://cdna.artstation.com/p/assets/covers/images/007/262/828/small/monica-kyrie-1.jpg?1504865060
-#
-# API URLs
-#
-# * https://www.artstation.com/projects/04XA4.json
-
 class Source::URL::ArtStation < Source::URL
   RESERVED_SUBDOMAINS = %w[www cdn cdna cdnb]
   IMAGE_SUBDOMAINS = %w[cdn cdna cdnb]

--- a/app/logical/source/url/fanbox.rb
+++ b/app/logical/source/url/fanbox.rb
@@ -1,37 +1,5 @@
 # frozen_string_literal: true
 
-# Image URLs
-#
-# * https://downloads.fanbox.cc/images/post/39714/JvjJal8v1yLgc5DPyEI05YpT.png (full res)
-# * https://downloads.fanbox.cc/images/post/39714/c/1200x630/JvjJal8v1yLgc5DPyEI05YpT.jpeg (sample)
-# * https://downloads.fanbox.cc/images/post/39714/w/1200/JvjJal8v1yLgc5DPyEI05YpT.jpeg (sample)
-# * https://fanbox.pixiv.net/images/post/39714/JvjJal8v1yLgc5DPyEI05YpT.png (old)
-#
-# Cover image URLs
-#
-# * https://pixiv.pximg.net/c/1200x630_90_a2_g5/fanbox/public/images/post/186919/cover/VCI1Mcs2rbmWPg0mmiTisovn.jpeg
-#
-# Profile image URLs
-#
-# * https://pixiv.pximg.net/c/400x400_90_a2_g5/fanbox/public/images/creator/1566167/profile/Ix6bnJmTaOAFZhXHLbWyIY1e.jpeg
-# * https://pixiv.pximg.net/fanbox/public/images/creator/1566167/profile/Ix6bnJmTaOAFZhXHLbWyIY1e.jpeg (dead URL type)
-# * https://pixiv.pximg.net/c/1620x580_90_a2_g5/fanbox/public/images/creator/1566167/cover/WPqKsvKVGRq4qUjKFAMi23Z5.jpeg
-# * https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/4635/cover/L6AZNneFuHW6r25CHHlkpHg4.jpeg
-#
-# Page URLs
-#
-# Username doesn't matter (Fanbox will redirect to the right post if the username is wrong).
-#
-# * https://omu001.fanbox.cc/posts/39714
-# * https://brllbrll.fanbox.cc/posts/626093 (R-18)
-# * https://www.fanbox.cc/@tsukiori/posts/1080657
-# * https://www.pixiv.net/fanbox/creator/1566167/post/39714 (old)
-#
-# Profile URLs
-#
-# * https://omu001.fanbox.cc
-# * https://www.pixiv.net/fanbox/creator/1566167
-#
 class Source::URL::Fanbox < Source::URL
   RESERVED_SUBDOMAINS = %w[www downloads]
 

--- a/app/logical/source/url/foundation.rb
+++ b/app/logical/source/url/foundation.rb
@@ -1,59 +1,12 @@
 # frozen_string_literal: true
-#
-# Page URLs
-#
-# * https://foundation.app/@mochiiimo/~/97376
-# * https://foundation.app/@mochiiimo/foundation/97376
-# * https://foundation.app/@KILLERGF/kgfgen/4
-# * https://foundation.app/@huwari/~/88982 (video)
-# * https://foundation.app/@asuka111art/dinner-with-cats-82426 (redirects to https://foundation.app/@asuka111art/foundation/82426)
-#
-# Even if the username is wrong, the ID is still fetched correctly. Example:
-#
+
+# Note: even if the username is wrong, the url is still resolved correctly. Example:
 # * https://foundation.app/@foundation/~/97376
 #
-# Full image URLs
-#
-# # Page: https://foundation.app/@mochiiimo/~/97376
-# * https://f8n-ipfs-production.imgix.net/QmX4MotNAAj9Rcyew43KdgGDxU1QtXemMHoUTNacMLLSjQ/nft.png
-# * https://ipfs.io/ipfs/QmX4MotNAAj9Rcyew43KdgGDxU1QtXemMHoUTNacMLLSjQ/nft.png
-#
-# # Page: https://foundation.app/@mochiiimo/~/128711
-# * https://f8n-production-collection-assets.imgix.net/0x3B3ee1931Dc30C1957379FAc9aba94D1C48a5405/128711/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png
-# * https://f8n-ipfs-production.imgix.net/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png
-# * https://ipfs.io/ipfs/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png
-#
-# # Page: https://foundation.app/@KILLERGF/kgfgen/4
-# * https://f8n-production-collection-assets.imgix.net/0xFb0a8e1bB97fD7231Cd73c489dA4732Ae87995F0/4/nft.png
-# * https://ipfs.io/ipfs/QmbdxcWQ9bg6JUMfK4ubpW2rGDFA8qfTidoCaf6GKMqvr7/nft.png
-#
-# Video URLs
-#
-# # Page: https://foundation.app/@huwari/foundation/88982
-# * https://assets.foundation.app/7i/gs/QmU8bbsjaVQpEKMDWbSZdDD6GsPmRYBhQtYRn8bEGv7igs/nft_q4.mp4
-# * https://f8n-ipfs-production.imgix.net/QmU8bbsjaVQpEKMDWbSZdDD6GsPmRYBhQtYRn8bEGv7igs/nft.mp4
-# * https://ipfs.io/ipfs/QmU8bbsjaVQpEKMDWbSZdDD6GsPmRYBhQtYRn8bEGv7igs/nft.mp4
-#
-# Sample image URLs
-#
-# * https://f8n-ipfs-production.imgix.net/QmX4MotNAAj9Rcyew43KdgGDxU1QtXemMHoUTNacMLLSjQ/nft.png?q=80&auto=format%2Ccompress&cs=srgb&max-w=1680&max-h=1680
-# * https://f8n-production-collection-assets.imgix.net/0x3B3ee1931Dc30C1957379FAc9aba94D1C48a5405/128711/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png?q=80&auto=format%2Ccompress&cs=srgb&h=640
-#
-# Profile URLs
-#
-# Profile urls seem to accept any character in them, even no character at all:
-#
-# * https://foundation.app/@mochiiimo
+# Unsupported patterns:
 # * https://foundation.app/@ <- This seems to be a novelty account.
-#
-# Public key profile URLs:
-#
-# * https://foundation.app/0x7E2ef75C0C09b2fc6BCd1C68B6D409720CcD58d2 (@mochiiimo)
-#
-# The @ is optional:
-#
-# * https://foundation.app/mochiiimo
-#
+# * https://foundation.app/mochiiimo <- no @
+
 class Source::URL::Foundation < Source::URL
   attr_reader :username, :token_id, :work_id, :hash
 

--- a/app/logical/source/url/hentai_foundry.rb
+++ b/app/logical/source/url/hentai_foundry.rb
@@ -1,36 +1,5 @@
 # frozen_string_literal: true
 
-# Image URLs
-#
-# * http://pictures.hentai-foundry.com/a/Afrobull/795025/Afrobull-795025-kuroeda.png
-# * http://pictures.hentai-foundry.com/_/-MadKaiser-/532792/-MadKaiser--532792-FFXIV_Miqote.png
-# * http://pictures.hentai-foundry.com/p/PalomaP/855497/PalomaP-855497-Boooo..._bs..jpg
-# * http://pictures.hentai-foundry.com//s/soranamae/363663.jpg
-# * http://www.hentai-foundry.com/piccies/d/dmitrys/1183.jpg
-#
-# Page URLs
-#
-# * http://www.hentai-foundry.com/pictures/user/Afrobull/795025
-# * http://www.hentai-foundry.com/pictures/user/Afrobull/795025/kuroeda
-# * http://www.hentai-foundry.com/pictures/user/Ganassa/457176/LOL-Swimsuit---Caitlyn-reworked-nude-ver.
-# * http://www.hentai-foundry.com/pic-795025
-# * http://www.hentai-foundry.com/pic-149160.html
-# * http://www.hentai-foundry.com/pic-149160.php
-# * http://www.hentai-foundry.com/pic_full-66045.php
-#
-# Preview URLs
-#
-# * https://thumbs.hentai-foundry.com/thumb.php?pid=795025&size=350
-#
-# Profile URLs
-#
-# * https://www.hentai-foundry.com/user/kajinman/profile
-# * https://www.hentai-foundry.com/pictures/user/kajinman
-# * https://www.hentai-foundry.com/pictures/user/kajinman/scraps
-# * https://www.hentai-foundry.com/user/J-likes-to-draw/profile
-# * http://www.hentai-foundry.com/user-RockCandy.php
-# * http://www.hentai-foundry.com/profile-sawao.php
-#
 class Source::URL::HentaiFoundry < Source::URL
   attr_reader :username, :work_id
 

--- a/app/logical/source/url/lofter.rb
+++ b/app/logical/source/url/lofter.rb
@@ -1,30 +1,5 @@
 # frozen_string_literal: true
 
-# Image URLs
-#
-# # sample
-# * https://imglf3.lf127.net/img/S1d2QlVsWkJhSW1qcnpIS0ZSa3ZJSzFCWFlnUWgzb01DcUdpT1lreG5yQjJVMkhGS09HNGR3PT0.png?imageView&thumbnail=1680x0&quality=96&stripmeta=0
-#
-# # full size
-# * https://imglf3.lf127.net/img/S1d2QlVsWkJhSW1qcnpIS0ZSa3ZJSzFCWFlnUWgzb01DcUdpT1lreG5yQjJVMkhGS09HNGR3PT0.png
-# * http://imglf0.nosdn.127.net/img/cHl3bXNZdDRaaHBnNWJuN1Y4OXBqR01CeVBZSVNmU2FWZWtHc1h4ZTZiUGxlRzMwZnFDM1JnPT0.jpg (404)
-#
-# Page URLs
-#
-# * https://gengar563.lofter.com/post/1e82da8c_1c98dae1b
-# * https://yuli031458.lofter.com/post/3163d871_1cbdc5f6d (different theme/css selectors)
-# * https://ssucrose.lofter.com/post/1d30f3e4_1cc58e9f0 (another different theme)
-# * https://zuodaoxing.lofter.com/post/30b9c9c3_1cd15b686 (another theme)
-#
-# Profile URLs
-#
-# * http://gengar563.lofter.com
-#
-# Non-profile URLs
-#
-# * https://i.lofter.com
-# * https://www.lofter.com
-#
 class Source::URL::Lofter < Source::URL
   RESERVED_SUBDOMAINS = %w[www.lofter.com i.lofter.com]
 

--- a/app/logical/source/url/mastodon.rb
+++ b/app/logical/source/url/mastodon.rb
@@ -1,26 +1,10 @@
 # frozen_string_literal: true
 
-# Image URLs
-#
-# * https://img.pawoo.net/media_attachments/files/001/297/997/small/c4272a09570757c2.png (page: https://pawoo.net/@evazion/19451018)
-# * https://img.pawoo.net/media_attachments/files/001/297/997/original/c4272a09570757c2.png
-#
-# * https://pawoo.net/media/lU2uV7C1MMQSb1czwvg (=> https://img.pawoo.net/media_attachments/files/001/300/923/original/cd18271f0077e789.png)
-#
-# Page URLs
-#
-# * https://pawoo.net/@evazion/19451018
-# * https://pawoo.net/web/statuses/19451018
-#
-# Account URLs
-#
-# * https://pawoo.net/@evazion
-# * https://pawoo.net/web/accounts/47806
+# Unparsed:
 #
 # OAuth URL: (Note: ID is different from account URL ID)
-#
 # * https://pawoo.net/oauth_authentications/17230064
-#
+
 class Source::URL::Mastodon < Source::URL
   attr_reader :username, :user_id, :work_id, :full_image_url
 

--- a/app/logical/source/url/moebooru.rb
+++ b/app/logical/source/url/moebooru.rb
@@ -1,36 +1,5 @@
 # frozen_string_literal: true
 
-# Original images:
-#
-# * https://yande.re/image/b4b1d11facd1700544554e4805d47bb6/.png
-# * https://files.yande.re/image/e4c2ba38de88ff1640aaebff84c84e81/469784.jpg
-# * https://files.yande.re/image/2a5d1d688f565cb08a69ecf4e35017ab/yande.re%20349790%20breast_hold%20kurashima_tomoyasu%20mahouka_koukou_no_rettousei%20naked%20nipples.jpg
-# * https://ayase.yande.re/image/2d0d229fd8465a325ee7686fcc7f75d2/yande.re%20192481%20animal_ears%20bunny_ears%20garter_belt%20headphones%20mitha%20stockings%20thighhighs.jpg
-# * https://yuno.yande.re/image/1764b95ae99e1562854791c232e3444b/yande.re%20281544%20cameltoe%20erect_nipples%20fundoshi%20horns%20loli%20miyama-zero%20sarashi%20sling_bikini%20swimsuits.jpg
-# * https://konachan.com/image/5d633771614e4bf5c17df19a0f0f333f/Konachan.com%20-%20270807%20black_hair%20bokuden%20clouds%20grass%20landscape%20long_hair%20original%20phone%20rope%20scenic%20seifuku%20skirt%20sky%20summer%20torii%20tree.jpg
-#
-# Jpeg sample images (full size is .png):
-#
-# * https://yande.re/jpeg/22577d2344fe694cf47f80563031b3cd.jpg
-# * https://yande.re/jpeg/0c9ec0ffcaa40470093cb44c3fd40056/yande.re%2064649%20animal_ears%20cameltoe%20fixme%20nekomimi%20nipples%20ryohka%20school_swimsuit%20see_through%20shiraishi_nagomi%20suzuya%20swimsuits%20tail%20thighhighs.jpg
-# * https://konachan.com/jpeg/e2e2994bae738ff52fff7f4f50b069d5/Konachan.com%20-%20270803%20banishment%20bicycle%20grass%20group%20male%20night%20original%20rooftop%20scenic%20signed%20stars%20tree.jpg
-#
-# Sample images (full size is .png or .jpg):
-#
-# * https://yande.re/sample/ceb6a12e87945413a95b90fada406f91/.jpg
-# * https://files.yande.re/sample/0d79447ce2c89138146f64ba93633568/yande.re%20290757%20sample%20seifuku%20thighhighs%20tsukudani_norio.jpg
-# * https://konachan.com/sample/e2e2994bae738ff52fff7f4f50b069d5/Konachan.com%20-%20270803%20sample.jpg
-#
-# Preview images:
-#
-# * https://assets.yande.re/data/preview/7e/cf/7ecfdead705d7b956b26b1d37b98d089.jpg
-# * https://konachan.com/data/preview/5d/63/5d633771614e4bf5c17df19a0f0f333f.jpg
-#
-# Post pages:
-#
-# * https://yande.re/post/show/3
-# * https://konachan.com/post/show/270803/banishment-bicycle-grass-group-male-night-original
-
 class Source::URL::Moebooru < Source::URL
   attr_reader :work_id, :md5, :original_file_ext
 

--- a/app/logical/source/url/newgrounds.rb
+++ b/app/logical/source/url/newgrounds.rb
@@ -1,23 +1,6 @@
 # frozen_string_literal: true
 
-# Image Urls
-#
-# * https://art.ngfiles.com/images/1543000/1543982_natthelich_pandora-2.jpg?f1607971817
-# * https://art.ngfiles.com/images/1033000/1033622_natthelich_fire-emblem-marth-plus-progress-pic.png?f1569487181
-#
-# * https://www.newgrounds.com/art/view/natthelich/weaver (page)
-# * https://art.ngfiles.com/images/1520000/1520217_natthelich_weaver.jpg?f1606365031
-# * https://art.ngfiles.com/comments/57000/iu_57615_7115981.jpg
-#
-# Thumbnail URLs
-#
-# * https://art.ngfiles.com/thumbnails/1543000/1543982_full.png?f1607971901
-# * https://art.ngfiles.com/thumbnails/1254000/1254985.png?f1588263349
-#
-# Page URLs
-#
-# * https://www.newgrounds.com/art/view/puddbytes/costanza-at-bat
-# * https://www.newgrounds.com/art/view/natthelich/weaver (multiple)
+# Unsupported:
 #
 # Video URLs
 #
@@ -31,18 +14,6 @@
 #
 # * https://www.newgrounds.com/portal/view/225625 (page)
 # * https://uploads.ungrounded.net/225000/225625_colormedressup.swf?1111143751 (file)
-#
-# Other URLs
-#
-# * https://www.newgrounds.com/reviews/portal/1543982/4/
-# * https://www.newgrounds.com/reviews/portal/1543982/4/score/1
-# * https://www.newgrounds.com/content/share/1543982/4/
-# * https://www.newgrounds.com/favorites/content/who/1543982/4
-#
-# Profile URLs
-#
-# * https://natthelich.newgrounds.com
-# * https://natthelich.newgrounds.com/art
 #
 class Source::URL::Newgrounds < Source::URL
   attr_reader :username, :work_id, :work_title

--- a/app/logical/source/url/nijie.rb
+++ b/app/logical/source/url/nijie.rb
@@ -1,18 +1,5 @@
 # frozen_string_literal: true
 
-# Image URLs:
-#
-# * https://pic03.nijie.info/nijie_picture/28310_20131101215959.jpg (page: https://www.nijie.info/view.php?id=64240)
-# * https://pic03.nijie.info/nijie_picture/236014_20170620101426_0.png (page: https://www.nijie.info/view.php?id=218856)
-# * https://pic01.nijie.info/nijie_picture/diff/main/218856_0_236014_20170620101329.png (page: http://nijie.info/view.php?id=218856)
-# * https://pic01.nijie.info/nijie_picture/diff/main/218856_1_236014_20170620101330.png
-# * https://pic05.nijie.info/nijie_picture/diff/main/559053_20180604023346_1.png (page: http://nijie.info/view_popup.php?id=265428#diff_2)
-# * https://pic04.nijie.info/nijie_picture/diff/main/287736_161475_20181112032855_1.png (page: http://nijie.info/view_popup.php?id=287736#diff_2)
-# * https://pic.nijie.net/03/nijie_picture/236014_20170620101426_0.png (page: https://www.nijie.info/view.php?id=218856)
-#
-# * https://pic.nijie.net/07/nijie/17/95/728995/illust/0_0_403fdd541191110c_c25585.jpg
-# * https://pic.nijie.net/06/nijie/17/14/236014/illust/218856_1_7646cf57f6f1c695_f2ed81.png (page: https://nijie.info/view.php?id=218856)
-#
 # Unhandled:
 #
 # * https://pic01.nijie.info/nijie_picture/20120211210359.jpg
@@ -21,35 +8,6 @@
 # * https://pic05.nijie.info/dojin_main/dojin_sam/1_2768_20180429004232.png
 # * https://pic04.nijie.info/horne_picture/diff/main/56095_20160403221810_0.jpg
 # * https://pic04.nijie.info/omata/4829_20161128012012.png (page: http://nijie.info/view_popup.php?id=33224#diff_3)
-#
-# Preview URLs:
-#
-# * https://pic01.nijie.info/__rs_l120x120/nijie_picture/diff/main/218856_0_236014_20170620101329.png
-# * https://pic03.nijie.info/__rs_l120x120/nijie_picture/236014_20170620101426_0.png
-# * https://pic03.nijie.info/__rs_l170x170/nijie_picture/236014_20170620101426_0.png
-# * https://pic03.nijie.info/__rs_l650x650/nijie_picture/236014_20170620101426_0.png
-# * https://pic03.nijie.info/__rs_cns350x350/nijie_picture/236014_20170620101426_0.png
-# * https://pic03.nijie.info/small_light(dh=150,dw=150,q=100)/nijie_picture/236014_20170620101426_0.png
-#
-# Page URLs:
-#
-# * https://nijie.info/view.php?id=167755 (deleted post)
-# * https://nijie.info/view.php?id=218856
-# * https://nijie.info/view_popup.php?id=218856
-# * https://nijie.info/view_popup.php?id=218856#diff_1
-# * https://www.nijie.info/view.php?id=218856
-# * https://sp.nijie.info/view.php?id=218856
-#
-# Profile URLs
-#
-# * https://nijie.info/members.php?id=236014
-# * https://nijie.info/members_illust.php?id=236014
-#
-# Doujin
-#
-# * http://nijie.info/view.php?id=384548
-# * http://pic.nijie.net/01/dojin_main/dojin_sam/20120213044700%E3%82%B3%E3%83%94%E3%83%BC%20%EF%BD%9E%200011%E3%81%AE%E3%82%B3%E3%83%94%E3%83%BC.jpg (NSFW)
-# * http://pic.nijie.net/01/__rs_l120x120/dojin_main/dojin_sam/20120213044700%E3%82%B3%E3%83%94%E3%83%BC%20%EF%BD%9E%200011%E3%81%AE%E3%82%B3%E3%83%94%E3%83%BC.jpg
 
 class Source::URL::Nijie < Source::URL
   attr_reader :work_id, :user_id

--- a/app/logical/source/url/plurk.rb
+++ b/app/logical/source/url/plurk.rb
@@ -1,32 +1,5 @@
 # frozen_string_literal: true
 
-# Notes
-#
-# * Posts can have up to 10 images.
-# * Artists commonly post extra images by replying to their own post.
-# * Adult posts are hidden for logged out users. The main images can be found by
-#   scraping a <script> tag, but an API call is needed to get the images in the replies.
-#
-# Image URLs
-#
-# * https://images.plurk.com/5wj6WD0r6y4rLN0DL3sqag.jpg
-#
-# Thumbnail URLs
-#
-# * https://images.plurk.com/mx_5wj6WD0r6y4rLN0DL3sqag.jpg
-#
-# Page URLs
-#
-# * https://www.plurk.com/p/om6zv4 (non-adult, single image)
-# * https://www.plurk.com/p/okxzae (non-adult, multiple images, with replies)
-# * https://www.plurk.com/p/omc64y (adult, multiple images, with replies)
-# * https://www.plurk.com/m/p/omc64y
-#
-# Profile URLs
-#
-# * https://www.plurk.com/redeyehare
-# * https://www.plurk.com/m/redeyehare
-
 class Source::URL::Plurk < Source::URL
   attr_reader :username, :work_id
 

--- a/app/logical/source/url/skeb.rb
+++ b/app/logical/source/url/skeb.rb
@@ -1,50 +1,5 @@
 # frozen_string_literal: true
 
-# Image URLs
-#
-## Non-watermarked:
-#
-# # Page: https://skeb.jp/@OrvMZ/works/3
-# * https://skeb.imgix.net/requests/199886_0?bg=%23fff&auto=format&w=800&s=5a6a908ab964fcdfc4713fad179fe715
-#
-## Watermarked:
-#
-# * https://skeb.imgix.net/requests/73290_0?bg=%23fff&auto=format&txtfont=bold&txtshad=70&txtclr=BFFFFFFF&txtalign=middle%2Ccenter&txtsize=150&txt=SAMPLE&w=800&s=4843435cff85d623b1f657209d131526
-# * https://skeb.imgix.net/uploads/origins/04d62c2f-e396-46f9-903a-3ca8bd69fc7c?bg=%23fff&auto=format&w=800&s=966c5d0389c3b94dc36ac970f812bef4 (new format)
-#
-## Full Size (found in commissioner_upload):
-#
-# # Page: https://skeb.jp/@matsuda_Toki/works/101
-# * https://skeb.imgix.net/requests/53269_1?bg=%23fff&fm=png&dl=53269.png&w=1.0&h=1.0&s=44588ea9c41881049e392adb1df21cce
-#
-# The signature is required and tied to the parameters. Doesn't seem like it's possible to reverse engineer it to remove the watermark, unfortunately.
-#
-# Video URLs
-#
-# # Page: https://skeb.jp/@kaisouafuro/works/112
-# * https://skeb-production.s3.ap-northeast-1.amazonaws.com/uploads/outputs/20f9d68f-50ec-44ae-8630-173fc38a2d6a?response-content-disposition=attachment%3B%20filename%3D%22458093-1.output.mp4%22%3B%20filename%2A%3DUTF-8%27%27458093-1.output.mp4&response-content-type=video%2Fmp4&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIVPUTFQBBL7UDSUA%2F20220221%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Date=20220221T200057Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=7f028cfd9a56344cf1d42410063fad3ef30a1e47b83cef047247e0c37df01df0
-#
-# Page URLs
-#
-# * https://skeb.jp/@OrvMZ/works/3 (non-watermarked)
-# * https://skeb.jp/@OrvMZ/works/1 (separated request and client's message after delivery. We can't get the latter)
-# * https://skeb.jp/@asanagi/works/16 (age-restricted, watermarked)
-# * https://skeb.jp/@asanagi/works/6 (private, returns 404)
-# * https://skeb.jp/@nasuno42/works/30 (multi-image post)
-#
-# Profile URLs
-#
-# Since skeb forces login through twitter, usernames are the same as twitter
-#
-# * https://skeb.jp/@asanagi
-#
-# API URLs
-#
-## Must send "Authorization: Bearer null"
-#
-# * https://skeb.jp/api/users/kaisouafuro
-# * https://skeb.jp/api/users/kaisouafuro/works/112
-#
 class Source::URL::Skeb < Source::URL
   attr_reader :username, :work_id, :image_id, :image_uuid
 
@@ -59,14 +14,18 @@ class Source::URL::Skeb < Source::URL
     in "skeb.jp", /^@/ => username
       @username = username.delete_prefix("@")
 
-    # https://skeb.jp/@OrvMZ/works/3
+    # https://skeb.jp/@OrvMZ/works/3 (non-watermarked)
+    # https://skeb.jp/@OrvMZ/works/1 (separated request and client's message after delivery)
+    # https://skeb.jp/@asanagi/works/16 (age-restricted, watermarked)
+    # https://skeb.jp/@asanagi/works/6 (private, returns 404)
+    # https://skeb.jp/@nasuno42/works/30 (multi-image post)
     in "skeb.jp", /^@/ => username, "works", work_id
       @username = username.delete_prefix("@")
       @work_id = work_id
 
     # https://skeb.imgix.net/requests/199886_0?bg=%23fff&auto=format&w=800&s=5a6a908ab964fcdfc4713fad179fe715
     # https://skeb.imgix.net/requests/73290_0?bg=%23fff&auto=format&txtfont=bold&txtshad=70&txtclr=BFFFFFFF&txtalign=middle%2Ccenter&txtsize=150&txt=SAMPLE&w=800&s=4843435cff85d623b1f657209d131526
-    # https://skeb.imgix.net/requests/53269_1?bg=%23fff&fm=png&dl=53269.png&w=1.0&h=1.0&s=44588ea9c41881049e392adb1df21cce
+    # https://skeb.imgix.net/requests/53269_1?bg=%23fff&fm=png&dl=53269.png&w=1.0&h=1.0&s=44588ea9c41881049e392adb1df21cce (full size)
     in "imgix.net", "requests", image_id
       @image_id = image_id
 

--- a/app/logical/source/url/twit_pic.rb
+++ b/app/logical/source/url/twit_pic.rb
@@ -20,7 +20,7 @@
 # Profile URLs:
 #
 # * http://twitpic.com/photos/Type10TK (dead)
-#
+
 class Source::URL::TwitPic < Source::URL
   attr_reader :base36_id
 

--- a/app/logical/source/url/twitter.rb
+++ b/app/logical/source/url/twitter.rb
@@ -1,31 +1,6 @@
 # frozen_string_literal: true
 
-# Page URLs:
-#
-# * https://twitter.com/motty08111213
-# * https://twitter.com/motty08111213/status/943446161586733056
-# * https://twitter.com/motty08111213/status/943446161586733056?s=19
-# * https://twitter.com/i/web/status/943446161586733056
-#
-# * https://mobile.twitter.com/motty08111213
-# * https://mobile.twitter.com/motty08111213/status/943446161586733056
-# * https://mobile.twitter.com/i/web/status/943446161586733056
-#
-# * https://twitter.com/Kekeflipnote/status/1496555599718498319/video/1
-# * https://twitter.com/sato_1_11/status/1496489742791475201/photo/2
-#
-# Sample image URLs:
-#
-# * https://pbs.twimg.com/media/FMSZOa6aQAMIuRD.jpg
-# * https://pbs.twimg.com/media/FMSZOa6aQAMIuRD.jpg?name=large
-# * https://pbs.twimg.com/media/FMSZOa6aQAMIuRD?format=jpg&name=large
-# * https://pbs.twimg.com/media/FMSZOa6aQAMIuRD?format=jpg&name=small
-#
-# Full image URLs:
-#
-# * https://pbs.twimg.com/media/FMSZOa6aQAMIuRD.jpg:orig
-# * https://pbs.twimg.com/media/FMSZOa6aQAMIuRD.jpg?name=orig
-# * https://pbs.twimg.com/media/FMSZOa6aQAMIuRD?format=jpg&name=orig
+# Unhandled:
 #
 # Video URLs:
 #
@@ -34,12 +9,6 @@
 # * https://video.twimg.com/ext_tw_video/1496554514312269828/pu/vid/360x270/SygSrUcDpCr1AnOf.mp4?tag=12
 # * https://video.twimg.com/ext_tw_video/1496554514312269828/pu/vid/960x720/wiC1XIw8QehhL5JL.mp4?tag=12
 # * https://video.twimg.com/ext_tw_video/1496554514312269828/pu/vid/480x360/amWjOw0MmLdnPMPB.mp4?tag=12
-#
-# Video thumbnail URLs:
-#
-# * https://pbs.twimg.com/tweet_video_thumb/ETkN_L3X0AMy1aT.jpg
-# * https://pbs.twimg.com/ext_tw_video_thumb/1496554514312269828/pu/img/Asrdh3Ji-EqYOYHv.jpg
-# * https://pbs.twimg.com/amplify_video_thumb/1215590775364259840/img/lolCkEEioFZTb5dl.jpg
 #
 # Profile image URLs:
 #
@@ -50,7 +19,7 @@
 #
 # * https://t.co/Dxn7CuVErW => https://twitter.com/Kekeflipnote/status/1496555599718498319/video/1
 # * https://pic.twitter.com/Dxn7CuVErW => https://twitter.com/Kekeflipnote/status/1496555599718498319/video/1
-#
+
 class Source::URL::Twitter < Source::URL
   # Twitter provides a list of reserved usernames but it's inaccurate; some names ('intent') aren't
   # included and other names in the list aren't actually reserved.
@@ -71,6 +40,7 @@ class Source::URL::Twitter < Source::URL
       @status_id = status_id
 
     # https://twitter.com/motty08111213/status/943446161586733056
+    # https://twitter.com/motty08111213/status/943446161586733056?s=19
     # https://twitter.com/Kekeflipnote/status/1496555599718498319/video/1
     # https://twitter.com/sato_1_11/status/1496489742791475201/photo/2
     in "twitter.com", username, "status", status_id, *rest
@@ -84,6 +54,8 @@ class Source::URL::Twitter < Source::URL
     # https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg
     # https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg:small
     # https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb?format=jpg&name=900x900
+    #
+    # video thumbnail urls:
     # https://pbs.twimg.com/tweet_video_thumb/ETkN_L3X0AMy1aT.jpg
     # https://pbs.twimg.com/ext_tw_video_thumb/1243725361986375680/pu/img/JDA7g7lcw7wK-PIv.jpg
     # https://pbs.twimg.com/amplify_video_thumb/1215590775364259840/img/lolCkEEioFZTb5dl.jpg

--- a/app/logical/sources/strategies/plurk.rb
+++ b/app/logical/sources/strategies/plurk.rb
@@ -15,6 +15,16 @@ module Sources
       end
 
       def image_urls
+        # * Posts can have up to 10 images.
+        # * Artists commonly post extra images by replying to their own post.
+        # * Adult posts are hidden for logged out users. The main images can be found by
+        #   scraping a <script> tag, but an API call is needed to get the images in the replies.
+        #
+        # Examples:
+        # * https://www.plurk.com/p/om6zv4 (non-adult, single image)
+        # * https://www.plurk.com/p/okxzae (non-adult, multiple images, with replies)
+        # * https://www.plurk.com/p/omc64y (adult, multiple images, with replies)
+
         if parsed_url.image_url?
           [url]
         elsif page_json["porn"]


### PR DESCRIPTION
These comments are already present under the parse blocks, so the huge walls of text before the code are not needed anymore.

I left the twitpic ones since they're useful and moved around some info for plurk and skeb to more adequate places. The rest of the information was already present in one way or another elsewhere.