### PR TITLE
MediaFile: add animated webp support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ ARG FFMPEG_BUILD_OPTIONS="\
   --disable-filters \
     --enable-filter=scale --enable-filter=thumbnail --enable-filter=silencedetect --enable-filter=ebur128 \
     --enable-filter=aresample --enable-filter=anull --enable-filter=null --enable-filter=copy \
-    --enable-filter=pad --enable-filter=fillborders \
+    --enable-filter=pad --enable-filter=fillborders --enable-filter=untile \
   --disable-encoders \
     --enable-encoder=libvpx_vp8 --enable-encoder=libvpx_vp9 --enable-encoder=libx264 --enable-encoder=libx265 --enable-encoder=libsvtav1 \
     --enable-encoder=png --enable-encoder=null --enable-encoder=wrapped_avframe --enable-encoder=pcm_s16le \

--- a/app/logical/media_file/image.rb
+++ b/app/logical/media_file/image.rb
@@ -5,6 +5,8 @@
 # @see https://github.com/libvips/ruby-vips
 # @see https://libvips.github.io/libvips/API/current
 class MediaFile::Image < MediaFile
+  class Error < StandardError; end
+
   delegate :thumbnail_image, to: :image
 
   def close
@@ -27,8 +29,6 @@ class MediaFile::Image < MediaFile
     case file_ext
     when :avif
       !metadata.is_rotated? && !metadata.is_mirrored? && !metadata.is_cropped? && !metadata.is_grid_image? && !metadata.has_auxiliary_image? && !metadata.is_animated_avif?
-    when :webp
-      !is_animated?
     else
       true
     end
@@ -256,9 +256,27 @@ class MediaFile::Image < MediaFile
     FFmpeg.new(self)
   end
 
+  def animated_webp_preview_frame
+    # https://www.libvips.org/2017/03/16/What's-new-in-8.5.html#toilet-roll-images
+    tr = Danbooru::Tempfile.new(["danbooru-toilet-roll-#{md5}-", ".png"], binmode: true)
+    n = [n_pages, 300].min
+    tr_image = open_image(fail: false, n: n)
+    tr_image.write_to_file(tr.path)
+
+    vp = Danbooru::Tempfile.new(["danbooru-video-preview-#{md5}-", ".png"], binmode: true)
+    ffmpeg_out, status = Open3.capture2e("ffmpeg -i #{tr.path.shellescape} -vf untile=1x#{n},thumbnail=300 -frames:v 1 -y #{vp.path.shellescape}")
+    raise Error, "ffmpeg failed: #{ffmpeg_out}" unless status.success?
+
+    MediaFile.open(vp)
+  ensure
+    tr&.close
+  end
+
   def preview_frame
     @preview_frame ||= begin
-      if is_animated?
+      if is_animated_webp?
+        animated_webp_preview_frame
+      elsif is_animated?
         video.smart_video_preview || self
       else
         self

--- a/app/models/media_asset.rb
+++ b/app/models/media_asset.rb
@@ -501,7 +501,7 @@ class MediaAsset < ApplicationRecord
         variants = []
         variants = %i[180x180 360x360 720x720] unless is_flash?
         variants << :sample if is_ugoira? || (is_static_image? && image_width > LARGE_IMAGE_WIDTH)
-        variants << :full if is_webp? || is_avif?
+        variants << :full if (is_webp? || is_avif?) && !is_animated?
         variants << :original
         variants
       end

--- a/test/unit/media_file/media_file_image_test.rb
+++ b/test/unit/media_file/media_file_image_test.rb
@@ -86,7 +86,7 @@ class MediaFileImageTest < ActiveSupport::TestCase
       assert_equal([150, 105], MediaFile.open("test/files/test-animated-400x281.gif").preview(150, 150).dimensions)
       assert_equal([150, 150], MediaFile.open("test/files/test-animated-256x256.png").preview(150, 150).dimensions)
       assert_equal([150, 150], MediaFile.open("test/files/apng/normal_apng.png").preview(150, 150).dimensions)
-      # assert_equal([150, 150], MediaFile.open("test/files/webp/nyancat.webp").preview(150, 150).dimensions) # XXX not supported by FFmpeg (https://trac.ffmpeg.org/ticket/4907)
+      assert_equal([150, 150], MediaFile.open("test/files/webp/nyancat.webp").preview(150, 150).dimensions)
       assert_equal([150, 113], MediaFile.open("test/files/avif/sequence-with-pitm.avif").preview(150, 150).dimensions)
       assert_equal([150, 84], MediaFile.open("test/files/avif/sequence-without-pitm.avif").preview(150, 150).dimensions)
       assert_equal([150, 150], MediaFile.open("test/files/avif/star-8bpc.avif").preview(150, 150).dimensions)
@@ -349,11 +349,10 @@ class MediaFileImageTest < ActiveSupport::TestCase
       assert_equal(true, MediaFile.open("test/files/webp/nyancat.webp").is_animated?)
       assert_equal(true, MediaFile.open("test/files/webp/nyancat.webp").is_animated_webp?)
       assert_equal(true, MediaFile.open("test/files/webp/nyancat.webp").metadata.is_animated?)
-      assert_equal(false, MediaFile.open("test/files/webp/nyancat.webp").is_supported?)
+      assert_equal(true, MediaFile.open("test/files/webp/nyancat.webp").is_supported?)
       assert_equal(12, MediaFile.open("test/files/webp/nyancat.webp").frame_count)
       assert_equal(Float::INFINITY, MediaFile.open("test/files/webp/nyancat.webp").metadata.loop_count)
-
-      # assert_equal(0.84, MediaFile.open("test/files/webp/nyancat.webp").duration)
+      assert_equal(0.84, MediaFile.open("test/files/webp/nyancat.webp").duration)
     end
 
     should "be able to generate a preview" do


### PR DESCRIPTION
To consider as a work-around over this format being unsupported by ffmpeg (#5619).