### PR TITLE
enable styled usernames by default

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -680,6 +680,7 @@ class User < ApplicationRecord
 
   def initialize_attributes
     self.new_post_navigation_layout = true
+    self.style_usernames = true
   end
 
   def presenter


### PR DESCRIPTION
It's useful to know who you're talking to. This won't apply to existing accounts with it disabled. Alternatively this setting could be removed entirely and only have them enabled, and people who want them off can use custom CSS to do so.