### PR TITLE
Furaffinity: fix uploads for non-ascii image urls

### DIFF
--- a/app/logical/source/extractor/furaffinity.rb
+++ b/app/logical/source/extractor/furaffinity.rb
@@ -19,7 +19,7 @@ class Source::Extractor
         download_button = html_response&.css(".submission-content .auto_link .button").to_a.find { |el| el.text == "Download" }
         partial_image = download_button&.[]("href")
         return [] unless partial_image.present?
-        [URI.join("https://d.furaffinity.net", partial_image).to_s].compact
+        [Addressable::URI.join("https://d.furaffinity.net", partial_image).to_s].compact
       end
     end
 

--- a/test/unit/sources/furaffinity_test.rb
+++ b/test/unit/sources/furaffinity_test.rb
@@ -42,6 +42,13 @@ module Sources
       strategy_should_work("https://www.furaffinity.net/view/3404111", deleted: true, profile_url: nil)
     end
 
+    context "A furaffinity post with non-ascii image url" do
+      strategy_should_work(
+        "https://www.furaffinity.net/view/20762907/",
+        image_urls: ["https://d.furaffinity.net/art/fhedge/1470365580/1470365580.fhedge_ミストランサーまとめアートボード_1.jpg"]
+      )
+    end
+
     should "Parse Furaffinity URLs correctly" do
       assert(Source::URL.image_url?("https://d.furaffinity.net/art/iwbitu/1650222955/1650222955.iwbitu_yubi.jpg"))
       assert(Source::URL.page_url?("https://www.furaffinity.net/view/46821705/"))


### PR DESCRIPTION
Use Addressable::URI, which supports non-ascii urls.