### PR TITLE
Add back current commit hash to site footer.

### DIFF
--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -180,7 +180,7 @@
   </div>
 
   <footer id="page-footer" class="text-sm flex-initial">
-    <span class="page-footer-app-name"><%= Danbooru.config.app_name %></span>
+    <span class="page-footer-app-name" title="Running commit: <%= Rails.application.config.x.git_hash&.first(9) %>"><%= Danbooru.config.app_name %></span>
     / <%= link_to "Terms", terms_of_service_path %>
     / <%= link_to "Privacy", privacy_policy_path %>
     / <%= link_to "2257", usc_2257_path %>


### PR DESCRIPTION
The commit hash is shown when hovering over the app name in the footer.