### PR TITLE
uploads: approve original post when a duplicate is uploaded by approver

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -84,6 +84,12 @@ class PostsController < ApplicationController
     elsif @post.errors.of_kind?(:md5, :taken)
       @original_post = Post.find_by!(md5: @post.md5)
       @original_post.update(rating: @post.rating, parent_id: @post.parent_id, tag_string: "#{@original_post.tag_string} #{@post.tag_string}")
+      
+      if CurrentUser.user.is_approver? && !@original_post.is_active? && @post.is_active?
+        @approval = authorize @original_post.approvals.new(user: CurrentUser.user)
+        @approval.save
+      end
+      
       flash[:notice] = "Duplicate of post ##{@original_post.id}; merging tags"
       redirect_to @original_post
     else

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -747,6 +747,22 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
         assert_equal(true, @post.is_pending?)
       end
 
+      should "approve the original post when a duplicate upload is made by approver" do
+        media_asset = create(:media_asset)
+        post = create_post!(user: create(:user), media_asset: media_asset)
+        assert_equal(true, post.is_pending?)
+        create_post!(user: create(:approver_user), media_asset: media_asset)
+        assert_equal(false, post.reload.is_pending?)
+      end
+
+      should "not approve the original post when a duplicate upload for approval is made by approver" do
+        media_asset = create(:media_asset)
+        post = create_post!(user: create(:user), media_asset: media_asset)
+        assert_equal(true, post.is_pending?)
+        create_post!(user: create(:approver_user), media_asset: media_asset, is_pending: true)
+        assert_equal(true, post.reload.is_pending?)
+      end
+
       should "create a commentary record if the commentary is present" do
         assert_difference("ArtistCommentary.count", 1) do
           @post = create_post!(


### PR DESCRIPTION
Somewhat related to #3130.
To my experience, most approvers would manually approve the post they got sniped on anyway, so I can't think of any reason why this should not be done automatically.