### PR TITLE
Users: display colored usernames by default

### DIFF
--- a/app/javascript/src/styles/common/user_styles.scss
+++ b/app/javascript/src/styles/common/user_styles.scss
@@ -1,4 +1,4 @@
-body[data-current-user-style-usernames="true"] {
+body {
   a.user-owner {
     color: var(--user-admin-color);
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
     enable_private_favorites
     _unused_enable_sequential_post_navigation
     _unused_hide_deleted_posts
-    style_usernames
+    _unused_style_usernames
     _unused_enable_auto_complete
     show_deleted_children
     _unused_has_saved_searches

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -47,7 +47,7 @@ class UserPolicy < ApplicationPolicy
       blacklisted_tags time_zone per_page custom_style theme
       receive_email_notifications
       new_post_navigation_layout enable_private_favorites
-      style_usernames show_deleted_posts show_deleted_children
+      show_deleted_posts show_deleted_children
       disable_categorized_saved_searches disable_tagged_filenames
       disable_mobile_gestures enable_safe_mode
       enable_desktop_mode disable_post_tooltips

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -58,7 +58,6 @@
           </p>
         </div>
 
-        <%= f.input :style_usernames, :as => :select, :label => "Colored usernames", :hint => "Color users according to their user level", :include_blank => false, :collection => [["Yes", "true"], ["No", "false"]] %>
         <%= f.input :new_post_navigation_layout, :as => :select, :label => "Navigation bar position", :include_blank => false, :collection => [["Below", "true"], ["Above", "false"]], :hint => "When browsing pools or posts, place navigation links above or below the image" %>
         <%= f.input :show_deleted_posts, as: :select, hint: "Show deleted posts in searches", collection: [["No", "false"], ["Yes", "true"]], include_blank: false %>
         <%= f.input :show_deleted_children, :as => :select, :label => "Show deleted children", :hint => "Show thumbnail borders on parent posts even if the children are deleted", :include_blank => false, :collection => [["Yes", "true"], ["No", "false"]] %>


### PR DESCRIPTION
The previous behavior can be replicated by putting the following in the custom css:

    .user { color: var(--link-color) !important }

This is an alternative to pull #5296. It doesn't make sense for us to keep this as a setting anymore given that those who don't want it can just use custom css.