### PR TITLE
Fix autotagger issues

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,11 @@ User.create(
   password: SecureRandom.base64(32),
   level: User::Levels::MODERATOR
 )
+
+# Create the rating:* tags for autotagging to be able to suggest them to users.
+%w[g e q s].each do |rating|
+  unless Tag.exists?(name: "rating:#{rating}")
+    # We need to bypass validation here, since we can't normally create rating tags
+    Tag.new(name: "rating:#{rating}").save(:validate => false)
+  end
+end


### PR DESCRIPTION
This fixes some issues with the autotagger that were brought up in #5271:

- The autotagger client now automatically creates tags that were returned from the autotagger but don't exist in the local database
- The seed file creates the rating tags (`rating:g`, `rating:q`, `rating:s`, and `rating:e`) that can be returned from the autotagger, similar to the ones that [exist on the main instance](https://danbooru.donmai.us/tags?commit=Search&search%5Bhide_empty%5D=no&search%5Bname_or_alias_matches%5D=rating%3A%2A&search%5Border%5D=date) (this is separate from the other auto-creation because we have to bypass validation to create `rating:` tags)