### PR TITLE
Added Japanese Tag Support

### DIFF
--- a/app/logical/tag_name_validator.rb
+++ b/app/logical/tag_name_validator.rb
@@ -37,8 +37,10 @@ class TagNameValidator < ActiveModel::EachValidator
       record.errors.add(attribute, "'#{value}' cannot contain consecutive underscores")
     when /[^[:graph:]]/
       record.errors.add(attribute, "'#{value}' cannot contain non-printable characters")
-    when /[^[:ascii:]]/
-      record.errors.add(attribute, "'#{value}' must consist of only ASCII characters")
+    when /[^ -~]/
+      record.errors.add(attribute, "'#{value}' cannot contain non-standard ASCII characters")
+    #when /[^[:ascii:]]/
+      #record.errors.add(attribute, "'#{value}' must consist of only ASCII characters")
     when /\A(#{PostQueryBuilder::METATAGS.join("|")}):(.+)\z/i
       record.errors.add(attribute, "'#{value}' cannot begin with '#{$1}:'")
     when /\A(#{PostEdit::METATAGS.join("|")}):(.+)\z/i


### PR DESCRIPTION
This unlocks the ability to use Chinese and Japanese UTF-8 characters when adding tags to images.

Unsure if this was attempted or was a feature request. I mainly made this modification for a future pixiv importer tool I'm planning to write.

If anything, maybe someone would want this to be a setting that administrators could toggle (my ruby knowledge isn't that great, so I wouldn't know how to do this).

Understandable if this gets denied, it's niche and it seems some danbooru instances want english only type-able characters. 