### PR TITLE
Tags: don't allow deprecation of tags without wiki

### DIFF
--- a/app/logical/bulk_update_request_processor.rb
+++ b/app/logical/bulk_update_request_processor.rb
@@ -131,13 +131,19 @@ class BulkUpdateRequestProcessor
 
         when :deprecate
           tag = Tag.find_by_name(args[0])
-          if tag.is_deprecated?
+          if tag.nil?
+            errors.add(:base, "Can't deprecate #{args[0]} (tag doesn't exist)")
+          elsif tag.is_deprecated?
             errors.add(:base, "Can't deprecate #{args[0]} (tag is already deprecated)")
+          elsif tag.wiki_page.blank?
+            errors.add(:base, "Can't deprecate #{args[0]} (tag must have a wiki page)")
           end
 
         when :undeprecate
           tag = Tag.find_by_name(args[0])
-          if !tag.is_deprecated?
+          if tag.nil?
+            errors.add(:base, "Can't undeprecate #{args[0]} (tag doesn't exist)")
+          elsif !tag.is_deprecated?
             errors.add(:base, "Can't undeprecate #{args[0]} (tag is not deprecated)")
           end
 

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -8,13 +8,14 @@ class TagPolicy < ApplicationPolicy
   end
 
   def can_change_deprecated_status?
+    return false if record.wiki_page.blank? && !record.is_deprecated?
     user.is_admin? || (record.post_count == 0 && !record.is_deprecated?)
   end
 
   def permitted_attributes
-    [
-      (:category if can_change_category?),
-      (:is_deprecated if can_change_deprecated_status?),
-    ].compact
+    permitted = []
+    permitted << :category if can_change_category?
+    permitted << :is_deprecated if can_change_deprecated_status?
+    permitted
   end
 end


### PR DESCRIPTION
This was raised as a concern in the discord, and I agree that a requirement for deprecating tags would be to offer alternatives in their wiki.

Also fixed and moved the tests for the BUR because I realized I had put them in the wrong place.