### PR TITLE
BURs: allow implying tags from artist to meta categories

### DIFF
--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -103,10 +103,11 @@ class TagImplication < TagRelationship
       end
     end
 
-    # Require tags to have the same category. Doesn't apply when either tag is empty,
-    # because they could have been populated from a previous update script.
+    # Require tags to have the same category, or an artist tag implying a meta tag.
+    # Doesn't apply when either tag is empty, because they could have been populated from a previous update script.
     def tag_categories_are_compatible
       return if antecedent_tag.empty? || consequent_tag.empty?
+      return if antecedent_tag.artist? && consequent_tag.meta?
       if antecedent_tag.category != consequent_tag.category
         errors.add(:base, "Can't imply a #{antecedent_tag.category_name.downcase} tag to a #{consequent_tag.category_name.downcase} tag")
       end


### PR DESCRIPTION
Addresses #5275
My editor complains that the methods `artist?` and `meta?` don't exist, but also complains about similar methods (i.e. `general?`) not existing as well.