### PR TITLE
Add tag category: deprecated

### DIFF
--- a/app/components/tag_list_component.rb
+++ b/app/components/tag_list_component.rb
@@ -40,6 +40,6 @@ class TagListComponent < ApplicationComponent
   end
 
   def is_underused_tag?(tag)
-    tag.post_count <= 1 && tag.general? && tag.name !~ /_\((cosplay|style)\)\z/
+    tag.post_count <= 1 && (tag.general? || tag.deprecated?) && tag.name !~ /_\((cosplay|style)\)\z/
   end
 end

--- a/app/components/tag_list_component/tag_list_component.html+categorized.erb
+++ b/app/components/tag_list_component/tag_list_component.html+categorized.erb
@@ -1,7 +1,7 @@
 <div class="tag-list categorized-tag-list">
   <% categorized_tags(TagCategory.split_header_list).each do |category_name, tags| %>
     <h3 class="<%= category_name %>-tag-list">
-      <%= category_name.capitalize.pluralize(tags) %>
+      <%= TagCategory.title_map[category_name] %>
     </h3>
 
     <ul class="<%= category_name %>-tag-list">

--- a/app/javascript/src/styles/base/040_colors.css
+++ b/app/javascript/src/styles/base/040_colors.css
@@ -295,11 +295,13 @@ html {
   --general-tag-hover-color: var(--link-hover-color);
   --meta-tag-color: var(--orange-3);
   --meta-tag-hover-color: var(--orange-2);
+  --deprecated-tag-color: var(--grey-5);
+  --deprecated-tag-hover-color: var(--grey-3);
 
   --user-admin-color: var(--red-5);
   --user-moderator-color: var(--character-tag-color);
   --user-builder-color: var(--copyright-tag-color);
-  --user-platinum-color: var(--grey-5);
+  --user-platinum-color: var(--deprecated-tag-color);
   --user-gold-color: var(--meta-tag-color);
   --user-member-color: var(--general-tag-color);
   --user-restricted-color: var(--general-tag-color);
@@ -500,11 +502,13 @@ body[data-current-user-theme="dark"] {
   --general-tag-hover-color: var(--azure-3);
   --meta-tag-color: var(--yellow-2);
   --meta-tag-hover-color: var(--yellow-1);
+  --deprecated-tag-color: var(--grey-3);
+  --deprecated-tag-hover-color: var(--grey-1);
 
   --user-admin-color: var(--artist-tag-color);
   --user-moderator-color: var(--character-tag-color);
   --user-builder-color: var(--copyright-tag-color);
-  --user-platinum-color: var(--grey-3);
+  --user-platinum-color: var(--deprecated-tag-color);
   --user-gold-color: var(--meta-tag-color);
   --user-member-color: var(--general-tag-color);
   --user-restricted-color: var(--general-tag-color);

--- a/app/javascript/src/styles/common/tags.scss
+++ b/app/javascript/src/styles/common/tags.scss
@@ -62,3 +62,16 @@
     color: var(--meta-tag-hover-color);
   }
 }
+
+.tag-type-6 a, a.tag-type-6 {
+  color: var(--deprecated-tag-color);
+  color: var(--deprecated-tag-hover-color);
+
+  &:link, &:visited {
+    color: var(--deprecated-tag-color);
+  }
+
+  &:hover {
+    color: var(--deprecated-tag-hover-color);
+  }
+}

--- a/app/logical/discord_slash_command/wiki_command.rb
+++ b/app/logical/discord_slash_command/wiki_command.rb
@@ -47,7 +47,7 @@ class DiscordSlashCommand
         search = "#{tag.name} rating:safe everyone copytags:<5 -parody -crossover"
       elsif tag.character?
         search = "#{tag.name} rating:safe solo chartags:<5"
-      else # meta or general
+      else # meta, deprecated or general
         search = "#{tag.name} rating:safe -animated -6+girls -comic"
       end
 

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -31,7 +31,7 @@ class PostQueryBuilder
   # allow e.g. `deleted_comments` as a synonym for `deleted_comment_count`
   COUNT_METATAG_SYNONYMS = COUNT_METATAGS.map { |str| str.delete_suffix("_count").pluralize }
 
-  # gentags, arttags, copytags, chartags, metatags
+  # gentags, arttags, copytags, chartags, metatags, depretags
   CATEGORY_COUNT_METATAGS = TagCategory.short_name_list.map { |category| "#{category}tags" }
 
   METATAGS = %w[

--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -9,28 +9,31 @@ module TagCategory
   # Returns a hash mapping various tag categories to a numerical value.
   def mapping
     {
-      "ch" => 4,
-      "co" => 3,
-      "gen" => 0,
-      "char" => 4,
-      "copy" => 3,
-      "art" => 1,
-      "meta" => 5,
       "general" => 0,
-      "character" => 4,
-      "copyright" => 3,
+      "gen" => 0,
       "artist" => 1,
+      "art" => 1,
+      "copyright" => 3,
+      "copy" => 3,
+      "co" => 3,
+      "character" => 4,
+      "char" => 4,
+      "ch" => 4,
+      "meta" => 5,
+      "deprecated" => 6,
+      "depre" => 6,
     }
   end
 
   # The order of tags in dropdown lists.
   def canonical_mapping
     {
-      "Artist"    => 1,
-      "Copyright" => 3,
-      "Character" => 4,
-      "General"   => 0,
-      "Meta"      => 5,
+      "Artist"      => 1,
+      "Copyright"   => 3,
+      "Character"   => 4,
+      "General"     => 0,
+      "Meta"        => 5,
+      "Deprecated"  => 6,
     }
   end
 
@@ -38,36 +41,40 @@ module TagCategory
   def reverse_mapping
     {
       0 => "general",
-      4 => "character",
-      3 => "copyright",
       1 => "artist",
+      3 => "copyright",
+      4 => "character",
       5 => "meta",
+      6 => "deprecated",
     }
   end
 
   def short_name_mapping
     {
-      "art"  => "artist",
-      "copy" => "copyright",
-      "char" => "character",
-      "gen"  => "general",
-      "meta" => "meta",
+      "art"   => "artist",
+      "copy"  => "copyright",
+      "char"  => "character",
+      "gen"   => "general",
+      "meta"  => "meta",
+      "depre" => "deprecated",
     }
   end
 
-  # Returns a hash mapping for related tag buttons (javascripts/related_tag.js.erb)
-  def related_button_mapping
+  # Returns a hash mapping for titleization of a category name.
+  # This is needed because pluralize thinks the plural of "deprecated" is "deprecateds"
+  def title_map
     {
       "general" => "General",
       "character" => "Characters",
       "copyright" => "Copyrights",
       "artist" => "Artists",
-      "meta" => nil,
+      "meta" => "Meta",
+      "deprecated" => "Deprecated",
     }
   end
 
   def categories
-    %w[general character copyright artist meta]
+    %w[general character copyright artist meta deprecated]
   end
 
   def category_ids
@@ -75,17 +82,17 @@ module TagCategory
   end
 
   def short_name_list
-    %w[art copy char gen meta]
+    %w[art copy char gen meta depre]
   end
 
   # The order of tags on the post page tag list.
   def split_header_list
-    %w[artist copyright character general meta]
+    %w[artist copyright character general deprecated meta]
   end
 
   # The order of tags inside the tag edit box, and on the comments page.
   def categorized_list
-    %w[artist copyright character meta general]
+    %w[artist copyright character meta deprecated general]
   end
 
   # The order of tags in the related tag buttons.

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -137,7 +137,7 @@ class Tag < ApplicationRecord
       end
     end
 
-    # define artist?, general?, character?, copyright?, meta?
+    # define artist?, general?, character?, copyright?, meta?, deprecated?
     TagCategory.categories.each do |category_name|
       define_method("#{category_name}?") do
         category == Tag.categories.send(category_name)
@@ -200,7 +200,7 @@ class Tag < ApplicationRecord
             # next few lines if the category is changed.
             tag.update_category_cache
 
-            if Pundit.policy!(creator, tag).can_change_category?
+            if Pundit.policy!(creator, tag).can_change_category? && !(category_id == TagCategory.mapping["deprecated"] && tag.post_count > 0 && !creator.is_admin?)
               tag.update(category: category_id)
             end
           end

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -18,8 +18,8 @@ class TagRelationship < ApplicationRecord
   scope :deleted, -> {where(status: "deleted")}
   scope :retired, -> {where(status: "retired")}
 
-  # TagAlias.artist, TagAlias.general, TagAlias.character, TagAlias.copyright, TagAlias.meta
-  # TagImplication.artist, TagImplication.general, TagImplication.character, TagImplication.copyright, TagImplication.meta
+  # TagAlias.artist, TagAlias.general, TagAlias.character, TagAlias.copyright, TagAlias.meta, TagAlias.deprecated
+  # TagImplication.artist, TagImplication.general, TagImplication.character, TagImplication.copyright, TagImplication.meta, TagImplication.deprecated
   TagCategory.categories.each do |category|
     scope category, -> { joins(:consequent_tag).where(consequent_tag: { category: TagCategory.mapping[category] }) }
   end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -2,9 +2,11 @@
 
 class TagPolicy < ApplicationPolicy
   def can_change_category?
-    user.is_admin? ||
-      (user.is_builder? && record.post_count < 1_000) ||
-      (user.is_member? && record.post_count < 50)
+    return true if user.is_admin?
+    return false if record.category == TagCategory.mapping["deprecated"]
+    return true if user.is_builder? && record.post_count < 1_000
+    return true if user.is_member? && record.post_count < 50
+    false
   end
 
   def permitted_attributes

--- a/app/views/related_tags/_buttons.html.erb
+++ b/app/views/related_tags/_buttons.html.erb
@@ -1,5 +1,5 @@
 <%= button_tag "Related tags", type: :button, class: "related-tags-button ui-button ui-widget ui-corner-all sub" %>
 
 <% TagCategory.related_button_list.each do |category| %>
-  <%= button_tag TagCategory.related_button_mapping[category], type: :button, "data-category": category, class: "related-tags-button ui-button ui-widget ui-corner-all sub" %>
+  <%= button_tag TagCategory.title_map[category], type: :button, "data-category": category, class: "related-tags-button ui-button ui-widget ui-corner-all sub" %>
 <% end %>

--- a/db/migrate/20220311093552_add_tag_count_deprecated_to_posts.rb
+++ b/db/migrate/20220311093552_add_tag_count_deprecated_to_posts.rb
@@ -1,0 +1,7 @@
+class AddTagCountDeprecatedToPosts < ActiveRecord::Migration[7.0]
+  def change
+    Post.without_timeout do
+      add_column :posts, :tag_count_deprecated, :integer, default: 0, null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -888,7 +888,8 @@ CREATE TABLE public.posts (
     last_commented_at timestamp without time zone,
     has_active_children boolean DEFAULT false,
     bit_flags bigint DEFAULT 0 NOT NULL,
-    tag_count_meta integer DEFAULT 0 NOT NULL
+    tag_count_meta integer DEFAULT 0 NOT NULL,
+    tag_count_deprecated integer DEFAULT 0 NOT NULL
 );
 
 
@@ -5779,6 +5780,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220207195123'),
 ('20220210171310'),
 ('20220210200157'),
-('20220211075129');
+('20220211075129'),
+('20220311093552');
 
 


### PR DESCRIPTION
* Only empty tags can be moved to deprecated manually
* No tags can be moved out of this category manually, only via BUR
* These restrictions don't apply to admins

Also adds a depretags:>0 search

Fixes #4562.

Ok, hear me out. This category is severely needed for proper gardening. There's a lot of massive tags like "Tied hair" (https://danbooru.donmai.us/forum_topics/20459), or the recent neckwear revert project, that would greatly benefit from the existence of this tag, or are simply impossible to tackle without it.


* it's impossible to currently be able to tell which tags are not supposed to be used. nobody reads wikis, and this is especially true for large tags with an "obvious" meaning
* having an entire category for deprecated tags encourages users to help in sorting them out, since it's immediately visible in the sidebar, not relegated to the wiki. If we want it to be more in-your-face it can be put above general in the sidebar, but for now it's under it but above meta to avoid making too many changes
* this change allows someone to use depretags:>0 to find posts that need to be handled, and lets us use a single search instead of browser bookmarks to keep track of people reusing the million empty ambiguous tags we have like "tree trunk" (https://danbooru.donmai.us/forum_topics/20488).
* this change allows us in the future to show warnings when someone uses a deprecated tag 
* the issue with people changing tag categories without telling anyone is handled by making only empty tags moveable to, but not from, the deprecated category. this allows anyone to move old ambiguous wikis, but prevents them from moving deprecated tags back to general without using a BUR. This means we don't need to implement a whole category versioning system just to keep track of them, because if someone empties a tag just to move it to deprecated we'll be able to see it in the post changes history
* realistically, any other complex rework of the tag system to mark wikis/tags is years away, while this category is needed yesterday

This is what it looks like:
![image](https://user-images.githubusercontent.com/12946050/157853073-8de47505-1b13-4ddb-b2a1-94eec86d0168.png)
![image](https://user-images.githubusercontent.com/12946050/157852363-f6393b2b-83a7-4219-aacd-0ec954a0b3be.png)

It uses a similar color to gelbooru, but without the strikethrough because that makes it hard to actually read the tag name. It also uses the same color as Platinum, just like gold with meta, builder with copyright, etc, thus it's not a fully new color being introduced, but something that fits into our color scheme.
