### PR TITLE
Make media assets reportable

### DIFF
--- a/app/components/media_asset_component/media_asset_component.scss
+++ b/app/components/media_asset_component/media_asset_component.scss
@@ -63,6 +63,12 @@
     }
   }
 
+  .moderation-report-notice {
+    font-weight: bold;
+    color: var(--moderation-report-text-color);
+    line-height: 1.25em
+  }
+
   .media-asset-image {
     user-select: none;
     width: auto;

--- a/app/policies/media_asset_policy.rb
+++ b/app/policies/media_asset_policy.rb
@@ -17,6 +17,10 @@ class MediaAssetPolicy < ApplicationPolicy
     !record.removed? && (record.post.blank? || record.post.visible?(user))
   end
 
+  def reportable?
+    record.post.blank?
+  end
+
   def api_attributes
     attributes = super + [:variants]
     attributes -= [:md5, :file_key, :variants] if !can_see_image?

--- a/app/policies/moderation_report_policy.rb
+++ b/app/policies/moderation_report_policy.rb
@@ -21,6 +21,10 @@ class ModerationReportPolicy < ApplicationPolicy
     user.is_moderator?
   end
 
+  def can_view_reported_user?
+    record.model.class != MediaAsset || can_see_moderation_reports?
+  end
+
   def permitted_attributes_for_create
     [:model_type, :model_id, :reason]
   end

--- a/app/views/media_assets/show.html.erb
+++ b/app/views/media_assets/show.html.erb
@@ -25,11 +25,23 @@
 
                 <%= link_to_media_asset @media_asset, url: @media_asset.original.file_url %>
 
+                <% if policy(ModerationReport).can_see_moderation_reports? && @media_asset.pending_moderation_reports.present? %>
+                  <span class="moderation-report-notice font-bold">
+                    Reported (<%= link_to pluralize(@media_asset.pending_moderation_reports.length, "report"), moderation_reports_path(search: { model_type: "MediaAsset", model_id: @media_asset.id, status: "pending" }) %>)
+                  </span>
+                <% end %>
+
                 <span>
                   <%= render PopupMenuComponent.new(hide_on_click: false) do |menu| %>
                     <% menu.with_item(hide_on_click: true) do %>
                       <%= link_to "#{@media_asset.original.file_url}?download=1", download: @media_asset.original.file_name do %>
                         <%= download_icon %> Download
+                      <% end %>
+
+                      <% if policy(@media_asset).reportable? %>
+                        <%= link_to new_moderation_report_path(moderation_report: { model_type: "MediaAsset", model_id: @media_asset.id }), remote: true, title: "Report this media asset to the moderators" do %>
+                          <%= flag_icon  %> Report
+                        <% end %>
                       <% end %>
                     <% end %>
 

--- a/app/views/moderation_reports/_new.html.erb
+++ b/app/views/moderation_reports/_new.html.erb
@@ -1,5 +1,9 @@
 <div class="report-dialog-body">
-  <%= embed_wiki("help:report_notice") %>
+  <% if @moderation_report.model_type == "MediaAsset" %>
+    <%= embed_wiki("help:media_asset_report_notice") %>
+  <% else %>
+    <%= embed_wiki("help:report_notice") %>
+  <% end %>
 
   <%= edit_form_for(moderation_report, format: :js, remote: true) do |f| %>
     <%= f.hidden_field :model_type %>

--- a/app/views/moderation_reports/index.html.erb
+++ b/app/views/moderation_reports/index.html.erb
@@ -44,14 +44,16 @@
         <div><%= time_ago_in_words_tagged(report.created_at) %></div>
       <% end %>
 
-      <% t.column column: "control" do |report| %>
-        <%= render PopupMenuComponent.new do |menu| %>
-          <% menu.with_item do %>
-            <%= link_to "Mark as handled", moderation_report_path(report.id), method: :put, remote: true, "data-params": "moderation_report[status]=handled" %>
-          <% end %>
+      <% if policy(ModerationReport).update? %>
+        <% t.column column: "control" do |report| %>
+          <%= render PopupMenuComponent.new do |menu| %>
+            <% menu.with_item do %>
+              <%= link_to "Mark as handled", moderation_report_path(report.id), method: :put, remote: true, "data-params": "moderation_report[status]=handled" %>
+            <% end %>
 
-          <% menu.with_item do %>
-            <%= link_to "Reject", moderation_report_path(report.id), method: :put, remote: true, "data-params": "moderation_report[status]=rejected" %>
+            <% menu.with_item do %>
+              <%= link_to "Reject", moderation_report_path(report.id), method: :put, remote: true, "data-params": "moderation_report[status]=rejected" %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/moderation_reports/index.html.erb
+++ b/app/views/moderation_reports/index.html.erb
@@ -32,9 +32,10 @@
         <%= link_to report.status.capitalize, moderation_reports_path(search: { status: report.status }) %>
       <% end %>
 
-      <% t.column "Reported user" do |report| %>
-        <%= link_to_user report.reported_user %>
-        <%= link_to "»", moderation_reports_path(search: { recipient_name: report.reported_user.name }) %>
+      <% t.column "Reported users" do |report| %>
+        <%= report.reported_users.map do |reported_user|
+          "#{link_to_user(reported_user)} #{link_to('»', moderation_reports_path(search: { recipient_name: reported_user.name }))}"
+        end.join(', ').html_safe %>
       <% end %>
 
       <% t.column "Reporter" do |report| %>

--- a/app/views/moderation_reports/index.html.erb
+++ b/app/views/moderation_reports/index.html.erb
@@ -33,9 +33,11 @@
       <% end %>
 
       <% t.column "Reported users" do |report| %>
-        <%= report.reported_users.map do |reported_user|
-          "#{link_to_user(reported_user)} #{link_to('»', moderation_reports_path(search: { recipient_name: reported_user.name }))}"
-        end.join(', ').html_safe %>
+        <% if policy(report).can_view_reported_user? %>
+          <%= report.reported_users.map do |reported_user|
+            "#{link_to_user(reported_user)} #{link_to('»', moderation_reports_path(search: { recipient_name: reported_user.name }))}"
+          end.join(', ').html_safe %>
+        <% end %>
       <% end %>
 
       <% t.column "Reporter" do |report| %>

--- a/test/functional/moderation_reports_controller_test.rb
+++ b/test/functional/moderation_reports_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
   context "The moderation reports controller" do
@@ -7,10 +7,13 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
       @spammer = create(:user, id: 5678, name: "spammer", created_at: 2.weeks.ago)
       @mod = create(:moderator_user, created_at: 2.weeks.ago)
 
+      @media_asset = create(:media_asset, id: 4567)
+
       as(@spammer) do
         @dmail = create(:dmail, from: @spammer, owner: @user, to: @user)
         @comment = create(:comment, id: 1234, creator: @spammer)
         @forum_post = create(:forum_post, topic: build(:forum_topic), body: "xxx", creator: @spammer)
+        @upload = create(:upload, uploader: @spammer, upload_media_assets: [build(:upload_media_asset, media_asset: @media_asset)])
       end
     end
 
@@ -37,6 +40,7 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
         @comment_report = create(:moderation_report, model: @comment, creator: @user)
         @forum_report = create(:moderation_report, model: @forum_post, creator: @user)
         @dmail_report = create(:moderation_report, reason: "spam", model: @dmail, creator: build(:builder_user, name: "daiyousei", created_at: 2.weeks.ago))
+        @media_asset_report = create(:moderation_report, model: @media_asset, creator: @user)
       end
 
       context "as a user" do
@@ -44,10 +48,11 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
           get_auth moderation_reports_path, @user
 
           assert_response :success
-          assert_select "tbody tr", count: 2
+          assert_select "tbody tr", count: 3
           assert_select "tr#moderation-report-#{@comment_report.id}", count: 1
           assert_select "tr#moderation-report-#{@forum_report.id}", count: 1
           assert_select "tr#moderation-report-#{@dmail_report.id}", count: 0
+          assert_select "tr#moderation-report-#{@media_asset_report.id}", count: 1
         end
 
         should "not show reports submitted by other users" do
@@ -68,16 +73,18 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
           assert_response :success
         end
 
-        should respond_to_search({}).with { [@dmail_report, @forum_report, @comment_report] }
-        should respond_to_search(reason_matches: "spam").with { @dmail_report }
-        should respond_to_search(recipient_id: 5678).with { [@dmail_report, @forum_report, @comment_report] }
-        should respond_to_search(recipient_name: "spammer").with { [@dmail_report, @forum_report, @comment_report] }
+        should(respond_to_search({}).with { [@media_asset_report, @dmail_report, @forum_report, @comment_report] })
+        should(respond_to_search(reason_matches: "spam").with { @dmail_report })
+        should(respond_to_search(recipient_id: 5678).with { [@media_asset_report, @dmail_report, @forum_report, @comment_report] })
+        should(respond_to_search(recipient_name: "spammer").with { [@media_asset_report, @dmail_report, @forum_report, @comment_report]})
 
         context "using includes" do
-          should respond_to_search(model_id: 1234).with { @comment_report }
-          should respond_to_search(model_type: "ForumPost").with { @forum_report }
-          should respond_to_search(ForumPost: {body_matches: "xxx"}).with { @forum_report }
-          should respond_to_search(creator_name: "daiyousei").with { @dmail_report }
+          should(respond_to_search(model_id: 1234).with { @comment_report })
+          should(respond_to_search(model_type: "ForumPost").with { @forum_report })
+          should(respond_to_search(model_id: 4567).with { @media_asset_report })
+          should(respond_to_search(model_type: "MediaAsset").with { @media_asset_report })
+          should(respond_to_search(ForumPost: {body_matches: "xxx"}).with { @forum_report })
+          should(respond_to_search(creator_name: "daiyousei").with { @dmail_report })
         end
       end
     end
@@ -87,6 +94,40 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
         @report = create(:moderation_report, model: @comment, creator: @user)
         get_auth moderation_report_path(@report), @mod
         assert_redirected_to moderation_reports_path(search: { id: @report.id })
+      end
+
+      should "show the reported user for comments" do
+        @report = create(:moderation_report, model: @comment, creator: @user)
+        get_auth moderation_reports_path(search: { id: @report.id, model_type: "Comment" }), @user
+        assert_select ".reported-users-column .user", count: 1
+      end
+
+      should "show the reported user for dmails" do
+        @report = create(:moderation_report, model: @forum_post, creator: @user)
+        get_auth moderation_reports_path(search: { id: @report.id, model_type: "ForumPost" }), @user
+
+        assert_select ".reported-users-column .user", count: 1
+      end
+
+      should "show the reported user for forum posts" do
+        @report = create(:moderation_report, model: @dmail, creator: @user)
+        get_auth moderation_reports_path(search: { id: @report.id, model_type: "Dmail" }), @user
+
+        assert_select ".reported-users-column .user", count: 1
+      end
+
+      should "not show the reported user for media assets to normal users" do
+        @report = create(:moderation_report, model: @media_asset, creator: @user)
+        get_auth moderation_reports_path(search: { id: @report.id, model_type: "MediaAsset" }), @user
+
+        assert_select ".reported-users-column .user", count: 0
+      end
+
+      should "show the reported user for media assets to mods" do
+        @report = create(:moderation_report, model: @media_asset, creator: @user)
+        get_auth moderation_reports_path(search: { id: @report.id, model_type: "MediaAsset" }), @mod
+
+        assert_select ".reported-users-column .user", count: 1
       end
     end
 
@@ -111,6 +152,13 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
           assert_response :success
         end
       end
+
+      should "create a new moderation report on a media asset" do
+        assert_difference("ModerationReport.count", 1) do
+          post_auth moderation_reports_path, @user, params: { format: "js", moderation_report: { model_id: @media_asset.id, model_type: "MediaAsset", reason: "xxx" }}
+          assert_response :success
+        end
+      end
     end
 
     context "update action" do
@@ -128,7 +176,7 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal("handled", report.reload.status)
         assert_equal(true, @user.dmails.received.exists?(from: User.system, title: "Thank you for reporting comment ##{@comment.id}"))
-        assert_equal(true, ModAction.moderation_report_handled.where(creator: @mod).exists?)
+        assert_equal(true, ModAction.moderation_report_handled.exists?(creator: @mod))
         assert_equal(report, ModAction.last.subject)
         assert_equal(@mod, ModAction.last.creator)
       end
@@ -140,7 +188,7 @@ class ModerationReportsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_equal("rejected", report.reload.status)
         assert_equal(false, @user.dmails.received.exists?(from: User.system))
-        assert_equal(true, ModAction.moderation_report_rejected.where(creator: @mod).exists?)
+        assert_equal(true, ModAction.moderation_report_rejected.exists?(creator: @mod))
         assert_equal(report, ModAction.last.subject)
         assert_equal(@mod, ModAction.last.creator)
       end


### PR DESCRIPTION
Fixes #5825.
Still a WIP, need to add tests and think of edge cases.

Media assets can only be reported if they're not associated to posts, otherwise flags must be used. Because of that, I added a different wiki for media asset report notices so that this can be explained separately.

The main change is that it changes reported_user to reported_users, because media assets can be associated with multiple uploads.


![image](https://github.com/user-attachments/assets/01bde199-f4fb-41f4-a81e-8e24a0a16885)
![image](https://github.com/user-attachments/assets/2a6d8e31-d5e1-4917-ba2d-751aa4913711)
