### PR TITLE
Add custom thumb sizes and score to pools and popular/most viewed

### DIFF
--- a/app/components/popup_menu_component.rb
+++ b/app/components/popup_menu_component.rb
@@ -17,4 +17,12 @@ class PopupMenuComponent < ApplicationComponent
     @classes = classes
     @button_classes = button_classes
   end
+
+  def render_votes_toggle(show_votes)
+    if show_votes
+      link_to "Hide scores", url_for(**params.merge(show_votes: nil).except(:z).permit!), class: "post-preview-hide-votes", rel: "nofollow"
+    else
+      link_to "Show scores", url_for(**params.merge(show_votes: true).except(:z).permit!), class: "post-preview-show-votes", rel: "nofollow"
+    end
+  end
 end

--- a/app/controllers/explore/posts_controller.rb
+++ b/app/controllers/explore/posts_controller.rb
@@ -12,12 +12,19 @@ module Explore
       limit = params.fetch(:limit, CurrentUser.user.per_page)
       @posts = popular_posts(@min_date, @max_date).paginate(params[:page], limit: limit, search_count: false)
 
+      @show_votes = (params[:show_votes].presence || cookies[:post_preview_show_votes].presence || "false").truthy?
+      @preview_size = params[:size].presence || cookies[:post_preview_size].presence || PostPreviewComponent::DEFAULT_SIZE
+
       respond_with(@posts)
     end
 
     def viewed
       @date, @scale, @min_date, @max_date = parse_date(params)
       @posts = ReportbooruService.new.popular_posts(@date)
+
+      @show_votes = (params[:show_votes].presence || cookies[:post_preview_show_votes].presence || "false").truthy?
+      @preview_size = params[:size].presence || cookies[:post_preview_size].presence || PostPreviewComponent::DEFAULT_SIZE
+
       respond_with(@posts)
     end
 

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -3,16 +3,6 @@
 class PoolsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @pool = authorize Pool.new(permitted_attributes(Pool))
-    respond_with(@pool)
-  end
-
-  def edit
-    @pool = authorize Pool.find(params[:id])
-    respond_with(@pool)
-  end
-
   def index
     if request.format.html?
       @pools = authorize Pool.paginated_search(params, count_pages: true, defaults: { is_deleted: false })
@@ -23,20 +13,35 @@ class PoolsController < ApplicationController
     respond_with(@pools)
   end
 
-  def gallery
-    limit = params[:limit].presence || CurrentUser.user.per_page
-    search = search_params.presence || ActionController::Parameters.new(category: "series")
-
-    @pools = authorize Pool.search(search, CurrentUser.user).paginate(params[:page], limit: limit, search_count: params[:search])
-    respond_with(@pools)
-  end
-
   def show
     limit = params[:limit].presence || CurrentUser.user.per_page
 
     @pool = authorize Pool.find(params[:id])
     @posts = @pool.posts.paginate(params[:page], limit: limit, count: @pool.post_count)
+
+    @show_votes = (params[:show_votes].presence || cookies[:post_preview_show_votes].presence || "false").truthy?
+    @preview_size = params[:size].presence || cookies[:post_preview_size].presence || PostPreviewComponent::DEFAULT_SIZE
+
     respond_with(@pool)
+  end
+
+  def new
+    @pool = authorize Pool.new(permitted_attributes(Pool))
+    respond_with(@pool)
+  end
+
+  def edit
+    @pool = authorize Pool.find(params[:id])
+    respond_with(@pool)
+  end
+
+  def gallery
+    limit = params[:limit].presence || CurrentUser.user.per_page
+    search = search_params.presence || ActionController::Parameters.new(category: "series")
+
+    @pools = authorize Pool.search(search, CurrentUser.user).paginate(params[:page], limit: limit, search_count: params[:search])
+    @preview_size = params[:size].presence || cookies[:post_preview_size].presence || PostPreviewComponent::DEFAULT_SIZE
+    respond_with(@pools)
   end
 
   def create

--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -43,6 +43,16 @@ Post.initialize_all = function() {
     this.initialize_edit_dialog();
   }
 
+  if ($("#c-explore-posts").length && $("#a-popular, #a-viewed").length) {
+    this.initialize_post_preview_size_menu();
+    this.initialize_post_preview_options_menu();
+  }
+
+  if ($("#c-pools").length && $("#a-show").length) {
+    this.initialize_post_preview_size_menu();
+    this.initialize_post_preview_options_menu();
+  }
+
   this.initialize_ruffle_player();
 
   $(window).on('danbooru:initialize_saved_seraches', () => {

--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -26,7 +26,6 @@ Post.initialize_all = function() {
   if ($("#c-posts").length && $("#a-index").length) {
     this.initialize_excerpt();
     this.initialize_gestures();
-    this.initialize_post_preview_size_menu();
     this.initialize_post_preview_options_menu();
   }
 
@@ -44,12 +43,10 @@ Post.initialize_all = function() {
   }
 
   if ($("#c-explore-posts").length && $("#a-popular, #a-viewed").length) {
-    this.initialize_post_preview_size_menu();
     this.initialize_post_preview_options_menu();
   }
 
   if ($("#c-pools").length && $("#a-show").length) {
-    this.initialize_post_preview_size_menu();
     this.initialize_post_preview_options_menu();
   }
 
@@ -256,19 +253,6 @@ Post.toggle_relationship_preview = function(preview, preview_link) {
     preview_link.html("show &raquo;");
     Cookie.put("show-relationship-previews", "0");
   }
-}
-
-Post.initialize_post_preview_size_menu = function() {
-  $(document).on("click.danbooru", ".post-preview-size-menu .popup-menu-content a", (e) => {
-    let url = new URL($(e.target).get(0).href);
-    let size = url.searchParams.get("size");
-
-    Cookie.put("post_preview_size", size);
-    url.searchParams.delete("size");
-    location.replace(url);
-
-    e.preventDefault();
-  });
 }
 
 Post.initialize_post_preview_options_menu = function() {

--- a/app/views/explore/posts/popular.html.erb
+++ b/app/views/explore/posts/popular.html.erb
@@ -5,12 +5,21 @@
 
 <div id="c-explore-posts">
   <div id="a-popular">
-    <h1>Popular: <%= date_range_description(@date, @scale, @min_date, @max_date) %></h1>
+    <div class="flex mb-4">
+      <h1>Popular: <%= date_range_description(@date, @scale, @min_date, @max_date) %></h1>
+      <span class="flex-grow-1"></span>
+      <%= render PreviewSizeMenuComponent.new(current_size: @preview_size) %>
+      <%= render PopupMenuComponent.new(classes: "post-preview-options-menu") do |menu| %>
+        <% menu.with_item do %>
+          <% menu.render_votes_toggle(@show_votes) %>
+        <% end %>
+      <% end %>
+    </div>
 
     <%= render "explore/posts/nav_links", path: :popular_explore_posts_path, date: @date, scale: @scale %>
     <%= render "posts/partials/common/inline_blacklist" %>
 
-    <%= render_post_gallery(@posts) do |gallery| %>
+    <%= render_post_gallery(@posts, size: @preview_size, show_votes: @show_votes) do |gallery| %>
       <% gallery.with_footer do %>
         <%= numbered_paginator(@posts) %>
       <% end %>

--- a/app/views/explore/posts/viewed.html.erb
+++ b/app/views/explore/posts/viewed.html.erb
@@ -5,11 +5,19 @@
 
 <div id="c-explore-posts">
   <div id="a-viewed">
-    <h1>Most Viewed - <%= @date %></h1>
-
+    <div class="flex mb-4">
+      <h1>Most Viewed - <%= @date %></h1>
+      <span class="flex-grow-1"></span>
+      <%= render PreviewSizeMenuComponent.new(current_size: @preview_size) %>
+      <%= render PopupMenuComponent.new(classes: "post-preview-options-menu") do |menu| %>
+        <% menu.with_item do %>
+          <% menu.render_votes_toggle(@show_votes) %>
+        <% end %>
+      <% end %>
+    </div>
     <%= render "posts/partials/common/inline_blacklist" %>
 
-    <%= render_post_gallery(@posts) %>
+    <%= render_post_gallery(@posts, size: @preview_size, show_votes: @show_votes) %>
 
     <div class="paginator text-center mt-4">
       <menu>

--- a/app/views/pools/gallery.html.erb
+++ b/app/views/pools/gallery.html.erb
@@ -5,13 +5,16 @@
 
 <div id="c-pools">
   <div id="a-gallery">
-    <%= render "search", :path => gallery_pools_path %>
+    <div class="flex mb-4">
+      <%= render "search", :path => gallery_pools_path %>
+      <%= render PreviewSizeMenuComponent.new(current_size: @preview_size) %>
+    </div>
 
     <%= render "posts/partials/common/inline_blacklist" %>
 
-    <%= render(PostGalleryComponent.new) do |gallery| %>
+    <%= render(PostGalleryComponent.new(size: @preview_size)) do |gallery| %>
       <% @pools.each do |pool| %>
-        <% gallery.with_post(post: pool.cover_post, link_target: pool, show_deleted: true) do |preview| %>
+        <% gallery.with_post(post: pool.cover_post, size: @preview_size, link_target: pool, show_deleted: true) do |preview| %>
           <% preview.with_footer do %>
             <div class="text-center">
               <%= link_to pool.pretty_name, pool, class: "text-sm pool-category-#{pool.category}" %>

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -6,21 +6,34 @@
 
 <div id="c-pools">
   <div id="a-show">
-    <h1>
-      <%= @pool.pretty_category %>:
-      <%= link_to @pool.pretty_name, posts_path(:tags => "pool:#{@pool.id}"), :class => "pool-category-#{@pool.category}" %>
-      <% if @pool.is_deleted? %>
-        <span class="inactive">(deleted)</span>
-      <% end %>
-    </h1>
+    <div class="flex mb-4">
+      <div>
+        <h1>
+          <%= @pool.pretty_category %>:
+          <%= link_to @pool.pretty_name, posts_path(:tags => "pool:#{@pool.id}"), :class => "pool-category-#{@pool.category}" %>
+          <% if @pool.is_deleted? %>
+            <span class="inactive">(deleted)</span>
+          <% end %>
 
-    <div id="description" class="prose mb-4">
-      <%= @pool.dtext_description.format_text %>
+        </h1>
+
+        <div id="description" class="prose mb-4">
+          <%= @pool.dtext_description.format_text %>
+        </div>
+      </div>
+
+      <span class="flex-grow-1"></span>
+      <%= render PreviewSizeMenuComponent.new(current_size: @preview_size) %>
+      <%= render PopupMenuComponent.new(classes: "post-preview-options-menu") do |menu| %>
+        <% menu.with_item do %>
+          <% menu.render_votes_toggle(@show_votes) %>
+        <% end %>
+      <% end %>
     </div>
 
     <%= render "posts/partials/common/inline_blacklist" %>
 
-    <%= render_post_gallery(@posts, tags: "pool:#{@pool.id}", show_deleted: @pool.is_series?) do |gallery| %>
+    <%= render_post_gallery(@posts, tags: "pool:#{@pool.id}", show_deleted: @pool.is_series?, size: @preview_size, show_votes: @show_votes) do |gallery| %>
       <% gallery.with_footer do %>
         <%= numbered_paginator(@posts) %>
       <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -87,11 +87,7 @@
 
       <%= render PopupMenuComponent.new(classes: "post-preview-options-menu") do |menu| %>
         <% menu.with_item do %>
-          <% if @post_set.show_votes %>
-            <%= link_to "Hide scores", posts_path(tags: params[:tags], page: params[:page], limit: params[:limit], show_votes: nil, size: params[:size]), class: "post-preview-hide-votes", rel: "nofollow" %>
-          <% else %>
-            <%= link_to "Show scores", posts_path(tags: params[:tags], page: params[:page], limit: params[:limit], show_votes: true, size: params[:size]), class: "post-preview-show-votes", rel: "nofollow" %>
-          <% end %>
+          <% menu.render_votes_toggle(@post_set.show_votes) %>
         <% end %>
       <% end %>
     </li>


### PR DESCRIPTION
Fixes #5853.
On the gallery list of pools, only the thumbnail size is displayed because it would not make much sense to show vote controls for entire pools that would only affect thumbnails. I figured it would've been pretty confusing to most users.

![image](https://github.com/user-attachments/assets/9f833c75-8b3a-40c7-a687-f4e875b333be)
![image](https://github.com/user-attachments/assets/56ef4cd0-98ab-4bee-89dd-79f32a83bb33)

![image](https://github.com/user-attachments/assets/70219483-fabc-4c84-81ce-7ceb6ec0e611)
