### PR TITLE
Fix some long tags / wiki links overflowing their container

### DIFF
--- a/app/javascript/src/styles/common/main_layout.scss
+++ b/app/javascript/src/styles/common/main_layout.scss
@@ -40,6 +40,8 @@ footer#page-footer {
     @media (min-width: 1920px) {
       min-width: 280px;
     }
+
+    overflow-wrap: break-word;
   }
 
   #content {

--- a/app/javascript/src/styles/specific/post_tooltips.scss
+++ b/app/javascript/src/styles/specific/post_tooltips.scss
@@ -32,8 +32,13 @@ $tooltip-body-height: $tooltip-line-height * 6; // 4 lines high.
         margin-right: 0;
       }
 
-      .post-tooltip-body-left { flex: 0; }
-      .post-tooltip-body-right { flex: 1; }
+      .post-tooltip-body-left {
+        flex: 0;
+      }
+      .post-tooltip-body-right {
+        flex: 1;
+        min-width: 0;
+      }
     }
 
     div.post-tooltip-header {


### PR DESCRIPTION
Follow-up to 136e2777cb514763fb994565882ad737e201cc81, which didn't account for the wiki_pages sidebar.
Additionally fix tags containing long words causing the post tooltip to overflow (realistically this only happens for tooltips containing a preview image), for example post #1489167:
![image](https://user-images.githubusercontent.com/94963033/188267330-188f4442-dcba-4169-bfc4-f3e006715fc9.png)
The post tooltip fix needs the `overflow-wrap: break-word`, so I didn't revert 136e2777cb514763fb994565882ad737e201cc81.