### PR TITLE
Configurable max video duration during upload

### DIFF
--- a/app/models/media_asset.rb
+++ b/app/models/media_asset.rb
@@ -4,7 +4,7 @@ class MediaAsset < ApplicationRecord
   class Error < StandardError; end
 
   VARIANTS = %i[preview 180x180 360x360 720x720 sample original]
-  MAX_VIDEO_DURATION = 140 # 2:20
+  MAX_VIDEO_DURATION = Danbooru.config.max_video_duration.to_i
   MAX_IMAGE_RESOLUTION = Danbooru.config.max_image_resolution
   MAX_IMAGE_WIDTH = Danbooru.config.max_image_width
   MAX_IMAGE_HEIGHT = Danbooru.config.max_image_height

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -171,6 +171,12 @@ module Danbooru
       40000
     end
 
+    # Maximum duration of an video in seconds.
+    def max_video_duration
+      # 2:20m
+      140
+    end
+
     # How long pending posts stay in the modqueue before being deleted.
     def moderation_period
       3.days


### PR DESCRIPTION
This PR allows to easily configure max length of video by config or env variable.  
Previously 140 seconds (2:20 min) was hardcoded