### PR TITLE
Use input field for posts per page setting

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -38,7 +38,7 @@
 
             <%= f.input :theme, collection: User.themes.keys, include_blank: false, hint: "The site's colorscheme (light mode or dark mode)." %>
             <%= f.input :enable_safe_mode, label: "Safe mode", hint: "Show only safe images. Hide sensitive, questionable and explicit images.", as: :select, include_blank: false, collection: [["Yes", "true"], ["No", "false"]] %>
-            <%= f.input :per_page, label: "Posts per page", as: :select, hint: "Number of thumbnails per page", collection: (1..PostSets::Post::MAX_PER_PAGE), include_blank: false %>
+            <%= f.input :per_page, label: "Posts per page", hint: "Number of thumbnails per page (max: #{PostSets::Post::MAX_PER_PAGE})", input_html: { min: 1, max: PostSets::Post::MAX_PER_PAGE } %>
             <%= f.input :default_image_size, hint: "Show full original images or resized #{Danbooru.config.large_image_width}px width samples.", label: "Default image width", collection: [["850px", "large"], ["original", "original"]], include_blank: false %>
             <%= f.input :receive_email_notifications, as: :select, include_blank: false, collection: [["Yes", "true"], ["No", "false"]], hint: "Receive an email when you receive a new dmail." %>
             <%= f.input :time_zone, include_blank: false, hint: "The timezone to use for timestamps." %>


### PR DESCRIPTION
The current UI for changing the "Posts per page" setting is kinda... bad:

![image](https://github.com/danbooru/danbooru/assets/5049892/61dceeef-b35e-4e9f-8818-679dade158c2)

I changed it to a number input like the "Comment threshold" setting:

<img width="351" alt="image" src="https://github.com/danbooru/danbooru/assets/5049892/ff700ce8-3c3f-4bbd-91d7-d8ebb5775fab">

I also added "max: 200" to the hint-label to show what the maximum number is. If you go above that the error message is the same as for the comment threshold so I didn't change anything. It may be helpful adding the same hint to the "Comment threshold" setting?