### PR TITLE
post queries: add hash-like nested attributes search syntax

### DIFF
--- a/app/logical/concerns/searchable.rb
+++ b/app/logical/concerns/searchable.rb
@@ -582,11 +582,19 @@ module Searchable
       end
 
       if params[:"#{name}_include_any_array"]
-        relation = visible(relation, name).where_array_includes_any(name, params[:"#{name}_include_any_array"])
+        items = params[:"#{name}_include_any_array"]
+        items = [items] unless items.is_a?(Array)
+        items = items.map(&:to_i) if type == :integer
+
+        relation = visible(relation, name).where_array_includes_any(name, items)
       end
 
       if params[:"#{name}_include_all_array"]
-        relation = visible(relation, name).where_array_includes_all(name, params[:"#{name}_include_all_array"])
+        items = params[:"#{name}_include_all_array"]
+        items = [items] unless items.is_a?(Array)
+        items = items.map(&:to_i) if type == :integer
+
+        relation = visible(relation, name).where_array_includes_all(name, items)
       end
 
       if params[:"#{name}_include_any_lower"]
@@ -604,11 +612,19 @@ module Searchable
       end
 
       if params[:"#{name}_include_any_lower_array"]
-        relation = visible(relation, name).where_array_includes_any_lower(name, params[:"#{name}_include_any_lower_array"])
+        items = params[:"#{name}_include_any_lower_array"]
+        items = [items] unless items.is_a?(Array)
+        items = items.map(&:to_i) if type == :integer
+
+        relation = visible(relation, name).where_array_includes_any_lower(name, items)
       end
 
       if params[:"#{name}_include_all_lower_array"]
-        relation = visible(relation, name).where_array_includes_all_lower(name, params[:"#{name}_include_all_lower_array"])
+        items = params[:"#{name}_include_all_lower_array"]
+        items = [items] unless items.is_a?(Array)
+        items = items.map(&:to_i) if type == :integer
+
+        relation = visible(relation, name).where_array_includes_all_lower(name, items)
       end
 
       if params[:"any_#{singular_name}_matches_regex"]

--- a/app/logical/media_asset_query.rb
+++ b/app/logical/media_asset_query.rb
@@ -23,7 +23,7 @@ class MediaAssetQuery
   end
 
   def normalized_ast
-    @normalized_ast ||= ast.to_cnf.rewrite_opts.trim
+    @normalized_ast ||= ast.to_cnf.rewrite_partials.trim
   end
 
   def search(relation: MediaAsset.all, foreign_key: :id, score_range: (50..))
@@ -40,6 +40,11 @@ class MediaAssetQuery
         metatag_matches(node.name, node.value, relation)
       in :wildcard
         relation.none
+      # TODO:
+      in :search_param
+        raise "not implemented"
+      in :search
+        raise "not implemented"
       in :not
         children.first.negate_relation
       in :and

--- a/app/logical/post_query.rb
+++ b/app/logical/post_query.rb
@@ -22,7 +22,7 @@ class PostQuery
   attr_reader :current_user
   private attr_reader :tag_limit, :safe_mode, :builder
 
-  delegate :tag?, :metatag?, :wildcard?, :metatags, :wildcards, :tag_names, :to_infix, :to_pretty_string, to: :ast
+  delegate :tag?, :metatag?, :wildcard?, :search?, :metatags, :wildcards, :tag_names, :searches, :to_infix, :to_pretty_string, to: :ast
   alias_method :safe_mode?, :safe_mode
   alias_method :to_s, :to_infix
 
@@ -132,9 +132,9 @@ class PostQuery
     end
   end
 
-  # True if the search consists of a single tag, metatag, or wildcard.
+  # True if the search consists of a single tag, metatag, wildcard, or search tag.
   def is_single_term?
-    tag_names.size + metatags.size + wildcards.size == 1
+    tag_names.size + metatags.size + wildcards.size + searches.size == 1
   end
 
   # True if this search consists only of a single non-negated tag, with no other metatags or operators.
@@ -154,7 +154,7 @@ class PostQuery
       metatag.name.in?(%w[date upvoter upvote downvoter downvote commenter comm search flagger fav ordfav favgroup ordfavgroup]) ||
       metatag.name == "status" && metatag.value == "unmoderated" ||
       metatag.name == "disapproved" && !metatag.value.downcase.in?(PostDisapproval::REASONS)
-    end
+    end || searches.present?
   end
 
   def select_metatags(*names)

--- a/app/logical/post_query.rb
+++ b/app/logical/post_query.rb
@@ -324,7 +324,7 @@ class PostQuery
 
     # The number of unique tags, wildcards, and metatags in the search, excluding metatags that don't count against the user's tag limit.
     def term_count
-      tag_names.size + wildcards.size + metatags.count { !_1.name.in?(UNLIMITED_METATAGS) }
+      tag_names.size + wildcards.size + metatags.count { !_1.name.in?(UNLIMITED_METATAGS) } + searches.size
     end
   end
 

--- a/app/logical/post_query.rb
+++ b/app/logical/post_query.rb
@@ -324,7 +324,16 @@ class PostQuery
 
     # The number of unique tags, wildcards, and metatags in the search, excluding metatags that don't count against the user's tag limit.
     def term_count
-      tag_names.size + wildcards.size + metatags.count { !_1.name.in?(UNLIMITED_METATAGS) } + search_params.size
+      tag_names.size +
+        wildcards.size +
+        metatags.count { !_1.name.in?(UNLIMITED_METATAGS) } +
+        search_params.sum do |param|
+          if param.path.last == "tags" || param.path.last.ends_with?("_tags_match")
+            build(param.value).term_count
+          else
+            1
+          end
+        end
     end
   end
 

--- a/app/logical/post_query/ast.rb
+++ b/app/logical/post_query/ast.rb
@@ -104,7 +104,7 @@ class PostQuery
         end
 
         def search(path, is_array, value, quoted = false)
-          AST.new(:search, [path.map(&:downcase), is_array, value.downcase, quoted])
+          AST.new(:search, [path, is_array, value, quoted])
         end
       end
 

--- a/app/logical/post_query/parser.rb
+++ b/app/logical/post_query/parser.rb
@@ -205,7 +205,7 @@ class PostQuery
         expect(":")
         quoted, value = quoted_string
         space
-        AST.search(path, is_array, value, quoted)
+        AST.search_param(path, is_array, value, quoted)
       end
 
       def search_path

--- a/app/logical/post_query/parser.rb
+++ b/app/logical/post_query/parser.rb
@@ -201,20 +201,22 @@ class PostQuery
       # search_path  = "[" search_param "]" [search_path]
       # search_param = "uploader" | "approver" | "parent" | ...
       def search
-        path = search_path
+        path, is_array = search_path
         expect(":")
         quoted, value = quoted_string
         space
-        AST.search(path, value, quoted)
+        AST.search(path, is_array, value, quoted)
       end
 
       def search_path
-        one_or_more {
+        path = one_or_more {
           expect("[")
           path_component = string(/[^ \]]+/, skip_balanced_parens: true)
           expect("]")
           path_component
         }
+        is_array = accept("[]").present?
+        [path, is_array]
       end
 
       def string(pattern, skip_balanced_parens: false)

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -119,7 +119,8 @@ class PostQueryBuilder
         tag_names = Tag.wildcard_matches(node.name).limit(MAX_WILDCARD_TAGS).pluck(:name)
         relation.where_array_includes_any("string_to_array(posts.tag_string, ' ')", tag_names)
       in :search
-        params = node.path.reverse.reduce(node.value) do |params, path| { path => params } end.with_indifferent_access
+        value = node.is_array ? [node.value] : node.value
+        params = node.path.reverse.reduce(value) do |params, path| { path => params } end.with_indifferent_access
         relation.search(params, current_user)
       in :not
         children.first.negate_relation

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -119,7 +119,7 @@ class PostQueryBuilder
         tag_names = Tag.wildcard_matches(node.name).limit(MAX_WILDCARD_TAGS).pluck(:name)
         relation.where_array_includes_any("string_to_array(posts.tag_string, ' ')", tag_names)
       in :search
-        params = node.path.reverse.reduce(node.value) do |params, path| { path => params } end
+        params = node.path.reverse.reduce(node.value) do |params, path| { path => params } end.with_indifferent_access
         filtered = relation.search(params, current_user)
         # XXX hack to make invalid searches return no results
         filtered = relation.none if relation.arel.constraints == filtered.arel.constraints

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -118,10 +118,10 @@ class PostQueryBuilder
       in :wildcard
         tag_names = Tag.wildcard_matches(node.name).limit(MAX_WILDCARD_TAGS).pluck(:name)
         relation.where_array_includes_any("string_to_array(posts.tag_string, ' ')", tag_names)
+      in :search_param
+        # no-op
       in :search
-        value = node.is_array ? [node.value] : node.value
-        params = node.path.reverse.reduce(value) do |params, path| { path => params } end.with_indifferent_access
-        relation.search(params, current_user)
+        relation.search(node.search_hash, current_user)
       in :not
         children.first.negate_relation
       in :and

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -120,10 +120,7 @@ class PostQueryBuilder
         relation.where_array_includes_any("string_to_array(posts.tag_string, ' ')", tag_names)
       in :search
         params = node.path.reverse.reduce(node.value) do |params, path| { path => params } end.with_indifferent_access
-        filtered = relation.search(params, current_user)
-        # XXX hack to make invalid searches return no results
-        filtered = relation.none if relation.arel.constraints == filtered.arel.constraints
-        filtered
+        relation.search(params, current_user)
       in :not
         children.first.negate_relation
       in :and

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -118,6 +118,12 @@ class PostQueryBuilder
       in :wildcard
         tag_names = Tag.wildcard_matches(node.name).limit(MAX_WILDCARD_TAGS).pluck(:name)
         relation.where_array_includes_any("string_to_array(posts.tag_string, ' ')", tag_names)
+      in :search
+        params = node.path.reverse.reduce(node.value) do |params, path| { path => params } end
+        filtered = relation.search(params, current_user)
+        # XXX hack to make invalid searches return no results
+        filtered = relation.none if relation.arel.constraints == filtered.arel.constraints
+        filtered
       in :not
         children.first.negate_relation
       in :and

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1748,6 +1748,16 @@ class Post < ApplicationRecord
           current_user: current_user
         )
 
+        if params[:pools].present?
+          pools = Pool.search(params[:pools], current_user)
+          q = q.where(id: pools.select("unnest(post_ids)"))
+        end
+
+        if params[:favorite_groups].present?
+          favorite_groups = FavoriteGroup.search(params[:favorite_groups], current_user)
+          q = q.where(id: favorite_groups.select("unnest(post_ids)"))
+        end
+
         if params[:tags].present?
           q = q.where(id: user_tag_match(params[:tags], current_user).select(:id))
         end

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -1320,6 +1320,22 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([post], "[invalid]:nobody")
     end
 
+    should "return posts for [] array search syntax" do
+      posts1 = create_list(:post, 3)
+      posts2 = create_list(:post, 2)
+      posts3 = [posts1.first, posts1.last, posts2.last]
+      pool1 = create(:pool, post_ids: posts1.pluck(:id), category: "collection")
+      pool2 = create(:pool, post_ids: posts2.pluck(:id), category: "collection")
+      pool3 = create(:pool, post_ids: posts3.pluck(:id), category: "collection")
+
+      assert_tag_match(posts2.reverse, "[pools][post_ids_include_any_array][]:#{posts2.first.id}")
+
+      # NYI
+      # assert_tag_match((posts1 + posts2).reverse, "[pools][post_ids_include_any_array][]:#{posts1.first.id} [pools][post_ids_include_any_array][]:#{posts2.first.id}")
+      # assert_tag_match([], "[pools][post_ids_include_all_array][]:#{posts1.first.id} [pools][post_ids_include_all_array][]:#{posts2.first.id}")
+      # assert_tag_match(posts3.reverse, "[pools][post_ids_include_all_array][]:#{posts1.first.id} [pools][post_ids_include_all_array][]:#{posts2.last.id}")
+    end
+
     should "return posts ordered by a particular attribute" do
       posts = (1..2).map do |n|
         tags = ["tagme", "gentag1 gentag2 artist:arttag char:chartag copy:copytag"]

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -1316,7 +1316,8 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([post], "[uploader_name]:#{post.uploader.name}")
       assert_tag_match([post], "[uploader][name]:#{post.uploader.name}")
       assert_tag_match([], "[uploader_name]:nobody")
-      assert_tag_match([], "[invalid]:nobody")
+      # Match ?search[] behavior
+      assert_tag_match([post], "[invalid]:nobody")
     end
 
     should "return posts ordered by a particular attribute" do

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -1329,11 +1329,9 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       pool3 = create(:pool, post_ids: posts3.pluck(:id), category: "collection")
 
       assert_tag_match(posts2.reverse, "[pools][post_ids_include_any_array][]:#{posts2.first.id}")
-
-      # NYI
-      # assert_tag_match((posts1 + posts2).reverse, "[pools][post_ids_include_any_array][]:#{posts1.first.id} [pools][post_ids_include_any_array][]:#{posts2.first.id}")
-      # assert_tag_match([], "[pools][post_ids_include_all_array][]:#{posts1.first.id} [pools][post_ids_include_all_array][]:#{posts2.first.id}")
-      # assert_tag_match(posts3.reverse, "[pools][post_ids_include_all_array][]:#{posts1.first.id} [pools][post_ids_include_all_array][]:#{posts2.last.id}")
+      assert_tag_match((posts1 + posts2).reverse, "[pools][post_ids_include_any_array][]:#{posts1.first.id} [pools][post_ids_include_any_array][]:#{posts2.first.id}")
+      assert_tag_match([], "[pools][post_ids_include_all_array][]:#{posts1.first.id} [pools][post_ids_include_all_array][]:#{posts2.first.id}")
+      assert_tag_match(posts3.reverse, "[pools][post_ids_include_all_array][]:#{posts1.first.id} [pools][post_ids_include_all_array][]:#{posts2.last.id}")
     end
 
     should "return posts ordered by a particular attribute" do

--- a/test/unit/post_query_parser_test.rb
+++ b/test/unit/post_query_parser_test.rb
@@ -199,6 +199,7 @@ class PostQueryParserTest < ActiveSupport::TestCase
       assert_parse_equals("(search a=)", '[a]:')
       assert_parse_equals("(search a=foo)", "[a]:foo")
       assert_parse_equals("(search a.b=foo)", "[a][b]:foo")
+      assert_parse_equals("(search a.b[]=foo)", "[a][b][]:foo")
       assert_parse_equals('(search a.b="")', '[a][b]:""')
     end
 
@@ -398,7 +399,6 @@ class PostQueryParserTest < ActiveSupport::TestCase
       assert_parse_equals("none", '[a:foo')
       assert_parse_equals("none", '[a]')
       assert_parse_equals("none", '[a][:')
-      assert_parse_equals("none", '[a][]:')
       assert_parse_equals("none", '[a][][b]:')
     end
 
@@ -437,6 +437,7 @@ class PostQueryParserTest < ActiveSupport::TestCase
         assert_equal('a source:""', to_infix('a source:""'))
 
         assert_equal("a [b]:c", to_infix("a [b]:c"))
+        assert_equal("a [b][]:c", to_infix("a [b][]:c"))
         assert_equal('a [b]:"c d"', to_infix('a [b]:"c d"'))
         assert_equal('a [b]:"\\""', to_infix('a [b]:"\\""'))
         assert_equal('a [b]:""', to_infix('a [b]:""'))

--- a/test/unit/post_query_parser_test.rb
+++ b/test/unit/post_query_parser_test.rb
@@ -196,11 +196,19 @@ class PostQueryParserTest < ActiveSupport::TestCase
     end
 
     should "parse search tags correctly" do
-      assert_parse_equals("(search a=)", '[a]:')
-      assert_parse_equals("(search a=foo)", "[a]:foo")
-      assert_parse_equals("(search a.b=foo)", "[a][b]:foo")
-      assert_parse_equals("(search a.b[]=foo)", "[a][b][]:foo")
-      assert_parse_equals('(search a.b="")', '[a][b]:""')
+      assert_parse_equals("(search [a]:)", '[a]:')
+      assert_parse_equals("(search [a]:foo)", "[a]:foo")
+      assert_parse_equals("(search [a]:bar)", "[a]:foo [a]:bar")
+      assert_parse_equals("(search [a][b]:foo)", "[a][b]:foo")
+      assert_parse_equals("(search [a][b][]:foo)", "[a][b][]:foo")
+      assert_parse_equals("(search [a][b][]:bar [a][b][]:foo)", "[a][b][]:foo [a][b][]:bar")
+      assert_parse_equals('(search [a][b]:)', '[a][b]:""')
+      assert_parse_equals('(search [a][b]:"c d")', '[a][b]:"c d"')
+      assert_parse_equals('(search [a][b]:"\\"")', '[a][b]:"\\""')
+      assert_parse_equals('(search [a][b]:d)', '[a][b]:c [a][b]:d')
+      assert_parse_equals('(search [a][b]:c [a][d]:e)', '[a][d]:e [a][b]:c')
+      assert_parse_equals('(and (search [a]:b [c]:d) (search [e]:f [g]:h))', '([a]:b [c]:d) ([e]:f [g]:h)')
+      assert_parse_equals('(and (search [a][b]:c [a][d]:e) f)', '[a][b]:c [a][d]:e f')
     end
 
     should "parse single tag queries correctly" do

--- a/test/unit/post_query_parser_test.rb
+++ b/test/unit/post_query_parser_test.rb
@@ -195,6 +195,13 @@ class PostQueryParserTest < ActiveSupport::TestCase
       assert_parse_equals("(and (not (wildcard *)) a c)", "a -* c")
     end
 
+    should "parse search tags correctly" do
+      assert_parse_equals("(search a=)", '[a]:')
+      assert_parse_equals("(search a=foo)", "[a]:foo")
+      assert_parse_equals("(search a.b=foo)", "[a][b]:foo")
+      assert_parse_equals('(search a.b="")', '[a][b]:""')
+    end
+
     should "parse single tag queries correctly" do
       assert_parse_equals("a", "a")
       assert_parse_equals("a", "a ")
@@ -383,6 +390,16 @@ class PostQueryParserTest < ActiveSupport::TestCase
 
       assert_parse_equals("none", 'source:"foo')
       assert_parse_equals("none", 'source:"foo bar')
+
+      assert_parse_equals("none", '[')
+      assert_parse_equals("none", '[]')
+      assert_parse_equals("none", '[]:foo')
+      assert_parse_equals("none", '[a')
+      assert_parse_equals("none", '[a:foo')
+      assert_parse_equals("none", '[a]')
+      assert_parse_equals("none", '[a][:')
+      assert_parse_equals("none", '[a][]:')
+      assert_parse_equals("none", '[a][][b]:')
     end
 
     context "#to_infix" do
@@ -418,6 +435,11 @@ class PostQueryParserTest < ActiveSupport::TestCase
         assert_equal('a source:"b c"', to_infix('a source:"b c"'))
         assert_equal('a source:"\\""', to_infix('a source:"\\""'))
         assert_equal('a source:""', to_infix('a source:""'))
+
+        assert_equal("a [b]:c", to_infix("a [b]:c"))
+        assert_equal('a [b]:"c d"', to_infix('a [b]:"c d"'))
+        assert_equal('a [b]:"\\""', to_infix('a [b]:"\\""'))
+        assert_equal('a [b]:""', to_infix('a [b]:""'))
 
         assert_equal("a* b", to_infix("a* b"))
 


### PR DESCRIPTION
This is the proposal to allow filtering posts by related objects attributes in a similar way that is [implemented](https://danbooru.donmai.us/wiki_pages/help%3Ahash_syntax) for other models with the `search` query parameter, but integrated into the tag system instead to account for tag limits, as mentioned before at https://github.com/danbooru/danbooru/issues/5638#issuecomment-1930911388.

The syntax is similar to aforementioned `search` query parameter, and relies on the fact that tags can't start with `[` character.
Example:
- `[uploader_id]:508240`
- `[uploader][name]:Monki`
- `[uploader][level_gteq]:32`
- `[appeals][creator][id]:200729`
- etc.