### PR TITLE
Modqueue: support variable size thumbnails

### DIFF
--- a/app/controllers/modqueue_controller.rb
+++ b/app/controllers/modqueue_controller.rb
@@ -21,6 +21,8 @@ class ModqueueController < ApplicationController
     @copyright_tags = @tags.select(&:copyright?).sort_by(&:overlap_count).reverse.take(10)
     @character_tags = @tags.select(&:character?).sort_by(&:overlap_count).reverse.take(10)
 
+    @preview_size = params[:size].presence || cookies[:post_preview_size].presence || PostPreviewComponent::DEFAULT_SIZE
+
     respond_with(@posts)
   end
 end

--- a/app/views/modqueue/_post.html.erb
+++ b/app/views/modqueue/_post.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div id: "post-#{post.id}", **PostPreviewComponent.new(post: post).article_attrs("post mod-queue-preview column-container") do %>
   <aside class="column column-shrink">
-    <%= post_preview(post, show_size: true, show_deleted: true) %>
+    <%= post_preview(post, size: @preview_size, show_size: true, show_deleted: true) %>
   </aside>
 
   <section class="column column-expand">

--- a/app/views/modqueue/index.html.erb
+++ b/app/views/modqueue/index.html.erb
@@ -11,7 +11,10 @@
 <% end %>
 
 <% content_for(:top_content) do %>
-  <h1>Moderation Queue</h1>
+  <div class="flex mb-4">
+    <h1 class="flex-grow-1">Moderation Queue</h1>
+    <%= render PreviewSizeMenuComponent.new(current_size: @preview_size) %>
+  </div>
 
   <div id="moderation-guideline" class="fixed-width-container">
     <h2>Deletion Guidelines</h2>


### PR DESCRIPTION
Fixes #5029. I used PostPreviewComponent::DEFAULT_SIZE since PostGalleryComponent::PostGalleryComponent says it's to be used for a gallery, and modqueue entries are not arranged in a gallery, though I'm not 100% sure if that's correct.

![image](https://user-images.githubusercontent.com/12946050/157741388-3b4cb243-7da5-49ea-aaae-e456c6f1ec4c.png)
