### PR TITLE
Turn tag change notice into component, handle multiple burs in same topic

### DIFF
--- a/app/components/tag_change_notice_component.rb
+++ b/app/components/tag_change_notice_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class TagChangeNoticeComponent < ApplicationComponent
+  extend Memoist
+
+  attr_reader :tag, :current_user
+
+  def initialize(tag:, current_user:)
+    super
+    @tag = tag
+    @current_user = current_user
+  end
+
+  memoize def pending_burs
+    return BulkUpdateRequest.none unless tag.present?
+    BulkUpdateRequest.pending.where_array_includes_any(:tags, tag.name)
+  end
+
+  def bur_links_for_topic(forum_topic:, burs:)
+    if burs.length > 1
+      "topic ##{forum_topic.id}: \"#{forum_topic.title}\" (#{burs.map { |bur| link_to "forum ##{bur.forum_post.id}", bur.forum_post}.to_sentence})"
+    else
+      link_to "topic ##{forum_topic.id}: \"#{forum_topic.title}\"", burs.first.forum_post
+    end
+  end
+
+  def render?
+    !@current_user.is_anonymous? && @tag.present?
+  end
+end

--- a/app/components/tag_change_notice_component/tag_change_notice_component.html.erb
+++ b/app/components/tag_change_notice_component/tag_change_notice_component.html.erb
@@ -1,0 +1,8 @@
+<% cache("tag-change-notice:#{tag.name}", expires_in: 4.hours) do %>
+  <% if pending_burs.present? %>
+    <p class="fineprint tag-change-notice">
+      This tag is being discussed in
+      <%= pending_burs.group_by { |bur| bur.forum_topic }.map {|forum_topic, burs| bur_links_for_topic(forum_topic: forum_topic, burs: burs) }.to_sentence.html_safe %>.
+    </p>
+  <% end %>
+<% end %>

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -84,6 +84,10 @@ module ComponentsHelper
     # Swallow any exceptions when loading records so that the page load doesn't fail.
   end
 
+  def render_tag_change_notice(tag:, current_user:)
+    render TagChangeNoticeComponent.new(tag: tag, current_user: current_user)
+  end
+
   def numbered_paginator(records)
     if records.paginator_mode == :numbered
       render NumberedPaginatorComponent.new(records: records, params: params)

--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -131,11 +131,6 @@ module PostSets
       posts.reject(&:is_deleted).select(&:visible?).max_by { |post| [-post.rating_id, post.score] }
     end
 
-    def pending_bulk_update_requests
-      return BulkUpdateRequest.none unless tag.present?
-      @pending_bulk_update_requests ||= BulkUpdateRequest.pending.where_array_includes_any(:tags, tag.name)
-    end
-
     def show_deleted?
       current_user.show_deleted_posts? || has_status_metatag?
     end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -189,17 +189,8 @@
           </div>
         <% end %>
 
-        <% if !CurrentUser.user.is_anonymous? && @post_set.tag.present? && @post_set.current_page == 1 %>
-          <% cache("tag-change-notice:#{@post_set.tag.name}", expires_in: 4.hours) do %>
-            <% if @post_set.pending_bulk_update_requests.present? %>
-              <div class="fineprint tag-change-notice">
-                <p>
-                  This tag is being discussed in
-                  <%= to_sentence @post_set.pending_bulk_update_requests.map { |bur| link_to "Topic ##{bur.forum_topic_id}: #{bur.forum_topic.title}", bur.forum_post } %>.
-                </p>
-              </div>
-            <% end %>
-          <% end %>
+        <% if @post_set.current_page == 1 %>
+          <%= render_tag_change_notice(tag: @post_set.tag, current_user: CurrentUser.user) %>
         <% end %>
 
         <%= numbered_paginator(posts) %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -130,6 +130,8 @@
             <p class="fineprint">This tag is <%= link_to "deprecated", wiki_page_path("help:deprecation_notice") %> and can't be added to new posts.</p>
           <% end %>
 
+          <%= render_tag_change_notice(tag: wiki_page.tag, current_user: CurrentUser.user) %>
+
           <p class="mt-4">
             <%= link_to_wiki "View wiki", wiki_page.title, id: "view-wiki-link" %>
           </p>
@@ -167,6 +169,8 @@
       <% if @post_set.tag&.is_deprecated? %>
         <p class="fineprint">This tag is <%= link_to "deprecated", wiki_page_path("help:deprecation_notice") %> and can't be added to new posts.</p>
       <% end %>
+
+      <%= render_tag_change_notice(tag: @post_set.tag, current_user: CurrentUser.user) %>
     <% end %>
   </div>
 

--- a/app/views/wiki_pages/new.html.erb
+++ b/app/views/wiki_pages/new.html.erb
@@ -23,6 +23,8 @@
     <p class="fineprint">This tag is <%= link_to "deprecated", wiki_page_path("help:deprecation_notice") %> and can't be added to new posts.</p>
   <% end %>
 
+  <%= render_tag_change_notice(tag: @wiki_page.tag, current_user: CurrentUser.user) %>
+
   <%= render "wiki_pages/posts", wiki_page: @wiki_page %>
 <% end %>
 

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -48,5 +48,7 @@
     <% end %>
   </div>
 
+  <%= render_tag_change_notice(tag: wiki_page.tag, current_user: CurrentUser.user) %>
+
   <%= render "wiki_pages/posts", wiki_page: @wiki_page %>
 <% end %>


### PR DESCRIPTION
Fixes #5563, and adds the tag change notice to wiki pages.

Case of one topic, one BUR:
![image](https://github.com/danbooru/danbooru/assets/12946050/fb608a24-107e-45d1-89d6-0ce546bd445b)

Case of one topic, multiple BURs:
![image](https://github.com/danbooru/danbooru/assets/12946050/8f4c978d-db02-4287-b929-e7a4d0d7bc2a)

Case of multiple topics, mixed BUR count:
![image](https://github.com/danbooru/danbooru/assets/12946050/53f34acb-89af-4c98-84b7-7bdebfabef9f)


Adding a link to the topic in case of multiple BURs in the same topic seemed too noisy to me, but lemme know and I'll change it if it's desiderable.
