### PR TITLE
Autocomplete: Insert extra space after caret when completing between two terms

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -121,6 +121,9 @@ Autocomplete.insert_completion = function(input, completion) {
 
   var regexp = new RegExp(`([-~(]*(?:${Autocomplete.tag_prefixes().join("|")})?)\\S+$`, "g");
   before_caret_text = before_caret_text.replace(regexp, "$1") + completion + " ";
+  if (after_caret_text.length > 0) {
+    after_caret_text = " " + after_caret_text;
+  }
 
   input.value = before_caret_text + after_caret_text;
   input.selectionStart = input.selectionEnd = before_caret_text.length;


### PR DESCRIPTION
Currently, if you're modifying a term that is not the last one in the text field:
![image](https://github.com/user-attachments/assets/24f1ebf6-ad4e-483b-8d1e-8c441adaa318)
And you press tab to insert a completion:
![image](https://github.com/user-attachments/assets/f927d021-6b6c-4511-aad7-00639c8fcb3f)
It will insert one space after the term, then your caret, then the next term immediately after your caret.

The issue with this is that, with the change from #5954, autocomplete now can't see a difference between a new term you start typing and the next term that comes immediately after that, as they are only separated by your caret and no space:
![image](https://github.com/user-attachments/assets/729695cc-4f08-4149-ad22-22d4f42076cb)

This pull request makes a change so that in addition to the space after the previous completed term, another space will be added after your caret (but only if there's another term after it):
![image](https://github.com/user-attachments/assets/dc24258a-4df6-44c1-92ee-6a6b833c55c2)
This allows autocomplete to work in this scenario without having to manually add a second space or move your caret to the end:
![image](https://github.com/user-attachments/assets/d4fdb395-5721-4f33-a120-97d1c3e2397b)
