### PR TITLE
related tags: fix wiki link adding "undefined" tag

### DIFF
--- a/app/javascript/src/javascripts/related_tag.js
+++ b/app/javascript/src/javascripts/related_tag.js
@@ -6,7 +6,7 @@ let RelatedTag = {};
 RelatedTag.initialize_all = function() {
   $(document).on("click.danbooru", ".related-tags-button", RelatedTag.on_click_related_tags_button);
   $(document).on("change.danbooru", ".related-tags input", RelatedTag.toggle_tag);
-  $(document).on("click.danbooru", ".related-tags a", RelatedTag.toggle_tag);
+  $(document).on("click.danbooru", ".related-tags a.search-tag", RelatedTag.toggle_tag);
   $(document).on("click.danbooru", "#show-related-tags-link", RelatedTag.show);
   $(document).on("click.danbooru", "#hide-related-tags-link", RelatedTag.hide);
   $(document).on("keyup.danbooru.relatedTags", "#post_tag_string", RelatedTag.update_selected);

--- a/app/views/related_tags/_current_tags.html.erb
+++ b/app/views/related_tags/_current_tags.html.erb
@@ -1,10 +1,10 @@
 <div class="current-related-tags-columns space-y-4 md:space-y-0 md:flex md:space-x-4">
   <% if related_tags.present? %>
     <%= render "related_tags/tag_column", tags: related_tags.tags.map(&:name), class: "general-related-tags-column", title: related_tags.pretty_name %>
-    <%= render "related_tags/tag_column", tags: related_tags.wiki_page_tags, class: "wiki-related-tags-column", title: link_to_wiki("wiki:#{related_tags.pretty_name}", related_tags.query) %>
+    <%= render "related_tags/tag_column", tags: related_tags.wiki_page_tags, class: "wiki-related-tags-column", title: link_to_wiki("wiki:#{related_tags.pretty_name}", related_tags.query, target: "_blank") %>
 
     <% related_tags.other_wiki_pages.each do |wiki| %>
-      <%= render "related_tags/tag_column", tags: wiki.tags, class: "other-wiki-related-tags-column", title: link_to_wiki("wiki:#{wiki.pretty_title}", wiki.title) %>
+      <%= render "related_tags/tag_column", tags: wiki.tags, class: "other-wiki-related-tags-column", title: link_to_wiki("wiki:#{wiki.pretty_title}", wiki.title, target: "_blank") %>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
Fix #5154
Only add `toggle_tag` listener to links with the `search-tag` class,
add `target="_blank"` to wiki links to prevent accidentally leaving the
edit form.