### PR TITLE
Posts: show levelblocked posts to their uploader

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1584,7 +1584,7 @@ class Post < ApplicationRecord
 
   def levelblocked?(user = CurrentUser.user)
     #!user.is_gold? && RESTRICTED_TAGS.any? { |tag| has_tag?(tag) }
-    !user.is_gold? && tag_string.match?(RESTRICTED_TAGS_REGEX)
+    user != uploader && !user.is_gold? && tag_string.match?(RESTRICTED_TAGS_REGEX)
   end
 
   def banblocked?(user = CurrentUser.user)


### PR DESCRIPTION
I first raised this in issue #3261 when I was a member, because it REALLY sucked to not be able to fix your own uploads. Five years and several user levels later I still think this is a very annoying restriction that has no reason to exist and is really frustrating to new users. Nobody is going to buy an account just to see their own uploads.