### PR TITLE
Autocomplete: Improve behavior when caret is in the middle of a term

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -60,8 +60,10 @@ Autocomplete.initialize_dtext_autocomplete = function($fields) {
       my: "left bottom"
     },
     source: async function(req, resp) {
-      var cursor = this.element.get(0).selectionStart;
-      let match = req.term.substring(0, cursor).match(/([ \r\n/"\\()[\]{}<>]|^)([@:])(\S*)$/);
+      let caret = this.element.get(0).selectionStart;
+      let term_after_caret = req.term.substring(caret).match(/\S*/)[0];
+      caret += term_after_caret.length;
+      let match = req.term.substring(0, caret).match(/([ \r\n/"\\()[\]{}<>]|^)([@:])(\S*)$/);
 
       let prefix = match?.[1];
       let type = match?.[2];
@@ -99,6 +101,8 @@ Autocomplete.initialize_tag_autocomplete = function() {
 Autocomplete.current_term = function($input) {
   let query = $input.get(0).value;
   let caret = $input.get(0).selectionStart;
+  let term_after_caret = query.substring(caret).match(/\S*/)[0];
+  caret += term_after_caret.length;
   let regexp = new RegExp(`^[-~(]*(${Autocomplete.tag_prefixes().join("|")})?`);
   let match = query.substring(0, caret).match(/\S*$/)[0].replace(regexp, "").toLowerCase();
   return match;
@@ -107,9 +111,13 @@ Autocomplete.current_term = function($input) {
 // Update the input field with the item currently focused in the
 // autocomplete menu, then position the caret just after the inserted completion.
 Autocomplete.insert_completion = function(input, completion) {
+  let caret = input.selectionStart;
+  let term_after_caret = input.value.substring(caret).match(/\S*/)[0];
+  caret += term_after_caret.length;
+
   // Trim all whitespace (tabs, spaces) except for line returns
-  var before_caret_text = input.value.substring(0, input.selectionStart).replace(/^[ \t]+|[ \t]+$/gm, "");
-  var after_caret_text = input.value.substring(input.selectionStart).replace(/^[ \t]+|[ \t]+$/gm, "");
+  var before_caret_text = input.value.substring(0, caret).replace(/^[ \t]+|[ \t]+$/gm, "");
+  var after_caret_text = input.value.substring(caret).replace(/^[ \t]+|[ \t]+$/gm, "");
 
   var regexp = new RegExp(`([-~(]*(?:${Autocomplete.tag_prefixes().join("|")})?)\\S+$`, "g");
   before_caret_text = before_caret_text.replace(regexp, "$1") + completion + " ";


### PR DESCRIPTION
Sometimes people make typos when writing tags. If you're trying to write `brown_eyes` you may write `brow_e` and only then notice your mistake:
![image](https://github.com/user-attachments/assets/2241f022-7744-4095-9bf1-292bddad2218)
So you move your caret back and fix the typo:
![image](https://github.com/user-attachments/assets/386a0c32-9c69-4b1a-8be1-87debc39e639)
But now autocomplete doesn't see the `_e` part that comes after your cursor, so it's putting `brown_hair` above `brown_eyes` in the suggestions.
So you press down a couple times and manually select the second result instead, and then press tab so it completes `brown_eyes`:
![image](https://github.com/user-attachments/assets/73ee75d2-8fa7-4ed4-b184-9a1d0de865d6)
Now there's some junk at the end that will mess up your search, since `_e` is not a real tag. So you have to manually delete that before hitting enter.

This pull request makes a simple change to autocomplete so that it pretends the cursor is at the end of the current term rather than being in the middle. This way, it sees `brown|_e` correctly suggests `brown_eyes` at the top instead of `brown_hair`, and hitting tab won't leave the `_e` in there:
![image](https://github.com/user-attachments/assets/98fafbc0-9d63-4073-9f10-a2eaf93668ca)
I also made the same change for dtext autocomplete.
(Related tags already have similar logic to find the end of the current term, so that didn't need changing.)

Note: From what I've seen, this behavior is consistent with a lot of other programs that have autocomplete, such as Firefox's native autocomplete which is used when not overridden.