### PR TITLE
related tags: fix integer division in similarity values calculator

### DIFF
--- a/app/logical/related_tag_calculator.rb
+++ b/app/logical/related_tag_calculator.rb
@@ -45,7 +45,7 @@ class RelatedTagCalculator
 
     # The estimated number of posts in common between tag A and tag B; that is, the intersection between A and B.
     def overlap
-      [frequency * search_count, tag.post_count].min
+      [frequency * search_count, tag.post_count].min.to_f
     end
 
     # The estimated percentage of posts in common between tag A and tag B; that is, how frequently tag A appears together with tag B.


### PR DESCRIPTION
At `RelatedTagCalculator::RelatedTag#overlap`, using integer `tag.post_count` leads to integer division in `jaccard_similarity` and `overlap_coefficient` methods.

Fixes #5803