### PR TITLE
Users: add Contributor and Approver user levels

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,10 +10,8 @@ module Admin
       @user = authorize User.find(params[:id]), :promote?
 
       @level = params.dig(:user, :level)
-      @can_upload_free = params.dig(:user, :can_upload_free)
-      @can_approve_posts = params.dig(:user, :can_approve_posts)
 
-      @user.promote_to!(@level, CurrentUser.user, can_upload_free: @can_upload_free, can_approve_posts: @can_approve_posts)
+      @user.promote_to!(@level, CurrentUser.user)
 
       redirect_to edit_admin_user_path(@user), :notice => "User updated"
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -218,9 +218,7 @@ module ApplicationHelper
   def link_to_user(user, text = nil, classes: nil, **options)
     return "anonymous" if user.blank?
 
-    user_class = "user user-#{user.level_string.downcase} #{classes}"
-    user_class += " user-post-approver" if user.can_approve_posts?
-    user_class += " user-post-uploader" if user.can_upload_free?
+    user_class = "user user-#{user.level_string.downcase} #{classes}".strip
     user_class += " user-banned" if user.is_banned?
 
     text = user.pretty_name if text.blank?

--- a/app/javascript/src/styles/common/user_styles.scss
+++ b/app/javascript/src/styles/common/user_styles.scss
@@ -11,6 +11,14 @@ body {
     color: var(--user-moderator-color);
   }
 
+  a.user-approver {
+    color: var(--user-builder-color);
+  }
+
+  a.user-contributor {
+    color: var(--user-builder-color);
+  }
+
   a.user-builder {
     color: var(--user-builder-color);
   }

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -470,7 +470,7 @@ class PostQueryBuilder
       relation = relation.reorder(Arel.sql("log(3, posts.score) + (extract(epoch from posts.created_at) - extract(epoch from timestamp '2005-05-24')) / 35000 DESC"))
 
     when "curated"
-      contributors = User.bit_prefs_match(:can_upload_free, true)
+      contributors = User.where("level >= ?", User::Levels::CONTRIBUTOR)
 
       relation = relation
         .joins(:favorites)

--- a/app/logical/upload_limit.rb
+++ b/app/logical/upload_limit.rb
@@ -39,7 +39,7 @@ class UploadLimit
 
   # @return [Boolean] true if the user can't upload because they're out of upload slots.
   def limited?
-    !user.can_upload_free? && used_upload_slots >= upload_slots
+    !user.is_contributor? && used_upload_slots >= upload_slots
   end
 
   # @return [Boolean] true if the user is at max level.
@@ -91,7 +91,7 @@ class UploadLimit
   # @param is_approval [Boolean] true if the post is being approved or
   #   undeleted, false if the post is being deleted.
   def update_limit!(is_pending, is_approval)
-    return if user.can_upload_free?
+    return if user.is_contributor?
 
     user.with_lock do
       # If we're approving or deleting a pending post, we can simply increment

--- a/app/logical/user_promotion.rb
+++ b/app/logical/user_promotion.rb
@@ -5,31 +5,22 @@
 # user a feedback, sends them a notification dmail, and creates a mod action for
 # the promotion.
 class UserPromotion
-  attr_reader :user, :promoter, :new_level, :old_can_approve_posts, :old_can_upload_free, :can_upload_free, :can_approve_posts
+  attr_reader :user, :promoter, :new_level
 
   # Initialize a new promotion.
   # @param user [User] the user to promote
   # @param promoter [User] the user doing the promotion
   # @param new_level [Integer] the new user level
-  # @param can_upload_free [Boolean] whether the user should gain unlimited upload privileges
-  # @param can_approve_posts [Boolean] whether the user should gain approval privileges
-  def initialize(user, promoter, new_level, can_upload_free: nil, can_approve_posts: nil)
+  def initialize(user, promoter, new_level)
     @user = user
     @promoter = promoter
     @new_level = new_level.to_i
-    @can_upload_free = can_upload_free
-    @can_approve_posts = can_approve_posts
   end
 
   def promote!
     validate!
 
-    @old_can_approve_posts = user.can_approve_posts?
-    @old_can_upload_free = user.can_upload_free?
-
     user.level = new_level
-    user.can_upload_free = can_upload_free unless can_upload_free.nil?
-    user.can_approve_posts = can_approve_posts unless can_approve_posts.nil?
 
     create_user_feedback
     create_dmail
@@ -41,18 +32,6 @@ class UserPromotion
   private
 
   def create_mod_actions
-    if old_can_approve_posts == false && user.can_approve_posts? == true
-      ModAction.log("granted approval privileges to \"#{user.name}\":#{Routes.user_path(user)}", :user_approval_privilege, subject: user, user: promoter)
-    elsif old_can_approve_posts == true && user.can_approve_posts? == false
-      ModAction.log("removed approval privileges from \"#{user.name}\":#{Routes.user_path(user)}", :user_approval_privilege, subject: user, user: promoter)
-    end
-
-    if old_can_upload_free == false && user.can_upload_free? == true
-      ModAction.log("granted unlimited upload privileges to \"#{user.name}\":#{Routes.user_path(user)}", :user_upload_privilege, subject: user, user: promoter)
-    elsif old_can_upload_free == false && user.can_upload_free? == true
-      ModAction.log("removed unlimited upload privileges from \"#{user.name}\":#{Routes.user_path(user)}", :user_upload_privilege, subject: user, user: promoter)
-    end
-
     if user.level_changed? && user.level >= user.level_was
       ModAction.log(%{promoted "#{user.name}":#{Routes.user_path(user)} from #{user.level_string_was} to #{user.level_string}}, :user_level_change, subject: user, user: promoter)
     elsif user.level_changed? && user.level < user.level_was
@@ -73,37 +52,20 @@ class UserPromotion
   end
 
   # Build the dmail and user feedback message.
-  def build_messages
-    messages = []
-
-    if user.level_changed?
-      if user.level > user.level_was
-        messages << "You have been promoted to a #{user.level_string} level account from #{user.level_string_was}."
-      elsif user.level < user.level_was
-        messages << "You have been demoted to a #{user.level_string} level account from #{user.level_string_was}."
-      end
+  def build_message
+    level_string = (user.level == User::Levels::APPROVER) ? "an Approver" : "a #{user.level_string}"
+    if user.level > user.level_was
+      "You have been promoted to #{level_string} level account from #{user.level_string_was}."
+    elsif user.level < user.level_was
+      "You have been demoted to #{level_string} level account from #{user.level_string_was}."
     end
-
-    if user.can_approve_posts? && !old_can_approve_posts
-      messages << "You gained the ability to approve posts."
-    elsif !user.can_approve_posts? && old_can_approve_posts
-      messages << "You lost the ability to approve posts."
-    end
-
-    if user.can_upload_free? && !old_can_upload_free
-      messages << "You gained the ability to upload posts without limit."
-    elsif !user.can_upload_free? && old_can_upload_free
-      messages << "You lost the ability to upload posts without limit."
-    end
-
-    messages.join("\n")
   end
 
   def create_dmail
-    Dmail.create_automated(to_id: user.id, title: "Your account has been updated", body: build_messages)
+    Dmail.create_automated(to_id: user.id, title: "Your account has been updated", body: build_message)
   end
 
   def create_user_feedback
-    UserFeedback.create(user: user, creator: promoter, category: "neutral", body: build_messages, disable_dmail_notification: true)
+    UserFeedback.create(user: user, creator: promoter, category: "neutral", body: build_message, disable_dmail_notification: true)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -120,7 +120,7 @@ class Post < ApplicationRecord
       tag_string: tag_string,
       rating: rating,
       parent_id: parent_id,
-      is_pending: !upload.uploader.can_upload_free? || is_pending.to_s.truthy?,
+      is_pending: !upload.uploader.is_contributor? || is_pending.to_s.truthy?,
       artist_commentary: (commentary if commentary.any_field_present?),
     )
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -56,9 +56,8 @@ class UserPolicy < ApplicationPolicy
 
   def api_attributes
     attributes = %i[
-      id created_at name inviter_id level
+      id created_at name inviter_id level level_string
       post_upload_count post_update_count note_update_count is_banned
-      can_approve_posts can_upload_free level_string
     ]
 
     if record.id == user.id

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -15,20 +15,6 @@ class UserPresenter
     user.created_at.strftime("%Y-%m-%d")
   end
 
-  def permissions
-    permissions = []
-
-    if user.can_approve_posts?
-      permissions << "approve posts"
-    end
-
-    if user.can_upload_free?
-      permissions << "unrestricted uploads"
-    end
-
-    permissions.join(", ")
-  end
-
   def posts_for_saved_search_category(category)
     Post.user_tag_match("search:#{category}").limit(10)
   end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -7,8 +7,6 @@
 
     <%= edit_form_for(@user, url: admin_user_path(@user)) do |f| %>
       <%= f.input :level, collection: User.level_hash.to_a, selected: @user.level %>
-      <%= f.input :can_upload_free, label: "Unrestricted Uploads", as: :boolean, selected: @user.can_upload_free %>
-      <%= f.input :can_approve_posts, label: "Approve Posts", as: :boolean, selected: @user.can_approve_posts %>
       <%= f.submit "Update" %>
     <% end %>
   </div>

--- a/app/views/post_disapprovals/_compact_counts.html.erb
+++ b/app/views/post_disapprovals/_compact_counts.html.erb
@@ -1,4 +1,4 @@
-<% if (CurrentUser.can_approve_posts? || post.created_at < Danbooru.config.moderation_period.ago) && disapprovals.length > 0 %>
+<% if (CurrentUser.is_approver? || post.created_at < Danbooru.config.moderation_period.ago) && disapprovals.length > 0 %>
   <% if disapprovals.map(&:reason).grep("breaks_rules").count > 0 %>
     (breaks rules: <%= disapprovals.map(&:reason).grep("breaks_rules").count %>)
   <% end %>

--- a/app/views/post_disapprovals/_counts.html.erb
+++ b/app/views/post_disapprovals/_counts.html.erb
@@ -1,4 +1,4 @@
-<% if (CurrentUser.can_approve_posts? || post.created_at < Danbooru.config.moderation_period.ago) && disapprovals.length > 0 %>
+<% if (CurrentUser.is_approver? || post.created_at < Danbooru.config.moderation_period.ago) && disapprovals.length > 0 %>
   <p>
     It has been reviewed by <%= pluralize disapprovals.length, "approver" %>.
 

--- a/app/views/uploads/_single_asset_upload.html.erb
+++ b/app/views/uploads/_single_asset_upload.html.erb
@@ -16,7 +16,7 @@
 
   <%= embed_wiki("help:upload_notice", id: "upload-guide-notice") %>
 
-  <% unless CurrentUser.can_upload_free? %>
+  <% unless CurrentUser.is_contributor? %>
     <p id="upload-limit">Upload Limit: <%= render "users/upload_limit", user: CurrentUser.user %></p>
   <% end %>
 
@@ -88,7 +88,7 @@
 
     <%= f.submit "Post" %>
 
-    <% if CurrentUser.can_upload_free? %>
+    <% if CurrentUser.is_contributor? %>
       <%= f.input :is_pending, as: :boolean, label: "Upload for approval", wrapper_html: { class: "inline-block" }, input_html: { checked: post.is_pending? } %>
     <% end %>
 

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -94,11 +94,6 @@
         </td>
       </tr>
 
-      <tr>
-        <th>Permissions</th>
-        <td><%= presenter.permissions %></td>
-      </tr>
-
       <% if user.is_banned? && user.active_ban.present? %>
         <tr>
           <th>Ban reason</th>

--- a/app/views/users/_upload_limit.html.erb
+++ b/app/views/users/_upload_limit.html.erb
@@ -1,6 +1,6 @@
 <%# user %>
 
-<% if user.can_upload_free? %>
+<% if user.is_contributor? %>
   none
 <% else %>
   <%= link_to user.upload_limit.used_upload_slots, posts_path(tags: "user:#{user.name} status:pending") %> /

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -5,8 +5,6 @@
     <%= search_form_for(users_path) do |f| %>
       <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "user" } } %>
       <%= f.input :level, collection: User.level_hash.to_a, include_blank: true, selected: params[:search][:level] %>
-      <%= f.input :can_upload_free, label: "Contributor?", as: :select, include_blank: true, selected: params[:search][:can_upload_free] %>
-      <%= f.input :can_approve_posts, label: "Approver?", as: :select, include_blank: true, selected: params[:search][:can_approve_posts] %>
       <%= f.input :order, collection: [["Joined", "date"], ["Name", "name"], ["Posts", "post_upload_count"], ["Edits", "post_update_count"], ["Notes", "note_count"]], include_blank: true, selected: params[:search][:order] %>
       <%= f.submit "Search" %>
     <% end %>

--- a/app/views/users/show.html+tooltip.erb
+++ b/app/views/users/show.html+tooltip.erb
@@ -7,14 +7,6 @@
 
       <% if @user.is_banned? %>
         <%= link_to "Banned", users_path(search: { is_banned: true }), class: "user-tooltip-badge user-tooltip-badge-banned" %>
-      <% elsif @user.is_admin? %>
-        <%= link_to @user.level_string, users_path(search: { level: @user.level }), class: "user-tooltip-badge user-tooltip-badge-#{@user.level_string.downcase}" %>
-      <% elsif @user.is_moderator? %>
-        <%= link_to @user.level_string, users_path(search: { level: @user.level }), class: "user-tooltip-badge user-tooltip-badge-#{@user.level_string.downcase}" %>
-      <% elsif @user.can_approve_posts? %>
-        <%= link_to "Approver", users_path(search: { can_approve_posts: true }), class: "user-tooltip-badge user-tooltip-badge-approver" %>
-      <% elsif @user.can_upload_free? %>
-        <%= link_to "Contributor", users_path(search: { can_upload_free: true }), class: "user-tooltip-badge user-tooltip-badge-contributor" %>
       <% else %>
         <%= link_to @user.level_string, users_path(search: { level: @user.level }), class: "user-tooltip-badge user-tooltip-badge-#{@user.level_string.downcase}" %>
       <% end %>

--- a/db/populate.rb
+++ b/db/populate.rb
@@ -33,12 +33,6 @@ def populate_users(n, password: DEFAULT_PASSWORD)
     puts "Created user ##{user.id} (#{user.name})"
   end
 
-  user = User.create(name: "contributor", password: password, password_confirmation: password, level: User::Levels::BUILDER, can_upload_free: true)
-  puts "Created user ##{user.id} (#{user.name})"
-
-  user = User.create(name: "approver", password: password, password_confirmation: password, level: User::Levels::BUILDER, can_upload_free: true, can_approve_posts: true)
-  puts "Created user ##{user.id} (#{user.name})"
-
   n.times do |i|
     user = User.create(name: FFaker::Internet.user_name, password: password, password_confirmation: password, level: User::Levels::MEMBER)
     puts "Created user ##{user.id}"

--- a/script/fixes/122_populate_approvers_and_contributors.rb
+++ b/script/fixes/122_populate_approvers_and_contributors.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require_relative "base"
+
+with_confirmation do
+  User.where(level: User::Levels::BUILDER).bit_prefs_match(:_unused_can_upload_free, true).bit_prefs_match(:_unused_can_approve_posts, false).find_each do |contributor|
+    contributor.level = User::Levels::CONTRIBUTOR
+    contributor.save
+    puts "user ##{contributor.id} #{contributor.name} updated to contributor"
+  end
+
+  User.where(level: User::Levels::BUILDER).bit_prefs_match(:_unused_can_approve_posts, true).find_each do |approver|
+    approver.level = User::Levels::APPROVER
+    approver.save
+    puts "user ##{contributor.id} #{approver.name} updated to approver"
+  end
+end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -12,64 +12,30 @@ FactoryBot.define do
     end
 
     factory(:restricted_user) do
-      level {10}
+      level {User::Levels::RESTRICTED}
       requires_verification { true }
       is_verified { false }
     end
 
-    factory(:member_user) do
-      level {20}
-    end
+    User.level_hash.each do |level_name, level_value|
+      # allows create(:moderator_user), create(:approver) etc
+      next if level_name == "Restricted"  # already defined above
 
-    factory(:gold_user) do
-      level {30}
-    end
+      factory(level_name.downcase) do
+        level {level_value}
+      end
 
-    factory(:platinum_user) do
-      level {31}
-    end
-
-    factory(:builder_user) do
-      level {32}
-    end
-
-    factory(:contributor_user) do
-      level {32}
-      can_upload_free {true}
-    end
-
-    factory(:contrib_user) do
-      level {32}
-      can_upload_free {true}
-    end
-
-    factory(:moderator_user) do
-      level {40}
-      can_approve_posts {true}
+      factory("#{level_name.downcase}_user") do
+        level {level_value}
+      end
     end
 
     factory(:mod_user) do
-      level {40}
-      can_approve_posts {true}
-    end
-
-    factory(:admin_user) do
-      level {50}
-      can_approve_posts {true}
-    end
-
-    factory(:owner_user) do
-      level { User::Levels::OWNER }
-      can_approve_posts {true}
+      level {User::Levels::MODERATOR}
     end
 
     factory(:uploader) do
       created_at { 2.weeks.ago }
-    end
-
-    factory(:approver) do
-      level {32}
-      can_approve_posts {true}
     end
   end
 end

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -22,37 +22,7 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
 
           assert_redirected_to(edit_admin_user_path(@user))
           assert_equal(30, @user.reload.level)
-          assert_match(/promoted "#{@user.name}":\/users\/#{@user.id} from Member to Gold/, ModAction.last.description)
-          assert_equal(@user, ModAction.last.subject)
-          assert_equal(@mod, ModAction.last.creator)
-        end
-
-        should "promote the user to unrestricted uploads" do
-          put_auth admin_user_path(@user), @mod, params: { user: { level: User::Levels::BUILDER, can_upload_free: true }}
-
-          assert_redirected_to(edit_admin_user_path(@user.reload))
-          assert_equal(true, @user.is_builder?)
-          assert_equal(true, @user.can_upload_free?)
-          assert_equal(false, @user.can_approve_posts?)
-          assert_match(/granted unlimited upload privileges to "#{@user.name}":\/users\/#{@user.id}/, ModAction.first.description)
-          assert_match(/promoted "#{@user.name}":\/users\/#{@user.id} from Member to Builder/, ModAction.last.description)
-          assert_equal(@user, ModAction.first.subject)
-          assert_equal(@mod, ModAction.first.creator)
-          assert_equal(@user, ModAction.last.subject)
-          assert_equal(@mod, ModAction.last.creator)
-        end
-
-        should "promote the user to approver" do
-          put_auth admin_user_path(@user), @mod, params: { user: { level: User::Levels::BUILDER, can_approve_posts: true }}
-
-          assert_redirected_to(edit_admin_user_path(@user.reload))
-          assert_equal(true, @user.is_builder?)
-          assert_equal(false, @user.can_upload_free?)
-          assert_equal(true, @user.can_approve_posts?)
-          assert_match(/granted approval privileges to "#{@user.name}":\/users\/#{@user.id}/, ModAction.first.description)
-          assert_match(/promoted "#{@user.name}":\/users\/#{@user.id} from Member to Builder/, ModAction.last.description)
-          assert_equal(@user, ModAction.first.subject)
-          assert_equal(@mod, ModAction.first.creator)
+          assert_match(%r{promoted "#{@user.name}":/users/#{@user.id} from Member to Gold}, ModAction.last.description)
           assert_equal(@user, ModAction.last.subject)
           assert_equal(@mod, ModAction.last.creator)
         end

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -522,8 +522,8 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
       context "with everything" do
         setup do
-          @admin = create(:admin_user, can_approve_posts: true)
-          @builder = create(:builder_user, can_approve_posts: true)
+          @admin = create(:admin_user)
+          @approver = create(:approver_user)
 
           as(@user) do
             @post.update!(tag_string: "1girl solo highres blah 2001")
@@ -545,7 +545,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
             #create(:post_appeal, post: @post, creator: @user)
             create(:post_vote, post: @post, user: @user)
             create(:favorite, post: @post, user: @user)
-            create(:moderation_report, model: @comment, creator: @builder)
+            create(:moderation_report, model: @comment, creator: @approver)
           end
         end
 
@@ -560,7 +560,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
         end
 
         should "render for a builder" do
-          get_auth post_path(@post), @builder
+          get_auth post_path(@post), @approver
           assert_response :success
         end
 
@@ -570,7 +570,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
         end
 
         should "render for a builder with a search query" do
-          get_auth post_path(@post, q: "tagme"), @builder
+          get_auth post_path(@post, q: "tagme"), @approver
           assert_response :success
         end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -9,7 +9,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     context "index action" do
       setup do
         @mod_user = create(:moderator_user, name: "yukari")
-        @other_user = create(:builder_user, can_upload_free: true, inviter: @mod_user, created_at: 2.weeks.ago)
+        @other_user = create(:contributor_user, inviter: @mod_user, created_at: 2.weeks.ago)
         @uploader = create(:user, created_at: 2.weeks.ago)
       end
 
@@ -41,7 +41,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       should respond_to_search({}).with { [@uploader, @other_user, @mod_user, @user, User.system] }
       should respond_to_search(min_level: User::Levels::BUILDER).with { [@other_user, @mod_user, User.system] }
-      should respond_to_search(can_upload_free: "true").with { @other_user }
       should respond_to_search(name_matches: "yukari").with { @mod_user }
 
       context "using includes" do
@@ -114,7 +113,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     context "show action" do
       setup do
         # flesh out profile to get more test coverage of user presenter.
-        @user = create(:user, can_approve_posts: true, created_at: 2.weeks.ago)
+        @user = create(:approver, created_at: 2.weeks.ago)
         as(@user) do
           create(:saved_search, user: @user)
           create(:post, uploader: @user, tag_string: "fav:#{@user.name}")

--- a/test/unit/approver_pruner_test.rb
+++ b/test/unit/approver_pruner_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class ApproverPrunerTest < ActiveSupport::TestCase
   context "ApproverPruner" do
     setup do
-      @approver = create(:user, can_approve_posts: true)
+      @approver = create(:approver)
     end
 
     should "demote inactive approvers" do
       assert_equal([@approver.id], ApproverPruner.inactive_approvers.map(&:id))
       assert_nothing_raised { ApproverPruner.prune! }
-      assert_equal(false, @approver.reload.can_approve_posts)
+      assert_equal(User::Levels::CONTRIBUTOR, @approver.reload.level)
     end
 
     should "not demote active approvers" do
@@ -22,7 +22,7 @@ class ApproverPrunerTest < ActiveSupport::TestCase
     should "not demote recently promoted approvers" do
       as(create(:admin_user)) do
         @user = create(:user)
-        @user.promote_to!(User::Levels::BUILDER, can_approve_posts: true)
+        @user.promote_to!(User::Levels::APPROVER)
       end
 
       assert_not_includes(ApproverPruner.inactive_approvers.map(&:id), @user.id)

--- a/test/unit/post_appeal_test.rb
+++ b/test/unit/post_appeal_test.rb
@@ -43,7 +43,7 @@ class PostAppealTest < ActiveSupport::TestCase
 
         context "for users with unrestricted uploads" do
           should "should not have an appeal limit" do
-            @user = create(:user, can_upload_free: true)
+            @user = create(:contributor)
             create_list(:post_appeal, 10, creator: @user)
 
             assert_equal(15, @user.upload_limit.upload_slots)

--- a/test/unit/post_approval_test.rb
+++ b/test/unit/post_approval_test.rb
@@ -5,7 +5,7 @@ class PostApprovalTest < ActiveSupport::TestCase
     setup do
       @user = create(:user, created_at: 2.weeks.ago)
       @post = create(:post, uploader: @user, is_pending: true)
-      @approver = create(:user, can_approve_posts: true)
+      @approver = create(:approver)
     end
 
     context "a pending post" do

--- a/test/unit/post_flag_test.rb
+++ b/test/unit/post_flag_test.rb
@@ -4,7 +4,7 @@ class PostFlagTest < ActiveSupport::TestCase
   context "PostFlag: " do
     context "an approver" do
       should "be able to flag an unlimited number of posts" do
-        @user = create(:user, can_approve_posts: true)
+        @user = create(:approver)
 
         assert_nothing_raised do
           create_list(:post_flag, 6, creator: @user, status: :pending)


### PR DESCRIPTION
As discussed before. 


`script/fixes/122_populate_approvers_and_contributors.rb` needs to be run to transform unrestricted/approvers to the new level. 

I left the automatic demotion for approvers to how it was, because I imagine it would make people butthurt to get "You have been demoted" as a feedback for being inactive, but let me know if it doesn't matter and it should just leave a normal demotion feedback instead.


I couldn't run the functional tests because of this error:

```
Minitest::UnexpectedError:         RuntimeError: failed to execute:
        psql --set ON_ERROR_STOP=1 --quiet --no-psqlrc --output /dev/null --file /danbooru/db/structure.sql danbooru-1
      
        Please check the output above for any errors and make sure that `psql` is installed in your PATH and has proper permissions.
```

but I tried to test everything that wasn't covered by the unit tests manually.