### PR TITLE
css: prevent acidentally opening spoilered links

### DIFF
--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -123,6 +123,17 @@ div.prose {
     color: var(--dtext-spoiler-hover-color);
   }
 
+  // Prevent accidentally opening a link when tapping a spoiler to reveal it
+  .spoiler:hover a {
+    animation: delay-pointer-events 50ms;
+  }
+
+  @keyframes delay-pointer-events {
+    0%, 99% {
+      pointer-events: none;
+    }
+  }
+
   .spoiler {
     background: var(--dtext-spoiler-background-color);
   }


### PR DESCRIPTION
A small delay on the pointer-events property prevents accidentally
opening a link inside a spoiler when tapping to reveal the spoiler on
mobile.