### PR TITLE
views: Don't show 'Edit' link when editing a wiki

### DIFF
--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -13,15 +13,15 @@
     <li>|</li>
     <%= subnav_link_to "Posts (#{@wiki_page.tag.try(:post_count) || 0})", posts_path(:tags => @wiki_page.title) %>
     <%= subnav_link_to "History", wiki_page_versions_path(:search => {:wiki_page_id => @wiki_page.id}) %>
-    <% if policy(@wiki_page).edit? %>
-      <%= subnav_link_to "Edit", edit_wiki_page_path(@wiki_page.id), "data-shortcut": "e" %>
-
+    <% if policy(@wiki_page).edit? and %>
       <% if current_page?(action: :edit) %>
         <% if @wiki_page.is_deleted? %>
           <%= subnav_link_to "Undelete", wiki_page_path(@wiki_page.id), remote: true, method: :put, "data-params": "wiki_page[is_deleted]=false", "data-shortcut": "shift+d", "data-confirm": "Are you sure you want to undelete this wiki?" %>
         <% else %>
           <%= subnav_link_to "Delete", wiki_page_path(@wiki_page.id), remote: true, method: :put, "data-params": "wiki_page[is_deleted]=true", "data-shortcut": "shift+d", "data-confirm": "Are you sure you want to delete this wiki?" %>
         <% end %>
+      <% else %>
+        <%= subnav_link_to "Edit", edit_wiki_page_path(@wiki_page.id), "data-shortcut": "e" %>
       <% end %>
     <% end %>
   <% elsif @wiki_page_version %>


### PR DESCRIPTION
Right now, if you click Edit or hit the "e" shortcut key while editing a wiki page, the page will essentially reload, and you could lose all your changes without warning. A user on Discord had this issue because they forgot they were in Preview mode and clicked Edit again.

This makes it so Edit doesn't show when you're editing. Edit is only visible when Delete isn't.