### PR TITLE
favgroups: allow favgroup:any/none searches

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1251,8 +1251,17 @@ class Post < ApplicationRecord
       end
 
       def favgroup_matches(query, current_user)
-        favgroup = FavoriteGroup.visible(current_user).name_or_id_matches(query, current_user)
-        where(id: favgroup.select("unnest(post_ids)"))
+        case query.downcase
+        when "none"
+          favgroups = FavoriteGroup.where(creator: current_user)
+          where.not(id: favgroups.select("unnest(post_ids)"))
+        when "any"
+          favgroups = FavoriteGroup.where(creator: current_user)
+          where(id: favgroups.select("unnest(post_ids)"))
+        else
+          favgroup = FavoriteGroup.visible(current_user).name_or_id_matches(query, current_user)
+          where(id: favgroup.select("unnest(post_ids)"))
+        end
       end
 
       def ordfavgroup_matches(query, current_user)

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -387,11 +387,14 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
 
       assert_tag_match([post1], "favgroup:#{favgroup1.id}")
       assert_tag_match([post2], "favgroup:#{favgroup2.name}")
+      assert_tag_match([post2, post1], "favgroup:any")
       assert_tag_match([], "favgroup:#{favgroup3.name}")
       assert_tag_match([], "favgroup:dne")
 
       assert_tag_match([post3, post2], "-favgroup:#{favgroup1.id}")
       assert_tag_match([post3, post1], "-favgroup:#{favgroup2.name}")
+      assert_tag_match([post3], "-favgroup:any")
+      assert_tag_match([post3], "favgroup:none")
       assert_tag_match([post3, post2, post1], "-favgroup:#{favgroup3.name}")
       assert_tag_match([post3, post2, post1], "-favgroup:dne")
 
@@ -405,6 +408,7 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
         assert_tag_match([], "favgroup:#{favgroup1.name}")
         assert_tag_match([], "favgroup:#{favgroup2.name}")
         assert_tag_match([post3], "favgroup:#{favgroup3.name}")
+        assert_tag_match([post3], "favgroup:any")
       end
     end
 


### PR DESCRIPTION
Only matches on the current user's favgroups.