### PR TITLE
uploads: link to the media asset from the upload page

### DIFF
--- a/app/views/uploads/_single_asset_upload.html.erb
+++ b/app/views/uploads/_single_asset_upload.html.erb
@@ -31,6 +31,7 @@
         <%= number_to_human_size(media_asset.file_size) %> .<%= media_asset.file_ext %>
       <% end %>
       (<%= media_asset.image_width %>x<%= media_asset.image_height %>)
+      <%= link_to "»", media_asset_path(media_asset) %>
     </p>
   </div>
 


### PR DESCRIPTION
Similar to how there's a link on the post page. For convenience of checking metadata.