### PR TITLE
Add data-is-deprecated attribute to tags

### DIFF
--- a/app/components/categorized_tag_list_component/categorized_tag_list_component.html.erb
+++ b/app/components/categorized_tag_list_component/categorized_tag_list_component.html.erb
@@ -6,7 +6,7 @@
 
     <ul class="<%= category_name %>-tag-list">
       <% tags.each do |t| %>
-        <li class="tag-type-<%= t.category %>" data-tag-name="<%= t.name %>">
+        <li class="tag-type-<%= t.category %>" data-tag-name="<%= t.name %>" data-is-deprecated="<%= t.is_deprecated? %>">
           <% if t.artist? %>
             <%= link_to "?", show_or_new_artists_path(name: t.name, z: 1), class: "wiki-link" %>
           <% elsif t.name =~ /\A\d+\z/ %>

--- a/app/components/inline_tag_list_component/inline_tag_list_component.html.erb
+++ b/app/components/inline_tag_list_component/inline_tag_list_component.html.erb
@@ -1,7 +1,7 @@
 <div class="tag-list inline-tag-list">
   <% categorized_tags(TagCategory.categorized_list).each do |category_name, tags| %>
     <% tags.each do |t| %>
-      <%= link_to t.name, posts_path(tags: t.name), class: "search-tag tag-type-#{t.category}", "data-tag-name": t.name %>
+      <%= link_to t.name, posts_path(tags: t.name), class: "search-tag tag-type-#{t.category}", "data-tag-name": t.name, "data-is-deprecated": t.is_deprecated? %>
     <% end %>
   <% end %>
 </div>

--- a/app/components/search_tag_list_component/search_tag_list_component.html.erb
+++ b/app/components/search_tag_list_component/search_tag_list_component.html.erb
@@ -1,6 +1,6 @@
 <ul class="tag-list search-tag-list">
   <% tags.each do |t| %>
-    <li class="tag-type-<%= t.category %>" data-tag-name="<%= t.name %>">
+    <li class="tag-type-<%= t.category %>" data-tag-name="<%= t.name %>" data-is-deprecated="<%= t.is_deprecated? %>">
       <%# ignore search:foo metatags %>
       <% if t.artist? %>
         <%= link_to "?", show_or_new_artists_path(name: t.name, z: 2), class: "wiki-link" %>

--- a/app/views/explore/posts/missed_searches.html.erb
+++ b/app/views/explore/posts/missed_searches.html.erb
@@ -16,7 +16,7 @@
       </thead>
       <tbody>
         <% @missed_searches.each do |search, count| %>
-          <tr class="tag-type-<%= Tag.find_by_name(search)&.category.to_i %>">
+            <tr class="tag-type-<%= Tag.find_by_name(search)&.category.to_i %>" data-is-deprecated=<%= Tag.find_by_name(search)&.is_deprecated? %>>
             <td><%= link_to search, posts_path(tags: search) %></td>
             <td>
               <% unless WikiPage.titled(search).exists? %>

--- a/app/views/explore/posts/searches.html.erb
+++ b/app/views/explore/posts/searches.html.erb
@@ -14,7 +14,7 @@
       </thead>
       <tbody>
         <% @searches.each do |search, count| %>
-          <tr class="tag-type-<%= Tag.find_by_name(search)&.category.to_i %>">
+          <tr class="tag-type-<%= Tag.find_by_name(search)&.category.to_i %>" data-is-deprecated="<%= Tag.find_by_name(search)&.is_deprecated? %>">
             <td><%= link_to search, posts_path(tags: search) %></td>
             <td style="text-align: right;"><%= count.to_i %></td>
           </tr>


### PR DESCRIPTION
Allows using custom CSS to highlight deprecated tags, fixes #5110

```css
[data-is-deprecated='true'] a, a[data-is-deprecated='true'] {
  color: var(--low-post-count-color) !important;
}
```