### PR TITLE
pixiv: fix dtext conversion for non-english pixiv accounts

### DIFF
--- a/app/logical/source/extractor/pixiv.rb
+++ b/app/logical/source/extractor/pixiv.rb
@@ -11,12 +11,12 @@ module Source
       def self.to_dtext(text)
         return nil if text.nil?
 
-        text = text.gsub(%r{<a href="https?://www\.pixiv\.net/en/artworks/([0-9]+)">illust/[0-9]+</a>}i) do |_match|
+        text = text.gsub(%r{<a href="https?://www\.pixiv\.net/(?:[a-z]+/)?artworks/([0-9]+)">illust/[0-9]+</a>}i) do |_match|
           pixiv_id = $1
           %(pixiv ##{pixiv_id} "»":[#{Routes.posts_path(tags: "pixiv:#{pixiv_id}")}])
         end
 
-        text = text.gsub(%r{<a href="https?://www\.pixiv\.net/en/users/([0-9]+)">user/[0-9]+</a>}i) do |_match|
+        text = text.gsub(%r{<a href="https?://www\.pixiv\.net/(?:[a-z]+/)?users/([0-9]+)">user/[0-9]+</a>}i) do |_match|
           member_id = $1
           profile_url = "https://www.pixiv.net/users/#{member_id}"
 


### PR DESCRIPTION
There is an issue with `Source::Extractor::Pixiv.to_dtext` that causes `test/unit/sources/pixiv_test.rb:154` and `test/unit/sources/pixiv_test.rb:165` to fail if the Pixiv account that is used for extractor is set to language other than English.

It is worth to notice is that at the moment the bug reproduces on the actual Danbooru (e.g. post #5111725) - which can be kinda fixed by changing the language of the account used over there.
