### PR TITLE
Update _secondary_links.html.erb: help:upload -> howto:upload

### DIFF
--- a/app/views/uploads/_secondary_links.html.erb
+++ b/app/views/uploads/_secondary_links.html.erb
@@ -3,5 +3,5 @@
   <%= subnav_link_to "My Uploads", user_uploads_path(CurrentUser.user.id.to_i) %>
   <%= subnav_link_to "All Uploads", media_assets_path %>
   <%= subnav_link_to "Reverse Image Search", iqdb_queries_path %> |
-  <%= subnav_link_to "Help", wiki_page_path("help:upload") %>
+  <%= subnav_link_to "Help", wiki_page_path("howto:upload") %>
 <% end %>


### PR DESCRIPTION
help:upload has beed deleted from the wiki. 
Fix the button "Help", re-assigned to "howto:upload". 