### PR TITLE
change contributor -> unrestricted on users listing

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,7 +5,7 @@
     <%= search_form_for(users_path) do |f| %>
       <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "user" } } %>
       <%= f.input :level, collection: User.level_hash.to_a, include_blank: true, selected: params[:search][:level] %>
-      <%= f.input :can_upload_free, label: "Contributor?", as: :select, include_blank: true, selected: params[:search][:can_upload_free] %>
+      <%= f.input :can_upload_free, label: "Unrestricted?", as: :select, include_blank: true, selected: params[:search][:can_upload_free] %>
       <%= f.input :can_approve_posts, label: "Approver?", as: :select, include_blank: true, selected: params[:search][:can_approve_posts] %>
       <%= f.input :order, collection: [["Joined", "date"], ["Name", "name"], ["Posts", "post_upload_count"], ["Edits", "post_update_count"], ["Notes", "note_count"]], include_blank: true, selected: params[:search][:order] %>
       <%= f.submit "Search" %>

--- a/app/views/users/show.html+tooltip.erb
+++ b/app/views/users/show.html+tooltip.erb
@@ -14,7 +14,7 @@
       <% elsif @user.can_approve_posts? %>
         <%= link_to "Approver", users_path(search: { can_approve_posts: true }), class: "user-tooltip-badge user-tooltip-badge-approver" %>
       <% elsif @user.can_upload_free? %>
-        <%= link_to "Contributor", users_path(search: { can_upload_free: true }), class: "user-tooltip-badge user-tooltip-badge-contributor" %>
+        <%= link_to "Unrestricted", users_path(search: { can_upload_free: true }), class: "user-tooltip-badge user-tooltip-badge-contributor" %>
       <% else %>
         <%= link_to @user.level_string, users_path(search: { level: @user.level }), class: "user-tooltip-badge user-tooltip-badge-#{@user.level_string.downcase}" %>
       <% end %>


### PR DESCRIPTION
On https://danbooru.donmai.us/users the unrestricted privilege is just called Contributor.  No one calls unres users "contributors" anymore, to avoid confusion it should just say "Unrestricted?" instead of "Contributor?"