### PR TITLE
 Fix a bug with Post.user_tag_match sql generation

### DIFF
--- a/app/logical/concerns/searchable.rb
+++ b/app/logical/concerns/searchable.rb
@@ -19,6 +19,7 @@ module Searchable
     q = q.select(q.select_values + relation.select_values) if !relation.select_values.empty?
     q = q.from(relation.from_clause.value) if !relation.from_clause.empty?
     q = q.joins(relation.joins_values + q.joins_values) if relation.joins_values.present?
+    q = q.left_outer_joins(relation.left_outer_joins_values + q.left_outer_joins_values) if relation.left_outer_joins_values.present?
     q = q.where(relation.where_clause.ast) if relation.where_clause.present?
     q = q.group(relation.group_values) if relation.group_values.present?
     q = q.order(relation.order_values) if relation.order_values.present? && !relation.reordering_value

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PostQueryBuilderTest < ActiveSupport::TestCase
   def assert_tag_match(posts, query, relation: Post.all, current_user: CurrentUser.user, tag_limit: nil, **options)
-    assert_equal(posts.map(&:id), relation.user_tag_match(query, current_user, tag_limit: tag_limit, **options).pluck("posts.id"))
+    assert_equal(posts.map(&:id), relation.user_tag_match(query, current_user, tag_limit: tag_limit, **options).map(&:id))
   end
 
   def assert_search_error(query, current_user: CurrentUser.user, **options)
@@ -1422,6 +1422,12 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       post = create(:post)
 
       assert_tag_match([post], "order:random")
+    end
+
+    should "return posts for order:modqueue" do
+      post = create(:post)
+
+      assert_tag_match([post], "order:modqueue")
     end
 
     should "return posts for a filesize search" do


### PR DESCRIPTION
Fixes #5552

Fix a bug when post user_tag_match would use ordering which contained a left_outer_joins relation, it would not include relation when constructing a select query.

For example
```ruby
Post.user_tag_match("order:disapproved", User.first).to_a
Post.user_tag_match("order:modqueue", User.first).to_a
```

