### PR TITLE
sources: allow ugoira uploads from danbooru

### DIFF
--- a/app/logical/source/extractor/danbooru2.rb
+++ b/app/logical/source/extractor/danbooru2.rb
@@ -15,7 +15,7 @@ module Source
         elsif parsed_url.image_url?
           [parsed_url.candidate_full_image_urls.find { |url| http_exists?(url) } || url]
         else
-          [api_response.dig(:media_asset, :variants)&.find { it[:type] == "original" }&.dig(:url)].compact
+          [api_response[:variants]&.find { it[:type] == "original" }&.dig(:url)].compact
         end
       end
 
@@ -24,7 +24,7 @@ module Source
       end
 
       def tags
-        api_response[:tag_string].to_s.split.map do |tag|
+        api_response.dig(:post, :tag_string).to_s.split.map do |tag|
           [tag, "https://danbooru.donmai.us/posts?tags=#{::Danbooru::URL.escape(tag)}"]
         end
       end
@@ -43,21 +43,32 @@ module Source
         super.headers("User-Agent": "#{Danbooru.config.canonical_app_name}/#{Rails.application.config.x.git_hash}")
       end
 
-      memoize def api_response
-        fields = %w[id source tag_string tag_string_artist media_asset artist_commentary].join(",")
+      def download_file!(url)
+        media_file = super(url)
+        media_file.frame_delays = ugoira_frame_delays if ugoira_frame_delays.present?
+        media_file
+      end
 
-        if post_id_from_url.present?
-          http.cache(1.minute).parsed_get("https://danbooru.donmai.us/posts/#{post_id_from_url}.json?only=#{fields}") || {}
-        elsif post_md5_from_url.present?
-          http.cache(1.minute).parsed_get("https://danbooru.donmai.us/posts.json?md5=#{post_md5_from_url}&only=#{fields}") || {}
-        else
-          {}
+      def ugoira_frame_delays
+        api_response.dig(:media_metadata, :metadata, :"Ugoira:FrameDelays")
+      end
+
+      memoize def api_response
+        fields = %w[variants media_metadata[metadata] post[id,tag_string,source]].join(",")
+
+        api_url = if post_md5_from_url.present?
+          "https://danbooru.donmai.us/media_assets.json?search[md5]=#{post_md5_from_url}&only=#{fields}"
+        elsif post_id_from_url.present?
+          "https://danbooru.donmai.us/media_assets.json?search[post][id]=#{post_id_from_url}&only=#{fields}"
         end
+
+        response = http.cache(1.minute).parsed_get(api_url) if api_url.present?
+        (response || []).first.to_h.with_indifferent_access
       end
 
       concerning :HelperMethods do
         def post_id
-          post_id_from_url || api_response[:id]
+          post_id_from_url || api_response.dig(:post, :id)
         end
 
         def post_id_from_url
@@ -71,7 +82,7 @@ module Source
         def sub_extractor
           return nil if parent_extractor.present?
 
-          @sub_extractor ||= Source::Extractor.find(api_response[:source], default_extractor: nil, parent_extractor: self)
+          @sub_extractor ||= Source::Extractor.find(api_response.dig(:post, :source), default_extractor: nil, parent_extractor: self)
         end
       end
     end

--- a/app/logical/source/extractor/danbooru2.rb
+++ b/app/logical/source/extractor/danbooru2.rb
@@ -45,7 +45,9 @@ module Source
 
       def download_file!(url)
         media_file = super(url)
-        media_file.frame_delays = ugoira_frame_delays if ugoira_frame_delays.present?
+        if !media_file.is_a?(MediaFile::Ugoira) && ugoira_frame_delays.present?
+          media_file = MediaFile.open(media_file.file, frame_delays: ugoira_frame_delays)
+        end
         media_file
       end
 

--- a/app/models/media_asset.rb
+++ b/app/models/media_asset.rb
@@ -243,7 +243,7 @@ class MediaAsset < ApplicationRecord
       end
 
       def search(params, current_user)
-        q = search_attributes(params, %i[id created_at updated_at status md5 pixel_hash file_ext file_size image_width image_height duration file_key is_public post], current_user: current_user)
+        q = search_attributes(params, %i[id created_at updated_at status md5 pixel_hash file_ext file_size image_width image_height duration file_key is_public], current_user: current_user)
 
         if params[:metadata].present?
           q = q.joins(:media_metadata).merge(MediaMetadata.search({ metadata: params[:metadata] }, current_user))

--- a/app/models/media_asset.rb
+++ b/app/models/media_asset.rb
@@ -243,7 +243,7 @@ class MediaAsset < ApplicationRecord
       end
 
       def search(params, current_user)
-        q = search_attributes(params, %i[id created_at updated_at status md5 pixel_hash file_ext file_size image_width image_height duration file_key is_public], current_user: current_user)
+        q = search_attributes(params, %i[id created_at updated_at status md5 pixel_hash file_ext file_size image_width image_height duration file_key is_public post], current_user: current_user)
 
         if params[:metadata].present?
           q = q.joins(:media_metadata).merge(MediaMetadata.search({ metadata: params[:metadata] }, current_user))

--- a/test/unit/source/extractor/danbooru_extractor_test.rb
+++ b/test/unit/source/extractor/danbooru_extractor_test.rb
@@ -65,6 +65,15 @@ module Source::Tests::Extractor
       )
     end
 
+    context "an ugoira" do
+      strategy_should_work(
+        "https://cdn.donmai.us/original/22/30/2230a9de4ceecec50228cbb6e37630bd.zip",
+        image_urls: %w[https://cdn.donmai.us/original/22/30/2230a9de4ceecec50228cbb6e37630bd.zip],
+        media_files: [{ file_size: 3_433_318, frame_delays: [100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100] }],
+        page_url: "https://danbooru.donmai.us/posts/7271978",
+      )
+    end
+
     context "A post with a source pointing to itself" do
       strategy_should_work(
         "https://danbooru.donmai.us/posts/4542652",

--- a/test/unit/source/extractor/danbooru_extractor_test.rb
+++ b/test/unit/source/extractor/danbooru_extractor_test.rb
@@ -67,10 +67,19 @@ module Source::Tests::Extractor
 
     context "an ugoira" do
       strategy_should_work(
+        "https://cdn.donmai.us/original/4a/35/4a35664711f49f3f526257ca53d2992b.zip",
+        image_urls: %w[https://cdn.donmai.us/original/4a/35/4a35664711f49f3f526257ca53d2992b.zip],
+        media_files: [{ file_size: 7_938_927, frame_delays: [100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100] }],
+        page_url: "https://danbooru.donmai.us/posts/7271978",
+      )
+    end
+
+    context "an ugoira without embedded frame delays" do
+      strategy_should_work(
         "https://cdn.donmai.us/original/22/30/2230a9de4ceecec50228cbb6e37630bd.zip",
         image_urls: %w[https://cdn.donmai.us/original/22/30/2230a9de4ceecec50228cbb6e37630bd.zip],
         media_files: [{ file_size: 3_433_318, frame_delays: [100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100] }],
-        page_url: "https://danbooru.donmai.us/posts/7271978",
+        page_url: nil,
       )
     end
 


### PR DESCRIPTION
Rough draft as I can't properly test it at the moment.
This will let people running self-hosted booru to steal ugoiras from the main site.
Root model for api request changed from post to media asset to allow grabbing unposted media. Thus, post is also added as searchable attribute for media asset. Otherwise I have to make an extra request for media_asset to get frame delays.