### PR TITLE
Posts: prune disapprovals on new appeal or flag

### DIFF
--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -15,6 +15,7 @@ class PostFlag < ApplicationRecord
   validate :validate_post, on: :create
   validates :creator_id, uniqueness: { scope: :post_id, on: :create, unless: :is_deletion, message: "have already flagged this post" }
   before_save :update_post
+  after_create :prune_disapprovals
   attr_accessor :is_deletion
 
   enum status: {
@@ -88,6 +89,11 @@ class PostFlag < ApplicationRecord
     else
       :normal
     end
+  end
+
+  def prune_disapprovals
+    return if is_deletion
+    PostDisapproval.where(post: post).delete_all
   end
 
   def update_post


### PR DESCRIPTION
Fixes #4876.

Evazion mentioned that an alternative was to stop deleting disapprovals and mark them as soft deleted, however I'm not sure that's useful for us. I count more than 100k existing disapprovals right now, and that's even considering that they're purged monthly. The table risks ballooning out of proportion for no real benefit and the same behavior.