### PR TITLE
Posts: remove "hide from queue" from sidebar

### DIFF
--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -53,7 +53,6 @@
     <% if policy(PostApproval).create? %>
       <% if post.is_approvable? %>
         <li id="post-option-approve"><%= link_to (post.is_deleted? ? "Undelete" : "Approve"), post_approvals_path(post_id: post.id), remote: true, method: :post, "data-shortcut": "shift+o", "data-confirm": "Are you sure you want to approve this post?" %></li>
-        <li id="post-option-disapprove"><%= link_to "Hide from queue", post_disapprovals_path(post_disapproval: { post_id: post.id, reason: "disinterest" }), remote: true, method: :post %></li>
       <% end %>
 
       <% if post.is_deleted? && policy(post).move_favorites? %>


### PR DESCRIPTION
This option is basically padding for approvers, given the controls at the top of the page.