### PR TITLE
User Feedbacks: add option to hide ban messages from search results

### DIFF
--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -32,6 +32,16 @@ class UserFeedback < ApplicationRecord
     def search(params, current_user)
       q = search_attributes(params, [:id, :created_at, :updated_at, :category, :body, :is_deleted, :creator, :user], current_user: current_user)
 
+      if params[:hide_bans].to_s.truthy?
+        # Feedback generation from bans has changed several times over the years. However they all start like one of the following:
+        # "Blocked: "
+        # "Banned: "
+        # "Banned forever: "
+        # "Banned for <duration>: "
+        # "Banned <duration>: "
+        q = q.where("body ~ '^(?!Banned(:| for| [0-9])|Blocked:)'")
+      end
+
       q.apply_default_order(params)
     end
   end

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -7,6 +7,7 @@
       <%= f.input :creator_name, input_html: { value: params.dig(:search, :creator_name), "data-autocomplete": "user" } %>
       <%= f.input :body_matches, label: "Message", input_html: { value: params.dig(:search, :body_matches) } %>
       <%= f.input :category, collection: %w[positive neutral negative], include_blank: true, selected: params.dig(:search, :category) %>
+      <%= f.input :hide_bans, label: "Hide bans?", collection: %w[No Yes], selected: params.dig(:search, :hide_bans) %>
       <% if policy(UserFeedback).can_view_deleted? %>
         <%= f.input :is_deleted, label: "Deleted", collection: %w[Yes No], include_blank: true, selected: params.dig(:search, :is_deleted) %>
       <% end %>


### PR DESCRIPTION
This has been bugging me for a while. In times of heavy spam or sockpuppeting, the feedback page becomes pretty much unreadable, and there's no easy way to filter bans out of it.

This pull adds a simple dropdown that allows us to remove standard ban messages from the results, with default being no filtering (same as status quo).
![image](https://github.com/user-attachments/assets/e05e1779-84ac-468e-8158-bcd600c7180a)

https://danbooru.donmai.us/user_feedbacks?commit=Search&page=8&search%5Bbody_regex%5D=%5EBanned shows that the only false positives were joke bans made for april fools', so more accurate filtering doesn't seem necessary.