### PR TITLE
Fix normalization for fandom sources

### DIFF
--- a/app/logical/source/url/null.rb
+++ b/app/logical/source/url/null.rb
@@ -233,7 +233,7 @@ class Source::URL::Null < Source::URL
     in _, "nocookie.net", wiki, "images", /^\h$/, /^\h\h$/, file, *rest
       @wiki = wiki
       @file = file
-      @page_url = "https://#{wiki}.fandom.com/?file=#{file}"
+      @page_url = "https://#{wiki}.fandom.com/wiki/Gallery?file=#{file}"
 
     # https://static.zerochan.net/Fullmetal.Alchemist.full.2831797.png
     # https://s1.zerochan.net/Cocoa.Cookie.600.2957938.jpg

--- a/test/unit/sources/null_test.rb
+++ b/test/unit/sources/null_test.rb
@@ -84,7 +84,7 @@ module Sources
 
       should "normalize wikia links" do
         source = "https://vignette.wikia.nocookie.net/valkyriecrusade/images/c/c5/Crimson_Hatsune_H.png/revision/latest?cb=20180702031954"
-        assert_equal("https://valkyriecrusade.fandom.com/?file=Crimson_Hatsune_H.png", Source::URL.page_url(source))
+        assert_equal("https://valkyriecrusade.fandom.com/wiki/Gallery?file=Crimson_Hatsune_H.png", Source::URL.page_url(source))
       end
 
       should "normalize e-shuushuu links" do


### PR DESCRIPTION
Fixes #5072. One of the examples in that issue is still not normalized correctly but that's because the fandom name can't be extracted from the url. Nothing we can do in that case.