### PR TITLE
Fix modqueue highlighting after topic #20445 (screenshots)

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -330,8 +330,8 @@ module Danbooru
 
     # Posts with these tags will be highlighted in the modqueue.
     def modqueue_warning_tags
-      %w[hard_translated self_upload nude_filter third-party_edit screencap
-      duplicate image_sample md5_mismatch resized upscaled downscaled
+      %w[hard_translated self_upload nude_filter third-party_edit screenshot
+      anime_screencap duplicate image_sample md5_mismatch resized upscaled downscaled
       resolution_mismatch source_larger source_smaller]
     end
 


### PR DESCRIPTION
adds screenshot and anime_screencap to the modqueue highlighted tags and removes screencap