### PR TITLE
null extractor: try to get page url from referer

### DIFF
--- a/app/logical/source/extractor/null.rb
+++ b/app/logical/source/extractor/null.rb
@@ -16,11 +16,11 @@ module Source
       end
 
       def page_url
-        sub_extractor&.page_url
+        sub_extractor&.page_url || parsed_url.page_url || parsed_referer&.page_url
       end
 
       def profile_url
-        sub_extractor&.profile_url
+        sub_extractor&.profile_url || parsed_url.profile_url || parsed_referer&.profile_url
       end
 
       def profile_urls


### PR DESCRIPTION
I got too annoyed of having to manually copy source URL each time I upload from Discord, so I made a [BetterDiscord plugin](https://github.com/hdk5/danbooru.user.js/blob/master/dist/upload-to-danbooru.bd.plugin.js) to open the upload page with `ref` included.
To my surprise, it did not work right away, since the generic extractor just ignores it.
I think it is safe enough to try to get `page_url` and, maybe `profile_url` too, from `parsed_url`/`parsed_referer` in null extractor in all cases, so that's what I did here.