### PR TITLE
Allow background-clip and -webkit-background-clip properties in notes

### DIFF
--- a/app/logical/note_sanitizer.rb
+++ b/app/logical/note_sanitizer.rb
@@ -19,6 +19,7 @@ module NoteSanitizer
 
   ALLOWED_PROPERTIES = %w[
     align-items
+    background-clip -webkit-background-clip
     background background-color
     border border-color border-image border-radius border-style border-width
     border-bottom border-bottom-color border-bottom-left-radius border-bottom-right-radius border-bottom-style border-bottom-width


### PR DESCRIPTION
[It's supported by roughly the same browsers ](https://caniuse.com/?search=-webkit-background-clip) as the [previous added properties](https://github.com/danbooru/danbooru/commit/c909555da85c17dac065507e971468248b908b1e) and if everything works fine, it'll allow the translator to make gradient texts and such without resorting to [multiple `<span>` or `<div>` blocks](https://danbooru.donmai.us/posts/4954692?q=noteupdater%3AHyozen+order%3Anote+unconnected_marketeers+) when used along with `-webkit-text-fill-color: transparent`: https://www.w3schools.com/code/tryit.asp?filename=GT23TR6IBESV