### PR TITLE
/static/bookmarklet: fix the bookmarklet to comply with `javascript:` URI standard

### DIFF
--- a/app/views/static/bookmarklet.html.erb
+++ b/app/views/static/bookmarklet.html.erb
@@ -5,7 +5,7 @@
     <h1>Bookmarklet</h1>
 
     <p>
-      <%= link_to "Post to #{Danbooru.config.app_name}", "javascript:location.href='#{request.protocol + request.host_with_port}/uploads/new?url='+encodeURIComponent(location.href)+'&ref='+encodeURIComponent(document.referrer)" %>
+      <%= link_to "Post to #{Danbooru.config.app_name}", "javascript:void(location.href='#{request.protocol + request.host_with_port}/uploads/new?url='+encodeURIComponent(location.href)+'&ref='+encodeURIComponent(document.referrer))" %>
     </p>
 
     <div class="prose">


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/javascript

> If this completion value is a string, that string is treated as an HTML document and the browser navigates to a new document with that content, using the same URL as the current page. 

https://datatracker.ietf.org/doc/html/draft-hoehrmann-javascript-scheme

> In typical implementations, when the user activates the hyperlink, the web browser will pass control to the doSomething() function, and render its result, if any, in place of the current document.