### PR TITLE
Update Gemfile: abbrev no longer in Ruby 3.4.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem "connection_pool"
 gem "rotp"
 gem "rqrcode"
 gem "kramdown"
+gem "abbrev"
 
 group :development do
   gem 'rubocop', require: false


### PR DESCRIPTION
Using a brand new Master branch pull/run, we see the following:

> /home/danbooru/bundle/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: /usr/local/lib/ruby/3.3.0/abbrev.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add abbrev to your Gemfile or gemspec.

It suggests that while we load from the standardlib (which is fine as long as we version lock to ruby < 3.4.0), it's still recommended to add abbrev to either Gemfile or gemspec.

I added it to Gemfile.  This should behave/work and remove the deprecation warning.