### PR TITLE
fix category text formatting in CategorizedTagList template

### DIFF
--- a/app/components/categorized_tag_list_component/categorized_tag_list_component.html.erb
+++ b/app/components/categorized_tag_list_component/categorized_tag_list_component.html.erb
@@ -1,7 +1,7 @@
 <div class="tag-list categorized-tag-list">
   <% categorized_tags(TagCategory.split_header_list).each do |category_name, tags| %>
     <h3 class="<%= category_name %>-tag-list">
-      <%= category_name.capitalize.pluralize(tags) %>
+      <%= category_name.titleize.pluralize(tags.length) %>
     </h3>
 
     <ul class="<%= category_name %>-tag-list">


### PR DESCRIPTION
The call to `#capitalize` doesn't inflect properly and the call to `#pluralize` doesn't work right as it is receiving an array instead of a number.