### PR TITLE
Add image sample URL recognition

### DIFF
--- a/app/logical/source/url.rb
+++ b/app/logical/source/url.rb
@@ -288,12 +288,27 @@ module Source
       recognized? && image_url? && page_url.nil?
     end
 
+    # Determine if the URL is considered an "image sample".
+    #
+    # Posts will be tagged "image_sample" if this returns true for the post's source URL. If this returns false, then the
+    # image_sample tag will be removed. If this returns nil, then the image_sample tag will not be added or removed.
+    #
+    # @return [Boolean, nil] True if the URL is an image sample, false if it's not an image sample, or nil if we don't know
+    #   whether it's an image sample or not.
+    def image_sample?
+      nil
+    end
+
     def self.site_name(url)
       Source::URL.parse(url)&.site_name
     end
 
     def self.image_url?(url)
       Source::URL.parse(url)&.image_url?
+    end
+
+    def self.image_sample?(url)
+      Source::URL.parse(url)&.image_sample?
     end
 
     def self.page_url?(url)

--- a/app/logical/source/url.rb
+++ b/app/logical/source/url.rb
@@ -290,9 +290,6 @@ module Source
 
     # Determine if the URL is considered an "image sample".
     #
-    # Posts will be tagged "image_sample" if this returns true for the post's source URL. If this returns false, then the
-    # image_sample tag will be removed. If this returns nil, then the image_sample tag will not be added or removed.
-    #
     # @return [Boolean, nil] True if the URL is an image sample, false if it's not an image sample, or nil if we don't know
     #   whether it's an image sample or not.
     def image_sample?

--- a/app/logical/source/url/ci_en.rb
+++ b/app/logical/source/url/ci_en.rb
@@ -32,13 +32,17 @@ class Source::URL::CiEn < Source::URL
     in "media.ci-en.jp"
       case [*path_segments]
 
-      # https://media.ci-en.jp/private/attachment/creator/00011019/62a643d6423c18ec1be16826d687cefb47d8304de928a07c6389f8188dfe6710/image-800.jpg?px-time=1700517240&px-hash=eb626eafb7e5733c96fb0891188848dac10cb84c
+      # https://media.ci-en.jp/private/attachment/creator/00011019/62a643d6423c18ec1be16826d687cefb47d8304de928a07c6389f8188dfe6710/image-800.jpg?px-time=1700517240&px-hash=eb626eafb7e5733c96fb0891188848dac10cb84c (sample)
+      # https://media.ci-en.jp/private/attachment/creator/00011019/62a643d6423c18ec1be16826d687cefb47d8304de928a07c6389f8188dfe6710/upload/ばにっちA.jpg?px-time=1724352407&px-hash=7011c254c4f87a29937ac40ac00c89d919d2f3ec (full)
+      # https://media.ci-en.jp/private/attachment/creator/00012924/19f0db879cebbd78ddd8a4292088d0b0bd6bfe1af900081e89ae29c144f9e8a5/video-web.mp4?px-time=1724353317&px-hash=48e980878e385163d79bbd2e2ada5589c7520452
       # https://media.ci-en.jp/public/article_cover/creator/00020980/a65e3c05e2082018f4f28e99e7bc69b67ae96bb6f40b4a4b580ca939f435430d/image-1280-c.jpg
       # https://media.ci-en.jp/public/cover/creator/00013341/cc4ec0e58b9ad36c8f36aca9faee334239761b4b2969d379d6629a5e07a52a6c/image-990-c.jpg
-      in _, image_type, "creator", creator_id, *rest
+      in _, image_type, "creator", creator_id, file_hash, *subdirs, file_name
         @creator_id = creator_id.to_i.to_s
         @image_type = image_type
 
+        # Only `/upload/` are true not-samples, for others there's no known way to get the full file
+        @image_sample = subdirs != ["upload"] && (image_type == "attachment" && file_name != "video-web.mp4")
       end
 
     else
@@ -52,6 +56,11 @@ class Source::URL::CiEn < Source::URL
 
   def image_url?
     host == "media.ci-en.jp"
+  end
+
+  def image_sample?
+    return nil unless image_url?
+    @image_sample
   end
 
   def page_url

--- a/app/logical/source/url/fantia.rb
+++ b/app/logical/source/url/fantia.rb
@@ -35,6 +35,8 @@ class Source::URL::Fantia < Source::URL
       sample = $1
       file = $2
 
+      @image_sample = sample.present?
+
       #  post_id/product_id == image_id only for the first image in a post/product
       case image_type
       in "post" if sample.present? && file_ext == "webp"
@@ -59,12 +61,14 @@ class Source::URL::Fantia < Source::URL
     in _, "posts", post_id, "download", image_id
       @post_id = post_id
       @download_url = "https://fantia.jp/posts/#{post_id}/download/#{image_id}"
+      @image_sample = false
 
     # https://fantia.jp/posts/2533616/album_image?query=YsSkcpdnlam4JOy5dGHafbrSgfCZoMUmfrWD1XEouNkfO9Qk%2BC5Arv7ovxaiIo%2FEeJe5TI9mWDodDBp%2BzIIh70HJ6c0sWH8wMCc%2FM6IhDIKpxE%2BM1Zc1--Ol9M7yLd5TswwnZ5--wZ7u4P1tCVaAoL5ymFfA5Q%3D%3D
     # https://www.fantia.jp/posts/2533616/album_image?query=ohnfy48oGygFMkmdllgpHQQK61Mvm%2Bxy6%2FukgHOUMsbje%2BKMFaiKmLbP9hYDmeDNbJyiCbzSdN9cj3ovNY2T6N4LnRpH1%2Bpvk69f28QLG8T2zoVz%2BRNr--dGXRIUR3eSWXfSk1--IXeq0EUIc9%2Fmct%2BvbAbPqQ%3D%3D
     in _, "posts", post_id, "album_image" if params[:query].present?
       @post_id = post_id
       @download_url = "https://fantia.jp/posts/#{post_id}/album_image?query=#{Danbooru::URL.escape(params[:query])}"
+      @image_sample = false
 
     # https://fantia.jp/posts/1148334
     # https://fantia.jp/posts/2245222/post_content_photo/14978435
@@ -93,6 +97,11 @@ class Source::URL::Fantia < Source::URL
 
   def image_url?
     path.starts_with?("/uploads/") || download_url.present?
+  end
+
+  def image_sample?
+    return nil unless image_url?
+    @image_sample
   end
 
   def page_url

--- a/app/logical/source/url/misskey.rb
+++ b/app/logical/source/url/misskey.rb
@@ -60,6 +60,11 @@ class Source::URL::Misskey < Source::URL
     end
   end
 
+  def image_sample?
+    return nil unless image_url?
+    filename.starts_with? "thumbnail-"
+  end
+
   def page_url
     if note_id.present?
       "https://#{host}/notes/#{note_id}"

--- a/app/logical/source/url/null.rb
+++ b/app/logical/source/url/null.rb
@@ -242,6 +242,9 @@ class Source::URL::Null < Source::URL
 
   def parse
     @recognized = true
+    @bad_link = nil
+    @bad_source = nil
+    @image_sample = nil
 
     case [subdomain, domain, *path_segments]
 
@@ -376,6 +379,19 @@ class Source::URL::Null < Source::URL
     # https://e-hentai.org/uploader/Spirale
     in _, "e-hentai.org", *rest
       nil
+
+    # https://lyjrkow.ksxjubvoouva.hath.network/h/416a7c19fb25549e084876f932e2f6d45a5b2d63-1215161-2400-3589-jpg/keystamp=1683990600-aab6e15ff8;fileindex=119976531;xres=2400/89931055_p0.jpg
+    # https://drjvktq.miqlthdkffuu.hath.network/h/dce4b9677c8f769c12c8889e2581b989a3edd1bb-280532-642-802-png/keystamp=1683992100-6e1bddc318;fileindex=116114230;xres=org/1667196644017_fe0ug7p4.png
+    in _, "hath.network", "h", _, params_string, _
+      params = params_string.split(";").map { |s| s.split("=", 2) }.to_h rescue {}
+      @bad_link = true
+      @image_sample = params["xres"] != "org"
+
+    # https://hacaqjfrpvthigkeomjq.hath.network/om/119976531/188d8aec2d0ae17cfddf32849481385dd3303fc9-13295955-4379-6549-jpg/b09e528c8897a5a0ecb288f85fe9e9230d4a5f1c-483531-1280-1914-jpg/1280/v2f1fil8ij9dbk115c6/89931055_p0.jpg
+    # https://ykofnavysaepqurqrbmv.hath.network/om/119976531/188d8aec2d0ae17cfddf32849481385dd3303fc9-13295955-4379-6549-jpg/x/0/cqq6hb0kct3sx4115c4/89931055_p0.jpg
+    in _, "hath.network", "om", key, _, _, sample_size, _, _
+      @bad_link = true
+      @image_sample = sample_size != "0"
 
     # https://e-shuushuu.net/images/2017-07-19-915628.jpeg
     in _, "e-shuushuu.net", "images", /^\d{4}-\d{2}-\d{2}-(\d+)\.(jpeg|jpg|png|gif)$/i
@@ -725,10 +741,14 @@ class Source::URL::Null < Source::URL
   # Return `nil` to indicate that we don't know whether it's a bad source or not, since most sites here aren't fully
   # handled. Returning nil means the tag won't be added to or removed from the post.
   def bad_source?
-    nil
+    @bad_source
   end
 
   def bad_link?
-    nil
+    @bad_link
+  end
+
+  def image_sample?
+    @image_sample
   end
 end

--- a/app/logical/source/url/pixiv.rb
+++ b/app/logical/source/url/pixiv.rb
@@ -260,6 +260,11 @@ module Source
       "https://i.pximg.net/img-original/img/#{date.join("/")}/#{work_id}_ugoira#{n}.#{ext}" if ugoira_frame_url?
     end
 
+    def image_sample?
+      # TODO: img-zip-ugoira are also samples per #5793
+      image_url? && !image_type.in?(%w[img-original img-zip-ugoira novel-cover-original])
+    end
+
     def page_url
       if work_id.present?
         "https://www.pixiv.net/artworks/#{work_id}"

--- a/app/logical/source/url/pixiv.rb
+++ b/app/logical/source/url/pixiv.rb
@@ -261,8 +261,10 @@ module Source
     end
 
     def image_sample?
-      # TODO: img-zip-ugoira are also samples per #5793
-      image_url? && !image_type.in?(%w[img-original img-zip-ugoira novel-cover-original])
+      image_url? && !(
+        image_type.in?(%w[img-original novel-cover-original]) ||
+        ugoira_zip_url? && to_s == ugoira_zip_url
+      )
     end
 
     def page_url

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -493,6 +493,18 @@ class Post < ApplicationRecord
         # it's unknown whether it's a bad source or not; don't add or remove the tag
       end
 
+      # An image_sample is a source from a recognized site that points to the direct sample image.
+      if parsed_source&.image_url?
+        case parsed_source&.image_sample?
+        when true
+          tags << "image_sample"
+        when false
+          tags -= ["image_sample"]
+        when nil
+          # it's unknown whether it's an image sample or not; don't add or remove the tag
+        end
+      end
+
       # Allow only Flash files to be manually tagged as `animated`; GIFs, PNGs, videos, and ugoiras are automatically tagged.
       tags -= ["animated"] unless is_flash?
       tags << "animated" if media_asset.is_animated?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -493,18 +493,6 @@ class Post < ApplicationRecord
         # it's unknown whether it's a bad source or not; don't add or remove the tag
       end
 
-      # An image_sample is a source from a recognized site that points to the direct sample image.
-      if parsed_source&.image_url?
-        case parsed_source&.image_sample?
-        when true
-          tags << "image_sample"
-        when false
-          tags -= ["image_sample"]
-        when nil
-          # it's unknown whether it's an image sample or not; don't add or remove the tag
-        end
-      end
-
       # Allow only Flash files to be manually tagged as `animated`; GIFs, PNGs, videos, and ugoiras are automatically tagged.
       tags -= ["animated"] unless is_flash?
       tags << "animated" if media_asset.is_animated?

--- a/app/models/upload_media_asset.rb
+++ b/app/models/upload_media_asset.rb
@@ -92,6 +92,10 @@ class UploadMediaAsset < ApplicationRecord
     parsed_canonical_url&.bad_link?
   end
 
+  def image_sample?
+    parsed_canonical_url&.image_sample?
+  end
+
   # The source of the post after upload. This is either the image URL, if the image URL is convertible to a page URL
   # (e.g. Pixiv), or the page URL if it's not (e.g. Twitter).
   memoize def canonical_url

--- a/app/views/uploads/_single_asset_upload.html.erb
+++ b/app/views/uploads/_single_asset_upload.html.erb
@@ -88,6 +88,10 @@
                   <%= link_to "Bad Source", wiki_page_path("bad_link"), class: "upload-source-warning button-danger button-xs" %>
                 <% end %>
 
+                <% if upload_media_asset.image_sample? %>
+                  <%= link_to "Image Sample", wiki_page_path("image_sample"), class: "upload-sample-warning button-danger button-xs" %>
+                <% end %>
+
                 <% if media_asset.is_ai_generated? %>
                   <%= link_to "AI-Generated", wiki_page_path("ai-generated"), class: "upload-ai-warning button-danger button-xs" %>
                 <% end %>

--- a/test/unit/source/url/ci_en_url_test.rb
+++ b/test/unit/source/url/ci_en_url_test.rb
@@ -10,6 +10,9 @@ module Source::Tests::URL
           "https://media.ci-en.jp/public/article_cover/creator/00020980/a65e3c05e2082018f4f28e99e7bc69b67ae96bb6f40b4a4b580ca939f435430d/image-1280-c.jpg",
           "https://media.ci-en.jp/public/cover/creator/00013341/cc4ec0e58b9ad36c8f36aca9faee334239761b4b2969d379d6629a5e07a52a6c/image-990-c.jpg",
         ],
+        image_samples: [
+          "https://media.ci-en.jp/private/attachment/creator/00011019/62a643d6423c18ec1be16826d687cefb47d8304de928a07c6389f8188dfe6710/image-800.jpg?px-time=1700517240&px-hash=eb626eafb7e5733c96fb0891188848dac10cb84c",
+        ],
         page_urls: [
           "https://ci-en.jp/creator/922/article/23700",
           "https://ci-en.net/creator/11019/article/921762",
@@ -28,6 +31,12 @@ module Source::Tests::URL
       )
 
       should_not_find_false_positives(
+        image_samples: [
+          "https://media.ci-en.jp/private/attachment/creator/00011019/62a643d6423c18ec1be16826d687cefb47d8304de928a07c6389f8188dfe6710/upload/ばにっちA.jpg?px-time=1724352407&px-hash=7011c254c4f87a29937ac40ac00c89d919d2f3ec",
+          "https://media.ci-en.jp/private/attachment/creator/00012924/19f0db879cebbd78ddd8a4292088d0b0bd6bfe1af900081e89ae29c144f9e8a5/video-web.mp4?px-time=1724353317&px-hash=48e980878e385163d79bbd2e2ada5589c7520452",
+          "https://media.ci-en.jp/public/article_cover/creator/00020980/a65e3c05e2082018f4f28e99e7bc69b67ae96bb6f40b4a4b580ca939f435430d/image-1280-c.jpg",
+          "https://media.ci-en.jp/public/cover/creator/00013341/cc4ec0e58b9ad36c8f36aca9faee334239761b4b2969d379d6629a5e07a52a6c/image-990-c.jpg",
+        ],
         page_urls: [
           "https://media.ci-en.jp/private/attachment/creator/00011019/62a643d6423c18ec1be16826d687cefb47d8304de928a07c6389f8188dfe6710/image-web.jpg?px-time=1703968668&px-hash=9497dce5fa56c5081413ad1126e06d6f44f0ab3e",
           "https://media.ci-en.jp/public/cover/creator/00011019/ae96c79d7626c8127bfe9823111601d3b566977d19c3aa0409de4ef838f8dc12/image-990-c.jpg",

--- a/test/unit/source/url/fantia_url_test.rb
+++ b/test/unit/source/url/fantia_url_test.rb
@@ -12,6 +12,14 @@ module Source::Tests::URL
           "https://cc.fantia.jp/uploads/post_content/file/1830956/cbcdfcbe_20220224_120_040_100.png?Key-Pair-Id=APKAIOCKYZS7WKBB6G7A&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jYy5mYW50aWEuanAvdXBsb2Fkcy9wb3N0X2NvbnRlbnQvZmlsZS8xODMwOTU2L2NiY2RmY2JlXzIwMjIwMjI0XzEyMF8wNDBfMTAwLnBuZyIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTY0NjkxNDU4Nn19fV19&Signature=d1nw8gs9vcshIAeEH4oESm9-7z6y4A7MfoIRRvtUtV9iqTNA8KM0ORuCI7NwEoYc1VHsxy9ByeuSBpNaJoknnc3TOmHFhVRcLn~OWpnWqiHEPpMcSEG7uGlorysjEPmYYRGHjE7LJYcWiiJxjZ~fSBbYzxxwsjroPm-fyGUtNhdJWEMNp52vHe5P9KErb7M8tP01toekGdOqO-pkWm1t9xm2Tp5P7RWcbtQPOixgG4UgOhE0f3LVwHGHYJV~-lB5RjrDbTTO3ezVi7I7ybZjjHotVUK5MbHHmXzC1NqI-VN3vHddTwTbTK9xEnPMR27NHSlho3-O18WcNs1YgKD48w__",
           "https://fantia.jp/posts/1143951/download/1830956",
         ],
+        image_samples: [
+          "https://c.fantia.jp/uploads/post/file/1070093/main_16faf0b1-58d8-4aac-9e86-b243063eaaf1.jpeg",
+          "https://c.fantia.jp/uploads/post/file/1132267/main_webp_2a265470-e551-409c-b7cb-04437fd6ab2c.webp",
+          "https://cc.fantia.jp/uploads/post_content_photo/file/7087182/main_7f04ff3c-1f08-450f-bd98-796c290fc2d1.jpg?Key-Pair-Id=APKAIOCKYZS7WKBB6G7A&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jYy5mYW50aWEuanAvdXBsb2Fkcy9wb3N0X2NvbnRlbnRfcGhvdG8vZmlsZS83MDg3MTgyL21haW5fN2YwNGZmM2MtMWYwOC00NTBmLWJkOTgtNzk2YzI5MGZjMmQxLmpwZyIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTcyNDM1MTk4M319fV19&Signature=AiEKd1dnB4i2ifJLfpb1AW9dg5gaDbNgZ8pbifkt-MQaj9XtL1LLS3CMuBlV9wlbQ7YQ03iiafuVUWQ9iuxVEgdmYzl7UOiH1ntBTraJ50CD1xfiybbPMxLOCR9pAJq-B~-bh-LYXT1Yf2B3ZSQa-C2dZwjqjJnCZSA6M~BDESmi-GFcG0fLPfAMo~I2qxNoY1qt98ibDAlws5ZRHLXzFnKyigY55-3I5F~MK5xj6sncVp1m21pTYUwp2whf9kstSbFkHB08y~xEB7-a21-p5xJZC6qvuVBSwEDhfls~~umUCqgycR0UXNLrbcjnuHbXzfS278oK5Wq2jTboQoIgBw__",
+          "https://c.fantia.jp/uploads/product/image/249638/main_fd5aef8f-c217-49d0-83e8-289efb33dfc4.jpg",
+          "https://c.fantia.jp/uploads/product_image/file/219407/main_bd7419c2-2450-4c53-a28a-90101fa466ab.jpg",
+          "https://cc.fantia.jp/uploads/album_image/file/326995/main_00abd740-74d5-4289-be85-782cb8cdd382.png?Key-Pair-Id=APKAIOCKYZS7WKBB6G7A&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jYy5mYW50aWEuanAvdXBsb2Fkcy9hbGJ1bV9pbWFnZS9maWxlLzMyNjk5NS9tYWluXzAwYWJkNzQwLTc0ZDUtNDI4OS1iZTg1LTc4MmNiOGNkZDM4Mi5wbmciLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3MTMyMjAzODN9fX1dfQ__&Signature=Wmw~M4FjxgpDFYfQmtSE6bmIybdLbsby-SLCMcEPImK1ObbSeCq7GeOuOlwggxFTHU-O2juo-x8f8BCG~YKW1OGHBmHXpQJStw1f5juwHr7gtnM-GKmC3FIXCbWbmsMSpr~8frXOJX0AMHWKBN3aJAnZ01kXF5g9YrC8o31~hlHqDodh9zGNEGFlYkBisfh73Gn6f~Lvu4N8-tdfhedKnPkhy95sc2HTdbIlvfM7hq191BbeGWUwagKtrKIkTFJDWgaLinoZCMFqZDgQ4l8PmdK9UF6wi60iqSeWh~CEsHWinOprdAQVzrg~QDlSOLm2GiPnJjcwYO6D42DbFFmvxw__",
+        ],
         page_urls: [
           "https://fantia.jp/posts/1148334",
           "https://fantia.jp/products/249638",
@@ -20,6 +28,17 @@ module Source::Tests::URL
           "https://fantia.jp/fanclubs/64496",
           "https://fantia.jp/asanagi",
           "https://job.fantia.jp/fanclubs/5734",
+        ],
+      )
+
+      should_not_find_false_positives(
+        image_samples: [
+          "https://c.fantia.jp/uploads/post/file/1070093/16faf0b1-58d8-4aac-9e86-b243063eaaf1.jpeg",
+          "https://cc.fantia.jp/uploads/post_content_photo/file/7087182/7f04ff3c-1f08-450f-bd98-796c290fc2d1.jpg?Key-Pair-Id=APKAIOCKYZS7WKBB6G7A&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jYy5mYW50aWEuanAvdXBsb2Fkcy9wb3N0X2NvbnRlbnRfcGhvdG8vZmlsZS83MDg3MTgyLzdmMDRmZjNjLTFmMDgtNDUwZi1iZDk4LTc5NmMyOTBmYzJkMS5qcGciLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3MjQzNTIwMTJ9fX1dfQ__&Signature=otcg8CwBlSDM2DPeEop1OEbgvmnjChV6gR0SgleEDxh3eb49f36KZ33RdKgN8eb9X8Mk9Oyd1MwLk0fsXd7aACUmEDxIrZnipU1Xmlkz-fhobW3QKtvTk1XXWcMxEhmnv-XQzUXG9SwM1vrqMsE17eh5R14aTiUYfPNIrq~UvmusWas-orDBDKAEyNrg1U3DujL75-4Tq4y73Enpyxa5w51fLYN8D2QTx9nJwrsQvJOircpjPvEs1Pg1K~qJLzHdBxCwoWT0QqgMfmamuW0z~5p1AUnnul9v9vXZxT2j1lUzNEwLrX2ZTUni3JyMjp7wDC2mUWkZvTfsQP~572LrRA__",
+          "https://c.fantia.jp/uploads/product_image/file/219407/bd7419c2-2450-4c53-a28a-90101fa466ab.jpg",
+          "https://cc.fantia.jp/uploads/album_image/file/326995/00abd740-74d5-4289-be85-782cb8cdd382.png?Key-Pair-Id=APKAIOCKYZS7WKBB6G7A&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jYy5mYW50aWEuanAvdXBsb2Fkcy9hbGJ1bV9pbWFnZS9maWxlLzMyNjk5NS8wMGFiZDc0MC03NGQ1LTQyODktYmU4NS03ODJjYjhjZGQzODIucG5nIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzEzMjM2OTYxfX19XX0_&Signature=XSpRUwWyKOpR53aImaRQeBQx1R4e8hShO6cm-bmqXtJVchiigbTKsV-kCBMox1aeISAcN-O8VhujVlYwtOV1pw6WmE8kIrKeMnWteA17lYd6wAW2BUcVlQb6TBdpPA38V0UTRlmM0cypgw1ipmmDTKtjQ8-Tmo368bZqi4w4M6EukgK~L8Ss42K0JBwfiv0VuLTw49hK9-jGjA1gyQdzZXZwXkuClelV7VVHWxTX06yT8Anv6giOyOM1IP35LxfYG9ZhbTkN78TqAviZhQ9aLEceYG8Ua65f0bGMWCSnjeox5-UpiQ4irAlLDAVkKT~Lz5otNzQd2UnFkRiqbRB32A__",
+          "https://fantia.jp/posts/1143951/download/1830956",
+          "https://fantia.jp/posts/2533616/album_image?query=YsSkcpdnlam4JOy5dGHafbrSgfCZoMUmfrWD1XEouNkfO9Qk%2BC5Arv7ovxaiIo%2FEeJe5TI9mWDodDBp%2BzIIh70HJ6c0sWH8wMCc%2FM6IhDIKpxE%2BM1Zc1--Ol9M7yLd5TswwnZ5--wZ7u4P1tCVaAoL5ymFfA5Q%3D%3D",
         ],
       )
     end

--- a/test/unit/source/url/misskey_url_test.rb
+++ b/test/unit/source/url/misskey_url_test.rb
@@ -17,6 +17,9 @@ module Source::Tests::URL
           "https://files.misskey.art//webpublic-94d9354f-ddba-406b-b878-4ce02ccfa505.webp",
           "https://file.misskey.design/post/webpublic-ac7072e9-812f-460b-ad24-1f303a62f0b4.webp",
         ],
+        image_samples: [
+          "https://s3.arkjp.net/misskey/thumbnail-10c4379a-b999-4148-9d32-7bb6f22453bf.webp",
+        ],
         page_urls: [
           "https://misskey.io/notes/9bxaf592x6",
         ],
@@ -29,6 +32,9 @@ module Source::Tests::URL
       should_not_find_false_positives(
         image_urls: [
           "https://media.misskeyusercontent.com",
+        ],
+        image_samples: [
+          "https://s3.arkjp.net/misskey/7d2adf4a-b2dd-40b4-ba27-916e44f7bd48.png",
         ],
         profile_urls: [
           "https://misskey.io/@",

--- a/test/unit/source/url/null_url_test.rb
+++ b/test/unit/source/url/null_url_test.rb
@@ -133,6 +133,21 @@ module Source::Tests::URL
                              page_url: "https://hitomi.la/reader/1054851.html#1",)
     end
 
+    context "For e-hentai links" do
+      should_identify_url_types(
+        image_samples: [
+          "https://lyjrkow.ksxjubvoouva.hath.network/h/416a7c19fb25549e084876f932e2f6d45a5b2d63-1215161-2400-3589-jpg/keystamp=1683990600-aab6e15ff8;fileindex=119976531;xres=2400/89931055_p0.jpg",
+          "https://hacaqjfrpvthigkeomjq.hath.network/om/119976531/188d8aec2d0ae17cfddf32849481385dd3303fc9-13295955-4379-6549-jpg/b09e528c8897a5a0ecb288f85fe9e9230d4a5f1c-483531-1280-1914-jpg/1280/v2f1fil8ij9dbk115c6/89931055_p0.jpg",
+        ],
+      )
+      should_not_find_false_positives(
+        image_samples: [
+          "https://drjvktq.miqlthdkffuu.hath.network:8080/h/dce4b9677c8f769c12c8889e2581b989a3edd1bb-280532-642-802-png/keystamp=1683992100-6e1bddc318;fileindex=116114230;xres=org/1667196644017_fe0ug7p4.png",
+          "https://ykofnavysaepqurqrbmv.hath.network/om/119976531/188d8aec2d0ae17cfddf32849481385dd3303fc9-13295955-4379-6549-jpg/x/0/cqq6hb0kct3sx4115c4/89931055_p0.jpg",
+        ],
+      )
+    end
+
     context "For unknown sources" do
       should "leave them as they are" do
         assert_nil(Source::URL.page_url("https://google.com"))

--- a/test/unit/source/url/pixiv_url_test.rb
+++ b/test/unit/source/url/pixiv_url_test.rb
@@ -73,6 +73,8 @@ module Source::Tests::URL
         ],
         image_samples: [
           "https://i.pximg.net/img-master/img/2014/10/03/18/10/20/46324488_p0_master1200.jpg",
+          "https://i.pximg.net/img-zip-ugoira/img/2016/04/09/14/25/29/56268141_ugoira600x600.zip",
+          "https://i.pximg.net/img-zip-ugoira/img/2016/04/09/14/25/29/56268141_ugoira1920x1080.zip",
           "https://i.pximg.net/c/250x250_80_a2/img-master/img/2014/10/29/09/27/19/46785915_p0_square1200.jpg",
           "http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_64x64.jpg",
           "http://img18.pixiv.net/img/evazion/14901720.png",
@@ -105,7 +107,7 @@ module Source::Tests::URL
       should_not_find_false_positives(
         image_samples: [
           "https://i.pximg.net/img-original/img/2014/10/03/18/10/20/46324488_p0.png",
-          "https://i.pximg.net/img-zip-ugoira/img/2016/04/09/14/25/29/56268141_ugoira1920x1080.zip",
+          "https://i.pximg.net/img-zip-ugoira/img/2016/04/09/14/25/29/56268141_ugoira1920x1080.zip?original",
           "https://i-f.pximg.net/img-original/img/2020/02/19/00/40/18/79584713_p0.png",
           "https://www.pixiv.net/artworks/46324488",
         ],

--- a/test/unit/source/url/pixiv_url_test.rb
+++ b/test/unit/source/url/pixiv_url_test.rb
@@ -71,6 +71,13 @@ module Source::Tests::URL
           "http://img18.pixiv.net/img/evazion/14901720.png",
           "http://i2.pixiv.net/img18/img/evazion/14901720.png",
         ],
+        image_samples: [
+          "https://i.pximg.net/img-master/img/2014/10/03/18/10/20/46324488_p0_master1200.jpg",
+          "https://i.pximg.net/c/250x250_80_a2/img-master/img/2014/10/29/09/27/19/46785915_p0_square1200.jpg",
+          "http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_64x64.jpg",
+          "http://img18.pixiv.net/img/evazion/14901720.png",
+          "http://i2.pixiv.net/img18/img/evazion/14901720.png",
+        ],
         page_urls: [
           "https://www.pixiv.net/en/artworks/46324488",
           "https://www.pixiv.net/artworks/46324488",
@@ -93,6 +100,14 @@ module Source::Tests::URL
           "http://www.pixiv.me/noizave",
           "https://pixiv.cc/zerousagi/",
           "https://p.tl/m/9202877",
+        ],
+      )
+      should_not_find_false_positives(
+        image_samples: [
+          "https://i.pximg.net/img-original/img/2014/10/03/18/10/20/46324488_p0.png",
+          "https://i.pximg.net/img-zip-ugoira/img/2016/04/09/14/25/29/56268141_ugoira1920x1080.zip",
+          "https://i-f.pximg.net/img-original/img/2020/02/19/00/40/18/79584713_p0.png",
+          "https://www.pixiv.net/artworks/46324488",
         ],
       )
     end

--- a/test/unit/source/url/twitter_url_test.rb
+++ b/test/unit/source/url/twitter_url_test.rb
@@ -7,10 +7,30 @@ module Source::Tests::URL
         image_urls: [
           "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg",
           "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg:small",
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg:orig",
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb?format=jpg",
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb?format=jpg&name=900x900",
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb?format=jpg&name=orig",
+          "https://pbs.twimg.com/profile_banners/780804311529906176/1475001696",
+          "https://pbs.twimg.com/profile_banners/780804311529906176/1475001696/600x200",
+          "https://pbs.twimg.com/profile_banners/780804311529906176/1475001696/1500x500",
+          "https://pbs.twimg.com/tweet_video_thumb/ETkN_L3X0AMy1aT.jpg",
+          "https://pbs.twimg.com/ext_tw_video_thumb/1243725361986375680/pu/img/JDA7g7lcw7wK-PIv.jpg",
+          "https://pbs.twimg.com/amplify_video_thumb/1215590775364259840/img/lolCkEEioFZTb5dl.jpg",
+        ],
+        image_samples: [
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg",
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg:small",
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb?format=jpg",
           "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb?format=jpg&name=900x900",
           "https://pbs.twimg.com/tweet_video_thumb/ETkN_L3X0AMy1aT.jpg",
           "https://pbs.twimg.com/ext_tw_video_thumb/1243725361986375680/pu/img/JDA7g7lcw7wK-PIv.jpg",
           "https://pbs.twimg.com/amplify_video_thumb/1215590775364259840/img/lolCkEEioFZTb5dl.jpg",
+          "https://pbs.twimg.com/profile_images/1425792004877733891/UM8s9d2x_400x400.png",
+          "https://pbs.twimg.com/profile_images/417182061145780225/ttN6_CSs_normal.jpeg",
+          "https://pbs.twimg.com/profile_images/417182061145780225/ttN6_CSs_400x400.jpeg",
+          "https://pbs.twimg.com/profile_banners/780804311529906176/1475001696",
+          "https://pbs.twimg.com/profile_banners/780804311529906176/1475001696/600x200",
         ],
         page_urls: [
           "https://twitter.com/i/status/1261877313349640194",
@@ -54,6 +74,16 @@ module Source::Tests::URL
       )
 
       should_not_find_false_positives(
+        image_samples: [
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg:orig",
+          "https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb?format=jpg&name=orig",
+          "https://pbs.twimg.com/tweet_video_thumb/ETkN_L3X0AMy1aT.jpg:orig",
+          "https://pbs.twimg.com/ext_tw_video_thumb/1243725361986375680/pu/img/JDA7g7lcw7wK-PIv.jpg:orig",
+          "https://pbs.twimg.com/amplify_video_thumb/1215590775364259840/img/lolCkEEioFZTb5dl.jpg:orig",
+          "https://pbs.twimg.com/profile_images/417182061145780225/ttN6_CSs.jpeg",
+          "https://pbs.twimg.com/profile_banners/780804311529906176/1475001696/1500x500",
+          "https://twitter.com/i/status/1261877313349640194",
+        ],
         profile_urls: [
           "https://twitter.com/home",
           "https://t.co/Dxn7CuVErW",


### PR DESCRIPTION
* Recognize image sample URLs from Pixiv, Twitter, E-Hentai, Misskey
* Autotag posts with `image_sample` on save if source field contains such URL
* On upload, if URL can't be converted into something better, show a warning

Closes #5508