### PR TITLE
posts: fix sidebar min-width on small screens (fix #5052)

### DIFF
--- a/app/javascript/src/styles/common/main_layout.scss
+++ b/app/javascript/src/styles/common/main_layout.scss
@@ -32,6 +32,8 @@ footer#page-footer {
   #sidebar {
     flex: 0;
 
+    min-width: 230px;
+
     @media (min-width: 1080px) {
       min-width: 245px;
     }


### PR DESCRIPTION
I think the intent of c0610cb809f40d00bc0df02678986f9bf0103805 was to reduce the sidebar width on screens smaller than 1920px? Not sure why the 1080px query was added but it causes the sidebar to have no min-width on screens smaller than 1080px.