### PR TITLE
tag_list_component: fix overflow of some long tags

### DIFF
--- a/app/components/tag_list_component/tag_list_component.html.scss
+++ b/app/components/tag_list_component/tag_list_component.html.scss
@@ -4,7 +4,7 @@
   }
 
   a.search-tag {
-    overflow-wrap: normal;
+    overflow-wrap: break-word;
   }
 
   &.inline-tag-list {


### PR DESCRIPTION
Fixes rare cases of tags containing a long word overflowing outside the sidebar e.g.
https://danbooru.donmai.us/posts?tags=iwakiyamayukisatoshironanogojuurokushi_akira