### PR TITLE
disapprovals: handle disapproval errors in the view

### DIFF
--- a/app/controllers/post_disapprovals_controller.rb
+++ b/app/controllers/post_disapprovals_controller.rb
@@ -6,8 +6,6 @@ class PostDisapprovalsController < ApplicationController
   def create
     @post_disapproval = authorize PostDisapproval.new(user: CurrentUser.user, **permitted_attributes(PostDisapproval))
     @post_disapproval.save
-
-    flash[:notice] = @post_disapproval.errors.none? ? "Post disapproved" : @post_disapproval.errors.full_messages.join("; ")
     respond_with(@post_disapproval)
   end
 

--- a/app/views/post_disapprovals/create.js.erb
+++ b/app/views/post_disapprovals/create.js.erb
@@ -1,6 +1,10 @@
-if ($("#c-posts #a-show").length) {
-  location.reload();
-} else if ($("#c-modqueue").length) {
-  $("#post_<%= @post_disapproval.post.id %>").hide();
-  Danbooru.notice("<%= j format_text("Post ##{@post_disapproval.post.id} was #{@post_disapproval.reason == "disinterest" ? "skipped" : "rejected"}.", inline: true) %>");
-}
+<% if @post_disapproval.errors.any? %>
+  Danbooru.error("Error: " + <%= @post_disapproval.errors.full_messages.join("; ").to_json.html_safe %>);
+<% else %>
+  if ($("#c-posts #a-show").length) {
+    location.reload();
+  } else if ($("#c-modqueue").length) {
+    $("#post_<%= @post_disapproval.post.id %>").hide();
+    Danbooru.notice("<%= j format_text("Post ##{@post_disapproval.post.id} was #{@post_disapproval.reason == "disinterest" ? "skipped" : "rejected"}.", inline: true) %>");
+  }
+<% end %>


### PR DESCRIPTION
This is similar to how approval errors are currently handled ([app/views/post_approvals/create.js.erb][]).
Fixes #5666. Also fixes an issue where disapproval errors would get silently ignored until next page load if the disapproval was created from the modqueue.

[app/views/post_approvals/create.js.erb]: https://github.com/danbooru/danbooru/blob/d67bd670916644017a83a3de8fc5d0bdb3404585/app/views/post_approvals/create.js.erb