### PR TITLE
simple_form: Don't hide hints on mobile. Fix #4997

### DIFF
--- a/app/javascript/src/styles/common/simple_form.scss
+++ b/app/javascript/src/styles/common/simple_form.scss
@@ -39,7 +39,8 @@ form.simple_form {
       padding-left: 1em;
 
       @media (max-width: 660px) {
-        display: none;
+        padding-left: 0;
+        display: block;
       }
     }
 
@@ -124,6 +125,11 @@ form.inline-form {
     label, input {
       display: table-cell;
       line-height: 1em;
+    }
+
+    span.hint {
+      line-height: 1em;
+      padding-bottom: 0.5em;
     }
   }
 }


### PR DESCRIPTION
Hints are displayed below their fields on small screens.

Hints for `.text` and `.dtext` inputs weren't hidden even before this change.