### PR TITLE
posts: fix "Resize to window" for ugoira

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -358,7 +358,7 @@ class Note {
       let ratio = $container.width() / large_width;
       let font_percentage = ratio * 100;
 
-      $container.css('font-size', font_percentage + '%');
+      $container.css('--note-font-size', font_percentage + '%');
     }
 
     static toggle_all() {

--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -318,7 +318,6 @@ Post.view_large = function(e = null) {
 Post.toggle_fit_window = function(e) {
   $("#image").toggleClass("fit-width");
   Note.Box.scale_all();
-  Post.resize_ugoira_controls();
   e.preventDefault();
 };
 
@@ -400,7 +399,6 @@ Post.initialize_ugoira_player = function() {
     let file_url = $(".image-container").data("file-url");
 
     Ugoira.create_player(frame_delays, file_url);
-    $(window).on("resize.danbooru.ugoira_scale", Post.resize_ugoira_controls);
   }
 };
 
@@ -415,13 +413,6 @@ Post.initialize_ruffle_player = function() {
     player.load(src);
   }
 };
-
-Post.resize_ugoira_controls = function() {
-  var $img = $("#image");
-  var width = Math.max($img.width(), 350);
-  $("#ugoira-control-panel").css("width", width);
-  $("#seek-slider").css("width", width - 81);
-}
 
 Post.show_pending_update_notice = function() {
   if (Post.pending_update_count === 0) {

--- a/app/javascript/src/javascripts/ugoira.js
+++ b/app/javascript/src/javascripts/ugoira.js
@@ -44,7 +44,12 @@ Ugoira.create_player = (frames, file_url) => {
   });
 
   $("#seek-slider").progressbar({
-    value: 0
+    value: 0,
+    change: e => {
+      // Use % instead of px
+      const $progressbar = $(e.target);
+      $progressbar.find(".ui-progressbar-value").css("width", $progressbar.progressbar("value") + "%");
+    }
   });
 
   $("#seek-slider").slider({

--- a/app/javascript/src/styles/specific/notes.scss
+++ b/app/javascript/src/styles/specific/notes.scss
@@ -110,6 +110,7 @@
     opacity: 0.5;
     z-index: 100;
     box-sizing: content-box;
+    font-size: var(--note-font-size);
 
     /* Raise notes on hover so overlapping embedded notes are readable. */
     &:hover {

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -87,6 +87,10 @@ div#c-posts {
   }
 
   #ugoira-controls {
+    div#ugoira-control-panel {
+      width: calc(max(350px, 100%));
+    }
+
     div#seek-slider {
       overflow: visible;
       background: var(--ugoira-seek-slider-background);

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -282,10 +282,10 @@
         <%= tag.canvas(id: "image", class: "fit-width", width: @post.image_width, height: @post.image_height, "data-ugoira-frame-delays": @post.media_metadata.metadata["Ugoira:FrameDelays"].to_json) %>
 
         <div id="ugoira-controls">
-          <div id="ugoira-control-panel" class="mb-2 flex items-center" style="width: <%= [@post.image_width, 350].max %>px;">
+          <div id="ugoira-control-panel" class="mb-2 flex items-center">
             <button id="ugoira-play" style="display: none;">Play</button>
             <button id="ugoira-pause">Pause</button>
-            <div id="seek-slider" class="ml-4" style="width: <%= [@post.image_width, 350].max - 81 %>px;"></div>
+            <div id="seek-slider" class="ml-4 flex-1"></div>
           </div>
 
           <p><%= link_to "View WebM", current_page_path(size: "webm") %></p>


### PR DESCRIPTION
There are three things incorrect as of now:

First, `Note.Box.scale_all`, which is supposed to adjust font size for embedded notes, applied it to the whole image/notes container, which also contained ugoira controls, making them incorrectly sized, and the image itself, giving it a large top padding.
The fix is to change `font-size` only for `.note-box` elements.

Second, `Post.resize_ugoira_controls` couldn't calculate the right slider width - it was trying to use the image's width, but the image itself adjusted own width to match slider.
The fix is to get rid of that function and just use CSS.