### PR TITLE
Add /vendor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ public/data/
 public/packs-test/
 public/packs/
 test/reports/
+/vendor/
 
 # https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .yarn/*


### PR DESCRIPTION
This folder is created by running `bundle install`. It can quickly overwhelm IDEs like vscode since there's potentially thousands of files in there.