### PR TITLE
Foundation: fix some video posts not being extracted

### DIFF
--- a/app/logical/source/extractor/foundation.rb
+++ b/app/logical/source/extractor/foundation.rb
@@ -11,7 +11,7 @@ module Source
       def image_urls
         if parsed_url.full_image_url.present?
           [parsed_url.full_image_url]
-        elsif image_url = page&.at(".fullscreen img, .fullscreen video")&.attr(:src)
+        elsif (image_url = page&.at(".fullscreen img, .fullscreen video")&.attr(:src))
           [Source::URL.parse(image_url).full_image_url].compact
         else
           []

--- a/app/logical/source/url/foundation.rb
+++ b/app/logical/source/url/foundation.rb
@@ -11,8 +11,10 @@
 class Source::URL::Foundation < Source::URL
   attr_reader :username, :token_id, :work_id, :hash
 
+  IMAGE_HOSTS = %w[assets.foundation.app f8n-ipfs-production.imgix.net f8n-production-collection-assets.imgix.net d2ybmb80bbm9ts.cloudfront.net]
+
   def self.match?(url)
-    url.host.in?(%w[foundation.app assets.foundation.app f8n-ipfs-production.imgix.net f8n-production-collection-assets.imgix.net])
+    url.host.in?(%w[foundation.app assets.foundation.app]) || url.host.in?(IMAGE_HOSTS)
   end
 
   def parse
@@ -52,12 +54,14 @@ class Source::URL::Foundation < Source::URL
       @hash = hash
 
     # https://f8n-production-collection-assets.imgix.net/0xFb0a8e1bB97fD7231Cd73c489dA4732Ae87995F0/4/nft.png
-    in "f8n-production-collection-assets.imgix.net", token_id, work_id, file
+    # https://assets.foundation.app/0x21Afa9aB02B6Fb7cb483ff3667c39eCdd6D9Ea73/4/nft.mp4
+    in ("f8n-production-collection-assets.imgix.net" | "assets.foundation.app"), /^0x\w{40}$/ => token_id, work_id, file
       @token_id = token_id
       @work_id = work_id
 
     # https://assets.foundation.app/7i/gs/QmU8bbsjaVQpEKMDWbSZdDD6GsPmRYBhQtYRn8bEGv7igs/nft_q4.mp4
-    in "assets.foundation.app", *subdirs, hash, file
+    # https://d2ybmb80bbm9ts.cloudfront.net/zd/BD/QmXiCEoBLcpfvpEwAEanLXe3Tjr5ykYJFzCVfpzDDQzdBD/nft_q4.mp4
+    in ("assets.foundation.app" | "d2ybmb80bbm9ts.cloudfront.net"), *subdirs, hash, file
       @hash = hash
 
     else
@@ -74,7 +78,7 @@ class Source::URL::Foundation < Source::URL
 
   def page_url
     return nil unless work_id.present?
-    return nil if host == "f8n-production-collection-assets.imgix.net" && @hash.blank?
+    return nil if host.in?(IMAGE_HOSTS) && @hash.blank?
     # https://f8n-production-collection-assets.imgix.net/0xAcf67a11D93D22bbB51fddD9B039d43d5Db484Bc/3/nft.png cannot be normalized to a correct page url
 
     username = @username || "foundation"
@@ -87,6 +91,8 @@ class Source::URL::Foundation < Source::URL
       "https://f8n-ipfs-production.imgix.net/#{hash}/nft.#{file_ext}"
     elsif host == "f8n-production-collection-assets.imgix.net" && token_id.present? && work_id.present? && file_ext.present?
       "https://f8n-production-collection-assets.imgix.net/#{token_id}/#{work_id}/nft.#{file_ext}"
+    elsif file_ext.present?
+      url.omit(:query).to_s
     end
   end
 

--- a/test/test_helpers/source_test_helper.rb
+++ b/test/test_helpers/source_test_helper.rb
@@ -4,51 +4,42 @@ module SourceTestHelper
   # * If download_size is nil, it tests that the file is downloaded correctly, otherwise it also checks the filesize.
   # * If deleted is true, it skips the downloading check, but it still tries everything else and makes sure nothing breaks.
   # * Any passed kwargs parameter is tested against the strategy.
-  def strategy_should_work(url, referer: nil, download_size: nil, deleted: false, **methods_to_test)
-    context "a strategy for #{url}#{", referer: #{referer}" if referer.present?}".chomp do
-      strategy = Source::Extractor.find(url, referer)
 
-      should "not raise anything" do
-        assert_nothing_raised { strategy.to_h }
-      end
+  def strategy_should_work(url, arguments)
+    # XXX: can't use **kwargs because of a bug with shoulda-context
+    referer, download_size, deleted = [:referer, :download_size, :deleted].map { |arg| arguments.delete(arg) }
 
-      should "make sure that image_urls is an array of valid elements" do
-        assert((strategy.image_urls.instance_of? Array))
-        assert_not(strategy.image_urls.include?(nil))
-      end
+    strategy = Source::Extractor.find(url, referer)
 
-      should_download_successfully(strategy, download_size) unless deleted
-
-      # {profile_url: nil}[:profile_url].present? -> false
-      # Doing it this way instead we can check profile_url even if it's passed as a nil.
-      if methods_to_test.include? :profile_url
-        profile_url = methods_to_test.delete(:profile_url)
-        should_handle_artists_correctly(strategy, profile_url)
-      end
-
-      tags = methods_to_test.delete(:tags)
-      should_validate_tags(strategy, tags)
-
-      # check any method that is passed as kwargs, in order to hardcode as few thingss as possible
-      methods_to_test.each do |method_name, expected_value|
-        should "make sure that '#{method_name}' matches" do
-          if expected_value.instance_of? Regexp
-            assert_match(expected_value, strategy.try(method_name))
-          elsif expected_value.nil?
-            assert_nil(strategy.try(method_name))
-          else
-            assert_equal(expected_value, strategy.try(method_name))
-          end
-        end
-      end
+    should "not raise anything" do
+      assert_nothing_raised { strategy.to_h }
     end
+
+    should "make sure that image_urls is an array of valid elements" do
+      assert((strategy.image_urls.instance_of? Array))
+      assert_not(strategy.image_urls.include?(nil))
+    end
+
+    should_download_successfully(strategy, download_size) unless deleted
+
+    # {profile_url: nil}[:profile_url].present? -> false
+    # Doing it this way instead we can check profile_url even if it's passed as a nil.
+    if arguments.include? :profile_url
+      profile_url = arguments.delete(:profile_url)
+      should_handle_artists_correctly(strategy, profile_url)
+    end
+
+    tags = arguments.delete(:tags)
+    should_validate_tags(strategy, tags)
+
+    should_match_source_data(strategy, arguments)
   end
 
   def should_download_successfully(strategy, download_size = nil)
     should "download successfully" do
       file = strategy.download_file!(strategy.image_urls.first)
       if download_size.present?
-        assert_equal(expected_filesize, file.size)
+        assert_equal(download_size, file.size)
       else
         assert_not_nil(file.size)
       end
@@ -90,4 +81,21 @@ module SourceTestHelper
     end
   end
 
+  def should_match_source_data(strategy, methods_to_test)
+    # check any method that is passed as kwargs, in order to hardcode as few things as possible
+    # XXX can't use **kwargs because of a bug with shoulda-context, so we're using a hash temporarily
+    methods_to_test.each do |method_name, expected_value|
+      should "make sure that '#{method_name}' matches" do
+        if expected_value.instance_of? Regexp
+          assert_match(expected_value, strategy.try(method_name))
+        elsif expected_value.instance_of? Array
+          assert_equal(expected_value.sort, strategy.try(method_name).sort)
+        elsif expected_value.nil?
+          assert_nil(strategy.try(method_name))
+        else
+          assert_equal(expected_value, strategy.try(method_name))
+        end
+      end
+    end
+  end
 end

--- a/test/unit/sources/anifty_test.rb
+++ b/test/unit/sources/anifty_test.rb
@@ -2,42 +2,50 @@ require "test_helper"
 
 module Sources
   class AniftyTest < ActiveSupport::TestCase
-    strategy_should_work(
-      "https://anifty.jp/ja/creations/1500",
-      image_urls: ["https://storage.googleapis.com/anifty-media/creation/0x0913be22dd08f7e092e00d4f8c2f61778dc6df94/a5bb2c63b8a602aba6cfd93d2147bef23b6b9bc2.jpg"],
-      profile_url: "https://anifty.jp/@inamihatoko",
-      page_url: "https://anifty.jp/creations/1500",
-      artist_name: "inami hatoko",
-      other_names: ["inamihatoko", "井波ハトコ"],
-      tags: ["background", "girl"],
-      artist_commentary_title: "Escape",
-      artist_commentary_desc: "Let's get out of there."
-    )
+    context "An anifty post" do
+      strategy_should_work(
+        "https://anifty.jp/ja/creations/1500",
+        image_urls: ["https://storage.googleapis.com/anifty-media/creation/0x0913be22dd08f7e092e00d4f8c2f61778dc6df94/a5bb2c63b8a602aba6cfd93d2147bef23b6b9bc2.jpg"],
+        profile_url: "https://anifty.jp/@inamihatoko",
+        page_url: "https://anifty.jp/creations/1500",
+        artist_name: "inami hatoko",
+        other_names: ["inamihatoko", "井波ハトコ"],
+        tags: ["background", "girl"],
+        artist_commentary_title: "Escape",
+        artist_commentary_desc: "Let's get out of there."
+      )
+    end
 
-    strategy_should_work(
-      "https://anifty.imgix.net/creation/0x9942a21fdc78fe2c3973d219a1d705a4efd056b4/22f4c9694dd2f1f32b610d1d75a18621c5c2d6d8.jpg?w=3840&q=undefined&auto=compress",
-      image_urls: ["https://storage.googleapis.com/anifty-media/creation/0x9942a21fdc78fe2c3973d219a1d705a4efd056b4/22f4c9694dd2f1f32b610d1d75a18621c5c2d6d8.jpg"],
-      profile_url: "https://anifty.jp/@unagi189",
-      page_url: "https://anifty.jp/creations/1585",
-      artist_name: "yunagi",
-      other_names: ["unagi189", "夕凪"],
-      tags: ["background", "girl", "uniform"],
-      artist_commentary_title: "Sound!",
-      artist_commentary_desc: "This work was created in 2017 and partially modified for exhibition.I created this work with the image of after-school for the girls in the brass band."
-    )
+    context "An anifty image hosted on imgix" do
+      strategy_should_work(
+        "https://anifty.imgix.net/creation/0x9942a21fdc78fe2c3973d219a1d705a4efd056b4/22f4c9694dd2f1f32b610d1d75a18621c5c2d6d8.jpg?w=3840&q=undefined&auto=compress",
+        image_urls: ["https://storage.googleapis.com/anifty-media/creation/0x9942a21fdc78fe2c3973d219a1d705a4efd056b4/22f4c9694dd2f1f32b610d1d75a18621c5c2d6d8.jpg"],
+        profile_url: "https://anifty.jp/@unagi189",
+        page_url: "https://anifty.jp/creations/1585",
+        artist_name: "yunagi",
+        other_names: ["unagi189", "夕凪"],
+        tags: ["background", "girl", "uniform"],
+        artist_commentary_title: "Sound!",
+        artist_commentary_desc: "This work was created in 2017 and partially modified for exhibition.I created this work with the image of after-school for the girls in the brass band."
+      )
+    end
 
-    strategy_should_work(
-      "https://storage.googleapis.com/anifty-media/profile/0x961d09077b4a9f7a27f6b7ee78cb4c26f0e72c18/a6d2c366a3e876ddbf04fc269b63124be18af424.png",
-      image_urls: ["https://storage.googleapis.com/anifty-media/profile/0x961d09077b4a9f7a27f6b7ee78cb4c26f0e72c18/a6d2c366a3e876ddbf04fc269b63124be18af424.png"],
-      profile_url: "https://anifty.jp/@hightree",
-      page_url: nil,
-      artist_name: "Knoy Konome",
-      other_names: ["hightree", "木芽のい"],
-      tags: [],
-      artist_commentary_title: nil,
-      artist_commentary_desc: nil
-    )
+    context "An anifty image hosted on googleapis" do
+      strategy_should_work(
+        "https://storage.googleapis.com/anifty-media/profile/0x961d09077b4a9f7a27f6b7ee78cb4c26f0e72c18/a6d2c366a3e876ddbf04fc269b63124be18af424.png",
+        image_urls: ["https://storage.googleapis.com/anifty-media/profile/0x961d09077b4a9f7a27f6b7ee78cb4c26f0e72c18/a6d2c366a3e876ddbf04fc269b63124be18af424.png"],
+        profile_url: "https://anifty.jp/@hightree",
+        page_url: nil,
+        artist_name: "Knoy Konome",
+        other_names: ["hightree", "木芽のい"],
+        tags: [],
+        artist_commentary_title: nil,
+        artist_commentary_desc: nil
+      )
+    end
 
-    strategy_should_work("https://anifty.jp/zh/creations/373123123", deleted: true, profile_url: nil)
+    context "A deleted or non-existing anifty post" do
+      strategy_should_work("https://anifty.jp/zh/creations/373123123", deleted: true, profile_url: nil)
+    end
   end
 end

--- a/test/unit/sources/booth_test.rb
+++ b/test/unit/sources/booth_test.rb
@@ -2,59 +2,71 @@ require "test_helper"
 
 module Sources
   class BoothTest < ActiveSupport::TestCase
-    standard_url_images = %w[
-      https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/ae0fdbcf-e4c5-4840-8d5c-43e18bddc93e.jpg
-      https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/d12bce50-a0c7-43f8-a4fb-5ee0ea6855a3.jpg
-      https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/f5332da3-4097-4d33-bbf6-a9b64c7671b3.jpg
-    ]
-    strategy_should_work(
-      "https://booth.pm/en/items/3713604",
-      image_urls: standard_url_images,
-      profile_url: "https://amedamacon.booth.pm",
-      page_url: "https://booth.pm/en/items/3713604",
-      artist_name: "amedamacon",
-      other_names: ["あめうさぎBOOTH"],
-      tags: [["抱き枕カバー", "https://booth.pm/en/browse/Pillow%20Cover?tags%5B%5D=%E6%8A%B1%E3%81%8D%E6%9E%95%E3%82%AB%E3%83%90%E3%83%BC"]],
-      artist_commentary_title: "フユちゃん抱き枕カバー",
-      dtext_artist_commentary_desc: /発送：6月上旬頃（BOOTH倉庫より発送）/
-    )
+    context "A booth post" do
+      images = %w[
+        https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/ae0fdbcf-e4c5-4840-8d5c-43e18bddc93e.jpg
+        https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/d12bce50-a0c7-43f8-a4fb-5ee0ea6855a3.jpg
+        https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/f5332da3-4097-4d33-bbf6-a9b64c7671b3.jpg
+      ]
+      strategy_should_work(
+        "https://booth.pm/en/items/3713604",
+        image_urls: images,
+        profile_url: "https://amedamacon.booth.pm",
+        page_url: "https://booth.pm/en/items/3713604",
+        artist_name: "amedamacon",
+        other_names: ["あめうさぎBOOTH"],
+        tags: [["抱き枕カバー", "https://booth.pm/en/browse/Pillow%20Cover?tags%5B%5D=%E6%8A%B1%E3%81%8D%E6%9E%95%E3%82%AB%E3%83%90%E3%83%BC"]],
+        artist_commentary_title: "フユちゃん抱き枕カバー",
+        dtext_artist_commentary_desc: /発送：6月上旬頃（BOOTH倉庫より発送）/
+      )
+    end
 
-    strategy_should_work(
-      "https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/d12bce50-a0c7-43f8-a4fb-5ee0ea6855a3_base_resized.jpg",
-      image_urls: [standard_url_images.second],
-      profile_url: "https://amedamacon.booth.pm",
-      page_url: "https://booth.pm/en/items/3713604",
-      artist_name: "amedamacon",
-      other_names: ["あめうさぎBOOTH"],
-      tags: [["抱き枕カバー", "https://booth.pm/en/browse/Pillow%20Cover?tags%5B%5D=%E6%8A%B1%E3%81%8D%E6%9E%95%E3%82%AB%E3%83%90%E3%83%BC"]],
-      artist_commentary_title: "フユちゃん抱き枕カバー",
-      dtext_artist_commentary_desc: /発送：6月上旬頃（BOOTH倉庫より発送）/
-    )
+    context "A booth image" do
+      strategy_should_work(
+        "https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/d12bce50-a0c7-43f8-a4fb-5ee0ea6855a3_base_resized.jpg",
+        image_urls: ["https://booth.pximg.net/a212cd73-75ab-482d-8fce-1ce2965e4d4f/i/3713604/d12bce50-a0c7-43f8-a4fb-5ee0ea6855a3.jpg"],
+        profile_url: "https://amedamacon.booth.pm",
+        page_url: "https://booth.pm/en/items/3713604",
+        artist_name: "amedamacon",
+        other_names: ["あめうさぎBOOTH"],
+        tags: [["抱き枕カバー", "https://booth.pm/en/browse/Pillow%20Cover?tags%5B%5D=%E6%8A%B1%E3%81%8D%E6%9E%95%E3%82%AB%E3%83%90%E3%83%BC"]],
+        artist_commentary_title: "フユちゃん抱き枕カバー",
+        dtext_artist_commentary_desc: /発送：6月上旬頃（BOOTH倉庫より発送）/
+      )
+    end
 
-    strategy_should_work(
-      "https://re-face.booth.pm/items/2423989",
-      image_urls: ["https://booth.pximg.net/8bb9e4e3-d171-4027-88df-84480480f79d/i/2423989/a692d4f3-4371-4a86-a337-83fee82d46a4.png"],
-      profile_url: "https://re-face.booth.pm",
-      page_url: "https://booth.pm/en/items/2423989",
-      artist_name: "re-face",
-      other_names: ["Re:fAce/りふぇいす。"],
-      tags: ["original"],
-      artist_commentary_title: "RwithV vol.1 -アイドルはじめます！-",
-      dtext_artist_commentary_desc: /注文が殺到した際は、発送が遅れてしまう場合もございますので予めご了承ください。/
-    )
+    context "A booth post with artist name in the url" do
+      strategy_should_work(
+        "https://re-face.booth.pm/items/2423989",
+        image_urls: ["https://booth.pximg.net/8bb9e4e3-d171-4027-88df-84480480f79d/i/2423989/a692d4f3-4371-4a86-a337-83fee82d46a4.png"],
+        profile_url: "https://re-face.booth.pm",
+        page_url: "https://booth.pm/en/items/2423989",
+        artist_name: "re-face",
+        other_names: ["Re:fAce/りふぇいす。"],
+        tags: ["original"],
+        artist_commentary_title: "RwithV vol.1 -アイドルはじめます！-",
+        dtext_artist_commentary_desc: /注文が殺到した際は、発送が遅れてしまう場合もございますので予めご了承ください。/
+      )
+    end
 
-    strategy_should_work(
-      "https://s2.booth.pm/8bb9e4e3-d171-4027-88df-84480480f79d/3d70de06-8e7c-444e-b8eb-a8a95bf20638_base_resized.jpg",
-      image_urls: ["https://s2.booth.pm/8bb9e4e3-d171-4027-88df-84480480f79d/3d70de06-8e7c-444e-b8eb-a8a95bf20638.png"],
-      profile_url: nil
-    )
+    context "A profile background picture" do
+      strategy_should_work(
+        "https://s2.booth.pm/8bb9e4e3-d171-4027-88df-84480480f79d/3d70de06-8e7c-444e-b8eb-a8a95bf20638_base_resized.jpg",
+        image_urls: ["https://s2.booth.pm/8bb9e4e3-d171-4027-88df-84480480f79d/3d70de06-8e7c-444e-b8eb-a8a95bf20638.png"],
+        profile_url: nil
+      )
+    end
 
-    strategy_should_work(
-      "https://booth.pximg.net/c/128x128/users/3193929/icon_image/5be9eff4-1d9e-4a79-b097-33c1cd4ad314_base_resized.jpg",
-      image_urls: ["https://booth.pximg.net/users/3193929/icon_image/5be9eff4-1d9e-4a79-b097-33c1cd4ad314.png"],
-      profile_url: nil
-    )
+    context "A profile icon" do
+      strategy_should_work(
+        "https://booth.pximg.net/c/128x128/users/3193929/icon_image/5be9eff4-1d9e-4a79-b097-33c1cd4ad314_base_resized.jpg",
+        image_urls: ["https://booth.pximg.net/users/3193929/icon_image/5be9eff4-1d9e-4a79-b097-33c1cd4ad314.png"],
+        profile_url: nil
+      )
+    end
 
-    strategy_should_work("https://booth.pm/en/items/2003079", deleted: true)
+    context "A non-existing or deleted post" do
+      strategy_should_work("https://booth.pm/en/items/2003079", deleted: true)
+    end
   end
 end

--- a/test/unit/sources/foundation_test.rb
+++ b/test/unit/sources/foundation_test.rb
@@ -2,97 +2,90 @@ require "test_helper"
 
 module Sources
   class FoundationTest < ActiveSupport::TestCase
-    context "The source for a Foundation picture" do
-      setup do
-        @post_url = "https://foundation.app/@dadachyo/~/103724"
-        @post_with_video = "https://foundation.app/@huwari/~/88982"
-        @image_url = "https://f8n-ipfs-production.imgix.net/QmPhpz6E9TFRpvdVTviM8Hy9o9rxrnPW5Ywj471NnSNkpi/nft.jpg"
-        @image1 = Source::Extractor.find(@post_url)
-        @image2 = Source::Extractor.find(@image_url)
-        @image3 = Source::Extractor.find(@post_with_video)
-      end
-
-      should "get the artist name" do
-        assert_equal("dadachyo", @image1.artist_name)
-        assert_equal("huwari", @image3.artist_name)
-      end
-
-      should "get the artist commentary title" do
-        assert_equal("Rose tea", @image1.artist_commentary_title)
-        assert_equal("bus", @image3.artist_commentary_title)
-      end
-
-      should "get profile url" do
-        assert_equal("https://foundation.app/@dadachyo", @image1.profile_url)
-        assert_equal(["https://foundation.app/@dadachyo", "https://foundation.app/0xb4D9073800c7935351ACDC1e46F0CF670853eA99"], @image1.profile_urls)
-
-        assert_equal("https://foundation.app/@huwari", @image3.profile_url)
-        assert_equal(["https://foundation.app/@huwari", "https://foundation.app/0xaa2f2eDE4D502F59b3706d2E2dA873C8A00A3d4d"], @image3.profile_urls)
-      end
-
-      should "get the image url" do
-        assert_equal([@image_url], @image1.image_urls)
-        assert_equal([@image_url], @image2.image_urls)
-      end
-
-      should "download an image" do
-        assert_downloaded(13_908_349, @image1.image_urls.sole)
-        assert_downloaded(13_908_349, @image2.image_urls.sole)
-        assert_downloaded(13_391_766, @image3.image_urls.sole)
-      end
-
-      should "find the correct artist" do
-        @artist = FactoryBot.create(:artist, name: "dadachyo", url_string: @image1.profile_url)
-        assert_equal([@artist], @image1.artists)
-      end
-
-      should "not raise errors" do
-        assert_nothing_raised { @image1.to_h }
-        assert_nothing_raised { @image2.to_h }
-        assert_nothing_raised { @image3.to_h }
-      end
+    context "A foundation post" do
+      strategy_should_work(
+        "https://foundation.app/@dadachyo/~/103724",
+        download_size: 13_908_349,
+        image_urls: ["https://f8n-ipfs-production.imgix.net/QmPhpz6E9TFRpvdVTviM8Hy9o9rxrnPW5Ywj471NnSNkpi/nft.jpg"],
+        artist_commentary_title: "Rose tea",
+        artist_name: "dadachyo",
+        profile_url: "https://foundation.app/@dadachyo",
+        profile_urls: ["https://foundation.app/0xb4D9073800c7935351ACDC1e46F0CF670853eA99", "https://foundation.app/@dadachyo"],
+        tags: %w[dadachyo rose 2018 matcrewnft]
+      )
     end
 
-    context "for a foundation.app/@username/foo-bar-1234 URL" do
-      should "work" do
-        page_url = "https://foundation.app/@asuka111art/dinner-with-cats-82426"
-        image_url = "https://f8n-ipfs-production.imgix.net/Qma7Lz2LfFb4swoqzr1V43oRGh9xikgigM11g3EukdU61R/nft.png"
-        source = Source::Extractor.find(page_url)
-
-        assert_equal("asuka111art", source.artist_name)
-        assert_equal(["https://foundation.app/@asuka111art", "https://foundation.app/0x9A94f94626352566e0A9105F1e3DA0439E3e3783"], source.profile_urls)
-        assert_equal([image_url], source.image_urls)
-        assert_equal(%w[2d anime illustration digital fantasy], source.tags.map(&:first))
-      end
+    context "A foundation image url" do
+      strategy_should_work(
+        "https://f8n-ipfs-production.imgix.net/QmPhpz6E9TFRpvdVTviM8Hy9o9rxrnPW5Ywj471NnSNkpi/nft.jpg",
+        image_urls: ["https://f8n-ipfs-production.imgix.net/QmPhpz6E9TFRpvdVTviM8Hy9o9rxrnPW5Ywj471NnSNkpi/nft.jpg"],
+        download_size: 13_908_349
+      )
     end
 
-    context "for a f8n-production-collection-assets.imgix.net URL" do
-      should "work" do
-        image_url = "https://f8n-production-collection-assets.imgix.net/0x3B3ee1931Dc30C1957379FAc9aba94D1C48a5405/128711/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png?q=80&auto=format%2Ccompress&cs=srgb&h=640"
-        source = Source::Extractor.find(image_url)
-
-        assert_equal("mochiiimo", source.artist_name)
-        assert_equal(["https://foundation.app/@mochiiimo", "https://foundation.app/0x7E2ef75C0C09b2fc6BCd1C68B6D409720CcD58d2"], source.profile_urls)
-        assert_equal(["https://f8n-ipfs-production.imgix.net/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png"], source.image_urls)
-        assert_equal(%w[anime landscape girl cat 2d illustration matcrewnft], source.tags.map(&:first))
-      end
+    context "A foundation.app/@username/foo-bar-1234 URL" do
+      strategy_should_work(
+        "https://foundation.app/@asuka111art/dinner-with-cats-82426",
+        image_urls: ["https://f8n-ipfs-production.imgix.net/Qma7Lz2LfFb4swoqzr1V43oRGh9xikgigM11g3EukdU61R/nft.png"],
+        artist_name: "asuka111art",
+        profile_url: "https://foundation.app/@asuka111art",
+        profile_urls: ["https://foundation.app/@asuka111art", "https://foundation.app/0x9A94f94626352566e0A9105F1e3DA0439E3e3783"],
+        tags: %w[2d anime illustration digital fantasy]
+      )
     end
 
-    context "for a collection" do
+    context "A f8n-production-collection-assets.imgix.net URL" do
+      strategy_should_work(
+        "https://f8n-production-collection-assets.imgix.net/0x3B3ee1931Dc30C1957379FAc9aba94D1C48a5405/128711/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png?q=80&auto=format%2Ccompress&cs=srgb&h=640",
+        image_urls: ["https://f8n-ipfs-production.imgix.net/QmcBfbeCMSxqYB3L1owPAxFencFx3jLzCPFx6xUBxgSCkH/nft.png"],
+        artist_name: "mochiiimo",
+        profile_url: "https://foundation.app/@mochiiimo",
+        profile_urls: ["https://foundation.app/0x7E2ef75C0C09b2fc6BCd1C68B6D409720CcD58d2", "https://foundation.app/@mochiiimo"],
+        tags: %w[anime landscape girl cat 2d illustration matcrewnft]
+      )
+    end
+
+    context "A foundation post with a video hosted on imgix" do
+      strategy_should_work(
+        "https://foundation.app/@huwari/~/88982",
+        image_urls: ["https://f8n-ipfs-production.imgix.net/QmU8bbsjaVQpEKMDWbSZdDD6GsPmRYBhQtYRn8bEGv7igs/nft.mp4"],
+        download_size: 13_391_766,
+        artist_name: "huwari",
+        profile_url: "https://foundation.app/@huwari",
+        profile_urls: ["https://foundation.app/@huwari", "https://foundation.app/0xaa2f2eDE4D502F59b3706d2E2dA873C8A00A3d4d"],
+        artist_commentary_title: "bus"
+      )
+    end
+
+    context "A foundation post with a video hosted on foundation" do
+      strategy_should_work(
+        "https://foundation.app/@mcbess/ladies/4",
+        image_urls: ["https://assets.foundation.app/0x21Afa9aB02B6Fb7cb483ff3667c39eCdd6D9Ea73/4/nft.mp4"]
+      )
+    end
+
+    context "A foundation post with a video hosted on cloudfront" do
+      strategy_should_work(
+        "https://foundation.app/@nixeu/foundation/109126",
+        image_urls: ["https://f8n-ipfs-production.imgix.net/QmXiCEoBLcpfvpEwAEanLXe3Tjr5ykYJFzCVfpzDDQzdBD/nft.mp4"]
+      )
+    end
+
+    context "A collection" do
       should "get the image urls" do
         assert_equal(
           ["https://f8n-ipfs-production.imgix.net/QmX4MotNAAj9Rcyew43KdgGDxU1QtXemMHoUTNacMLLSjQ/nft.png"],
-          Source::Extractor.find("https://foundation.app/@mochiiimo/~/97376").image_urls,
+          Source::Extractor.find("https://foundation.app/@mochiiimo/~/97376").image_urls
         )
 
         assert_equal(
           ["https://f8n-ipfs-production.imgix.net/QmX4MotNAAj9Rcyew43KdgGDxU1QtXemMHoUTNacMLLSjQ/nft.png"],
-          Source::Extractor.find("https://foundation.app/@mochiiimo/foundation/97376").image_urls,
+          Source::Extractor.find("https://foundation.app/@mochiiimo/foundation/97376").image_urls
         )
 
         assert_equal(
           ["https://f8n-production-collection-assets.imgix.net/0xFb0a8e1bB97fD7231Cd73c489dA4732Ae87995F0/4/nft.png"],
-          Source::Extractor.find("https://foundation.app/@KILLERGF/kgfgen/4").image_urls,
+          Source::Extractor.find("https://foundation.app/@KILLERGF/kgfgen/4").image_urls
         )
       end
     end


### PR DESCRIPTION
Fixes #5121.

Also refactors foundation tests and adjusts SourceTestHelper to not autogenerate contexts, so that tests can be launched individually.