### PR TITLE
fantia: extract free tier reward post page url from full size image page url passed as referer

### DIFF
--- a/app/logical/source/url/fantia.rb
+++ b/app/logical/source/url/fantia.rb
@@ -46,7 +46,8 @@ class Source::URL::Fantia < Source::URL
       @download_id = image_id
 
     # https://fantia.jp/posts/1148334
-    in _, "posts", /\d+/ => post_id
+    # https://fantia.jp/posts/2245222/post_content_photo/14978435
+    in _, "posts", /\d+/ => post_id, *rest
       @post_id = post_id
 
     # https://fantia.jp/products/249638

--- a/test/unit/sources/fantia_test.rb
+++ b/test/unit/sources/fantia_test.rb
@@ -40,6 +40,17 @@ module Sources
       end
     end
 
+    context "A c.fantia.jp/uploads/post_content_photo/ url with full size page referer" do
+      url = "https://cc.fantia.jp/uploads/post_content_photo/file/14978435/86ec43ba-8121-43ac-9d3c-aec86f5238a2.jpg?Key-Pair-Id=APKAIOCKYZS7WKBB6G7A&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jYy5mYW50aWEuanAvdXBsb2Fkcy9wb3N0X2NvbnRlbnRfcGhvdG8vZmlsZS8xNDk3ODQzNS84NmVjNDNiYS04MTIxLTQzYWMtOWQzYy1hZWM4NmY1MjM4YTIuanBnIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNjk1MTM4MDI1fX19XX0_&Signature=ypwGfl0VivNcjmsfC5Cu6qNXhnXpuKTHnukMwBEgdWlENuAbVBi0napKC~39NN0e~FBNpgoOW2OqY0BX5zgeMdbz2RAGI1eFsfYpRRNfHDpEvh6dOVgBrHopZvXZzMf1G12yiBnKmXAvNyzwD1cDhnCW0mvcy9RbCJro1ELQ4qWt4BuBUzOtYX5h6OV-WvGnOdys25p~t4n8h15MhaWyIVx32W0wIsbs~cHnaScwgOIJAinBkgp4Mp1AwqYtvmgw28PjJrzohhFDrLGZeM6yjlvLQKnYqjQn5D8CR9l0TLADtMYc65hL92ywG0BXf1zGnGJ86gmqSiZjZ077rl9FVw__"
+
+      strategy_should_work(
+        url,
+        referer: "https://fantia.jp/posts/2245222/post_content_photo/14978435",
+        image_urls: [url],
+        page_url: "https://fantia.jp/posts/2245222",
+      )
+    end
+
     context "A c.fantia.jp/uploads/product/image/ url" do
       should "work" do
         url = "https://c.fantia.jp/uploads/product/image/249638/fd5aef8f-c217-49d0-83e8-289efb33dfc4.jpg"


### PR DESCRIPTION
Considering that the most efficient way to upload free-tier fantia rewards that I'm aware of is to open the full-size image and upload it using the browser extension, this will save uploaders a few clicks each post due to not having to manually copy-and-paste fantia post url into the upload form.