### PR TITLE
docker: Fix Download link on posts

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -77,11 +77,13 @@ http {
       expires max;
 
       rewrite (.*)/__.+?__(.+)$ $1/$2;
-      rewrite ^/data/(.*) /$1 break;
+      rewrite ^/data/(.*) /$1;
 
       if ($arg_download) {
         more_set_headers 'Content-Disposition: attachment';
       }
+
+      break;
     }
 
     location / {


### PR DESCRIPTION
On provided `nginx.conf`, the `break` statement (from `ngx_http_rewrite_module`) executed too early, so that the following `if ($arg_download) { ... } ` block executed never. This commit fixes it by putting the `break;` on it's own line at the end of the location block.

The reasons it looked like it worked are:
1. Locally, it was most probably, if at all, tested by left-clicking the "Download" button on post (huh!), which initiated download because the `<a>` element had `download` attribute.
This wouldn't have worked if the user clicked the button with the middle mouse button (resulting it to just opening in a new tab), or reached that url through other means, or, while not directly applicable here, if the anchor location was cross-origin (as both Firefox and Chromium ignore it in that case, see [[1]](https://chromestatus.com/feature/4969697975992320), [[2]](https://html.spec.whatwg.org/multipage/links.html#downloading-resources))
2. On `cdn.donmai.us`, the [different](https://github.com/danbooru/danbooru-infrastructure/blob/98fd57b5877937bff17a25ffe9701c85f7c4d4b2/k8s/danbooru-images/config/nginx.conf#L203-L218) config with different rewrite rules is used. However, it has another funny quirk: despite the anchor download attribute - with filename in a different format than in the url itself when tagged filenames are enabled - being present, it is completely ignored by browsers for the reason mentioned above.