### PR TITLE
Removed deprecated docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Alternatively, if you already have Docker Compose installed, you can just do:
 
 ```sh
 wget https://raw.githubusercontent.com/danbooru/danbooru/master/docker-compose.yaml
-docker-compose up
+docker compose up
 ```
+
+You will likely need to run docker with elevated permissions.
 
 If you get an error such as `'name' does not match any of the regexes: '^x-'` make sure
 that you're running an updated version of Docker Compose.


### PR DESCRIPTION
Removed deprecated `docker-compose` command and replaced with `docker compose`. Also added a reminder that `docker compose` may need to be run with elevated privileges.