### PR TITLE
Remove duplicate unqualified tag names from essential tag string

### DIFF
--- a/app/presenters/tag_set_presenter.rb
+++ b/app/presenters/tag_set_presenter.rb
@@ -24,12 +24,12 @@ class TagSetPresenter
   end
 
   def humanized_essential_tag_string
-    chartags = tags_for_category("character")
+    chartags = tags_for_category("character").uniq(&:unqualified_name)
     characters = chartags.max_by(5, &:post_count).map(&:unqualified_name)
     characters += ["#{chartags.size - 5} more"] if chartags.size > 5
     characters = characters.to_sentence
 
-    copytags = tags_for_category("copyright")
+    copytags = tags_for_category("copyright").uniq(&:unqualified_name)
     copyrights = copytags.max_by(1, &:post_count).map(&:unqualified_name)
     copyrights += ["#{copytags.size - 1} more"] if copytags.size > 1
     copyrights = copyrights.to_sentence


### PR DESCRIPTION
If a post has multiple tags with the same `unqualified_name`, its page title, file name, etc. list all of their occurrences (instead of just one per tag).

For example, [post #7667814](https://safebooru.donmai.us/posts/7667814)'s `humanized_essential_tag_string` is:

> aubrey, kel, aubrey, and kel (omori) drawn by sr_ld_fr

This PR removes duplicate values from the `chartags` and `copytags` arrays, resulting in a more readable/concise title:

> aubrey and kel (omori) drawn by sr_ld_fr