### PR TITLE
related tags: fix toggle not working properly if the tag is listed twice in a row

### DIFF
--- a/app/javascript/src/javascripts/related_tag.js
+++ b/app/javascript/src/javascripts/related_tag.js
@@ -131,7 +131,7 @@ RelatedTag.toggle_tag = function(e) {
 
   if (RelatedTag.current_tags().includes(tag)) {
     var escaped_tag = Utility.regexp_escape(tag);
-    $field.val($field.val().replace(new RegExp("(^|\\s)" + escaped_tag + "($|\\s)", "gi"), "$1$2"));
+    $field.val($field.val().replace(new RegExp("(?<=^|\\s)" + escaped_tag + "(?=$|\\s)", "gi"), ""));
   } else {
     $field.val($field.val() + " " + tag);
   }


### PR DESCRIPTION
It is not working as intended because the current regex would produce overlapping matches

i.e., `blue_archive loli loli sex` matches on `/(^|\s)loli($|\s)/g` like:
```
blue_archive loli loli sex
            ^^^^^^
                 ^^^^^^ - can't overlap on " "
```

The solution is to make whitespace matches non-consuming by using lookaround assertions

i.e., the same string would match on `/(?<=^|\s)loli(?=$|\s)/g` like:
```
blue_archive loli loli sex
             ^^^^
                  ^^^^
```

Related: fa59c1742451b48529d44894683b298860125397 (#1477), 21282b4c99217ad75466120871c63ea51b56c13c, 5843b3037fa10700718d9e062cba6b1ef215adf1, 3ccad2cc18c5e25a319c8cc8145ab07af3c5a4fd (#1062, #1283)
