### PR TITLE
Fix tests being broken by CurrentUser

### DIFF
--- a/test/factories/post.rb
+++ b/test/factories/post.rb
@@ -13,6 +13,14 @@ FactoryBot.define do
     source { Faker::Internet.url }
     media_asset { build(:media_asset) }
 
+    after(:build) do |post|
+      CurrentUser.stubs(:user).returns(post.uploader)
+    end
+
+    after(:create) do
+      CurrentUser.unstub(:user)
+    end
+
     factory(:post_with_file) do
       transient do
         filename { "test.jpg" }


### PR DESCRIPTION
See https://discord.com/channels/310432830138089472/310846683376517121/1288146168915951639

https://github.com/danbooru/danbooru/commit/df778c8585097143e3639f936604409a485f580f introduced some calls to CurrentUser that broke every factory instantiaton of post objects. There's more stuff to fix since post.update! also needs to be fixed, and probably some more methods, so this is a wip.