### PR TITLE
Notes: allow using -webkit-text-stroke and related

### DIFF
--- a/app/logical/note_sanitizer.rb
+++ b/app/logical/note_sanitizer.rb
@@ -46,6 +46,8 @@ module NoteSanitizer
     text-indent
     text-shadow
     transform transform-origin
+    -webkit-text-fill-color
+    -webkit-text-stroke -webkit-text-stroke-color -webkit-text-stroke-width
     white-space
     word-break
     word-spacing


### PR DESCRIPTION
These properties are widely supported: https://caniuse.com/text-stroke
Currently some notes use multiple text-shadows as a workaround:
https://danbooru.donmai.us/notes?search[body_matches]=text-shadow