### PR TITLE
[DText] Fix: Correct parsing of blockquote closing tags

### DIFF
--- a/lib/dtext_rb/ext/dtext/dtext.cpp.rl
+++ b/lib/dtext_rb/ext/dtext/dtext.cpp.rl
@@ -292,7 +292,7 @@ open_u = '[u]'i | '<u>'i;
 
 close_spoilers = ('[/spoiler'i 's'i? ']') | ('</spoiler'i 's'i? '>');
 close_nodtext = '[/nodtext]'i | '</nodtext>'i;
-close_quote = '[/quote'i (']' when in_quote) | '</quote'i ('>' when in_quote) | '</blockquote'i (']' when in_quote);
+close_quote = '[/quote'i (']' when in_quote) | '</quote'i ('>' when in_quote) | '</blockquote'i ('>' when in_quote);
 close_expand = '[/expand'i (']' when in_expand) | '</expand'i ('>' when in_expand);
 close_code = '[/code]'i | '</code>'i;
 close_table = '[/table]'i | '</table>'i;


### PR DESCRIPTION
Fixes incorrect parsing of the `</blockquote>`. There was a simple typo/copy-paste error in the parsing rule which meant the parser was attempting to match on a closing square bracket (`]`) instead of the closing angle bracket (`>`). This has been corrected to allow this tag to be parsed correctly.