### PR TITLE
artists: allow API clients to request sorted_urls

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -69,6 +69,10 @@ class ApplicationRecord < ActiveRecord::Base
         reflections.select { |_, v| v.macro == :has_many }.keys.map(&:to_sym)
       end
 
+      def associated_relations(name)
+        [name]
+      end
+
       def associated_models(name)
         if reflections[name].options[:polymorphic]
           reflections[name].active_record.try(:model_types) || []

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -327,6 +327,15 @@ class Artist < ApplicationRecord
   end
 
   def self.available_includes
-    [:members, :urls, :wiki_page, :tag_alias, :tag]
+    [:members, :urls, :sorted_urls, :wiki_page, :tag_alias, :tag]
+  end
+
+  def self.associated_relations(name)
+    case name
+    when :sorted_urls
+      [:urls]
+    else
+      super
+    end
   end
 end


### PR DESCRIPTION
Also includes some changes to make in properly work with the `only` query param and do record prefetching via `includes`.

I want [translate-pixiv-tags userscript](https://github.com/evazion/translate-pixiv-tags) artist tooltip to show artist urls in the same convenient order as danbooru itself does.