### PR TITLE
Added `api:` to the list of META_WIKIS

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -3,7 +3,7 @@
 class WikiPage < ApplicationRecord
   class RevertError < StandardError; end
 
-  META_WIKIS = ["list_of_", "tag_group:", "pool_group:", "howto:", "about:", "help:", "template:"]
+  META_WIKIS = ["list_of_", "tag_group:", "pool_group:", "howto:", "about:", "help:", "template:","api:"]
 
   after_save :create_version
 


### PR DESCRIPTION
As of right now, api wiki pages are categorized as "general" when they should be categorized as "meta". Please see issue #5206 