### PR TITLE
BURs: don't allow edits to approved scripts

### DIFF
--- a/app/policies/bulk_update_request_policy.rb
+++ b/app/policies/bulk_update_request_policy.rb
@@ -6,7 +6,7 @@ class BulkUpdateRequestPolicy < ApplicationPolicy
   end
 
   def update?
-    unbanned? && (user.is_admin? || record.user_id == user.id)
+    unbanned? && !record.is_approved? && (user.is_admin? || record.user_id == user.id)
   end
 
   def approve?

--- a/app/views/bulk_update_requests/_bur_edit_links.html.erb
+++ b/app/views/bulk_update_requests/_bur_edit_links.html.erb
@@ -1,9 +1,9 @@
 <%# bur %>
 
-<%= link_to_if policy(bur).approve?, "Approve", approve_bulk_update_request_path(bur), remote: true, method: :post, "data-confirm": "Are you sure you want to approve this bulk update request?" %> |
+<%= link_to_if policy(bur).approve?, "Approve", approve_bulk_update_request_path(bur), remote: true, method: :post, "data-confirm": "Are you sure you want to approve this bulk update request?" %>
 <% if policy(bur).destroy? %>
-  <%= link_to "Reject", bur, remote: true, method: :delete, "data-confirm": "Are you sure you want to reject this bulk update request?" %> |
+  | <%= link_to "Reject", bur, remote: true, method: :delete, "data-confirm": "Are you sure you want to reject this bulk update request?" %>
 <% end %>
 <% if policy(bur).update? %>
-  <%= link_to "Edit", edit_bulk_update_request_path(bur), :"data-shortcut" => "e" %>
+  | <%= link_to "Edit", edit_bulk_update_request_path(bur), :"data-shortcut" => "e" %>
 <% end %>


### PR DESCRIPTION
Also fix bad formatting for non-admins in BUR index.
Right now they look like:
![image](https://user-images.githubusercontent.com/12946050/171400923-74fd3849-a9fe-422e-8827-7f4280058c41.png)

I suppose approved BURs could be edited because they often failed so you had to fix them manually, but now they just go into a failed status instead.