### PR TITLE
Add keyboard shortcuts for favorite groups

### DIFF
--- a/app/views/favorite_groups/_secondary_links.html.erb
+++ b/app/views/favorite_groups/_secondary_links.html.erb
@@ -10,8 +10,8 @@
     <%= subnav_link_to "Show", favorite_group_path(@favorite_group) %>
     <%= subnav_link_to "Posts", posts_path(:tags => "favgroup:#{@favorite_group.id} status:any") %>
     <% if policy(@favorite_group).update? %>
-      <%= subnav_link_to "Edit", edit_favorite_group_path(@favorite_group) %>
-      <%= subnav_link_to "Delete", favorite_group_path(@favorite_group), :method => :delete, :data => {:confirm => "Are you sure you want to delete this favorite group?"} %>
+      <%= subnav_link_to "Edit", edit_favorite_group_path(@favorite_group), "data-shortcut": "e" %>
+      <%= subnav_link_to "Delete", favorite_group_path(@favorite_group), :method => :delete, :data => {:shortcut => "shift+d", :confirm => "Are you sure you want to delete this favorite group?"} %>
       <% if @favorite_group.post_count <= 100 %>
         <%= subnav_link_to "Order", edit_favorite_group_order_path(@favorite_group) %>
       <% end %>

--- a/app/views/static/keyboard_shortcuts.html.erb
+++ b/app/views/static/keyboard_shortcuts.html.erb
@@ -64,6 +64,12 @@
           <li><kbd class="key">e</kbd> Edit wiki page</li>
           <li><kbd class="key">shift</kbd>+<kbd class="key">d</kbd> Delete wiki page</li>
         </ul>
+
+        <h2>Favorite Groups</h2>
+        <ul>
+          <li><kbd class="key">e</kbd> Edit favorite group</li>
+          <li><kbd class="key">shift</kbd>+<kbd class="key">d</kbd> Delete favorite group</li>
+        </ul>
       </section>
     </div>
   </div>


### PR DESCRIPTION
Add edit (<kbd>e</kbd>) and delete (<kbd>shift</kbd> + <kbd>d</kbd>) keyboard shortcuts for favorite groups, in the same fashion as artists, forum, pools, and wiki.

I plan to add a few more as mentioned in #5175, please let me know if there's anything :)