### PR TITLE
twitter: support www.twitter.com URLs

### DIFF
--- a/app/logical/source/url/twitter.rb
+++ b/app/logical/source/url/twitter.rb
@@ -29,7 +29,7 @@ class Source::URL::Twitter < Source::URL
   attr_reader :status_id, :twitter_username, :user_id
 
   def self.match?(url)
-    url.host.in?(%w[twitter.com mobile.twitter.com pic.twitter.com pbs.twimg.com video.twimg.com t.co])
+    url.host.in?(%w[twitter.com mobile.twitter.com pic.twitter.com pbs.twimg.com video.twimg.com www.twitter.com t.co])
   end
 
   def parse


### PR DESCRIPTION
Fixes NoMethodError preventing posts from being viewed if the source is
www.twitter.com