### PR TITLE
Bulk Update Requests: display better errors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -300,17 +300,17 @@ module ApplicationHelper
     end
   end
 
-  def edit_form_for(model, validate: false, error_notice: true, warning_notice: true, **options, &block)
+  def edit_form_for(model, validate: false, error_notice: true, warning_notice: true, error_separator: "; ", **options, &block)
     options[:html] = { autocomplete: "off", novalidate: !validate, **options[:html].to_h }
     options[:authenticity_token] = true if options[:remote] == true
 
     simple_form_for(model, **options) do |form|
       if error_notice && model.try(:errors).try(:any?)
-        concat tag.div(format_text(model.errors.full_messages.join("; ")), class: "notice notice-error notice-small prose")
+        concat tag.div(format_text(model.errors.full_messages.join(error_separator)), class: "notice notice-error notice-small prose")
       end
 
       if warning_notice && model.try(:warnings).try(:any?)
-        concat tag.div(format_text(model.warnings.full_messages.join("; ")), class: "notice notice-info notice-small prose")
+        concat tag.div(format_text(model.warnings.full_messages.join(error_separator)), class: "notice notice-info notice-small prose")
       end
 
       block.call(form)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -300,21 +300,29 @@ module ApplicationHelper
     end
   end
 
-  def edit_form_for(model, validate: false, error_notice: true, warning_notice: true, error_separator: "; ", **options, &block)
+  def edit_form_for(model, validate: false, error_notice: true, warning_notice: true, formatted_errors: false, **options, &block)
     options[:html] = { autocomplete: "off", novalidate: !validate, **options[:html].to_h }
     options[:authenticity_token] = true if options[:remote] == true
 
     simple_form_for(model, **options) do |form|
       if error_notice && model.try(:errors).try(:any?)
-        concat tag.div(format_text(model.errors.full_messages.join(error_separator)), class: "notice notice-error notice-small prose")
+        error_msg = formatted_errors ? format_errors(model.errors) : model.errors.full_messages.join("; ")
+        concat tag.div(format_text(error_msg), class: "notice notice-error notice-small prose")
       end
 
       if warning_notice && model.try(:warnings).try(:any?)
-        concat tag.div(format_text(model.warnings.full_messages.join(error_separator)), class: "notice notice-info notice-small prose")
+        warning_msg = formatted_errors ? format_errors(model.warnings) : model.warnings.full_messages.join("; ")
+        concat tag.div(format_text(warning_msg), class: "notice notice-info notice-small prose")
       end
 
       block.call(form)
     end
+  end
+
+  def format_errors(errors)
+    messages = errors.full_messages
+    messages = messages.map {|e| "* #{e}"} if messages.count > 1
+    messages.join("\n")
   end
 
   def table_for(...)

--- a/app/logical/bulk_update_request_processor.rb
+++ b/app/logical/bulk_update_request_processor.rb
@@ -73,14 +73,14 @@ class BulkUpdateRequestProcessor
           tag_alias = TagAlias.new(creator: User.system, antecedent_name: args[0], consequent_name: args[1])
           tag_alias.save(context: validation_context)
           if tag_alias.errors.present?
-            errors.add(:base, "Can't create alias #{tag_alias.antecedent_name} -> #{tag_alias.consequent_name} (#{tag_alias.errors.full_messages.join("; ")})")
+            errors.add(:base, "Can't create alias [[#{tag_alias.antecedent_name}]] -> [[#{tag_alias.consequent_name}]] (#{tag_alias.errors.full_messages.join("; ")})")
           end
 
         when :create_implication
           tag_implication = TagImplication.new(creator: User.system, antecedent_name: args[0], consequent_name: args[1], status: "active")
           tag_implication.save(context: validation_context)
           if tag_implication.errors.present?
-            errors.add(:base, "Can't create implication #{tag_implication.antecedent_name} -> #{tag_implication.consequent_name} (#{tag_implication.errors.full_messages.join("; ")})")
+            errors.add(:base, "Can't create implication [[#{tag_implication.antecedent_name}]] -> [[#{tag_implication.consequent_name}]] (#{tag_implication.errors.full_messages.join("; ")})")
           end
 
         when :remove_alias
@@ -89,7 +89,7 @@ class BulkUpdateRequestProcessor
           if validation_context == :approval
             # ignore non-existing aliases when approving a BUR
           elsif tag_alias.nil?
-            errors.add(:base, "Can't remove alias #{args[0]} -> #{args[1]} (alias doesn't exist)")
+            errors.add(:base, "Can't remove alias [[#{args[0]}]] -> [[#{args[1]}]] (alias doesn't exist)")
           else
             tag_alias.update(status: "deleted")
           end
@@ -99,7 +99,7 @@ class BulkUpdateRequestProcessor
 
           if tag_implication.nil?
             # ignore non-existing implication when approving a BUR
-            errors.add(:base, "Can't remove implication #{args[0]} -> #{args[1]} (implication doesn't exist)") unless validation_context == :approval
+            errors.add(:base, "Can't remove implication [[#{args[0]}]] -> [[#{args[1]}]] (implication doesn't exist)") unless validation_context == :approval
           else
             tag_implication.update(status: "deleted")
           end
@@ -107,7 +107,7 @@ class BulkUpdateRequestProcessor
         when :change_category
           tag = Tag.find_by_name(args[0])
           if tag.nil?
-            errors.add(:base, "Can't change category #{args[0]} -> #{args[1]} (the '#{args[0]}' tag doesn't exist)")
+            errors.add(:base, "Can't change category [[#{args[0]}]] -> [[#{args[1]}]] ([[#{args[0]}]] doesn't exist)")
           end
 
         when :rename
@@ -115,18 +115,18 @@ class BulkUpdateRequestProcessor
           new_tag = Tag.find_by_name(args[1]) || Tag.new(name: args[1])
 
           if old_tag.nil?
-            errors.add(:base, "Can't rename #{args[0]} -> #{args[1]} (the '#{args[0]}' tag doesn't exist)")
+            errors.add(:base, "Can't rename [[#{args[0]}]] -> [[#{args[1]}]] ([[#{args[0]}]] doesn't exist)")
           elsif old_tag.post_count > MAXIMUM_RENAME_COUNT
-            errors.add(:base, "Can't rename #{args[0]} -> #{args[1]} ('#{args[0]}' has more than #{MAXIMUM_RENAME_COUNT} posts, use an alias instead)")
+            errors.add(:base, "Can't rename [[#{args[0]}]] -> [[#{args[1]}]] ([[#{args[0]}]] has more than #{MAXIMUM_RENAME_COUNT} posts, use an alias instead)")
           elsif new_tag.invalid?(:name)
-            errors.add(:base, "Can't rename #{args[0]} -> #{args[1]} (#{new_tag.errors.full_messages.join("; ")})")
+            errors.add(:base, "Can't rename [[#{args[0]}]] -> [[#{args[1]}]] (#{new_tag.errors.full_messages.join("; ")})")
           end
 
         when :mass_update
           query = PostQuery.new(args[0])
 
           if query.is_null_search?
-            errors.add(:base, "Can't mass update #{args[0]} -> #{args[1]} (the search `#{args[0]}` has a syntax error)")
+            errors.add(:base, "Can't mass update {{#{args[0]}}} -> {{#{args[1]}}} (the search {{#{args[0]}}} has a syntax error)")
           end
 
         when :nuke
@@ -138,11 +138,11 @@ class BulkUpdateRequestProcessor
           if validation_context == :approval
             # ignore already deprecated tags and missing wikis when approving a tag deprecation.
           elsif tag.nil?
-            errors.add(:base, "Can't deprecate #{args[0]} (tag doesn't exist)")
+            errors.add(:base, "Can't deprecate [[#{args[0]}]] (tag doesn't exist)")
           elsif tag.is_deprecated?
-            errors.add(:base, "Can't deprecate #{args[0]} (tag is already deprecated)")
+            errors.add(:base, "Can't deprecate [[#{args[0]}]] (tag is already deprecated)")
           elsif tag.wiki_page.blank?
-            errors.add(:base, "Can't deprecate #{args[0]} (tag must have a wiki page)")
+            errors.add(:base, "Can't deprecate [[#{args[0]}]] (tag must have a wiki page)")
           end
 
         when :undeprecate
@@ -151,9 +151,9 @@ class BulkUpdateRequestProcessor
           if validation_context == :approval
             # ignore already deprecated tags and missing wikis when removing a tag deprecation.
           elsif tag.nil?
-            errors.add(:base, "Can't undeprecate #{args[0]} (tag doesn't exist)")
+            errors.add(:base, "Can't undeprecate [[#{args[0]}]] (tag doesn't exist)")
           elsif !tag.is_deprecated?
-            errors.add(:base, "Can't undeprecate #{args[0]} (tag is not deprecated)")
+            errors.add(:base, "Can't undeprecate [[#{args[0]}]] (tag is not deprecated)")
           end
 
         when :invalid_line

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -93,7 +93,7 @@ class BulkUpdateRequest < ApplicationRecord
 
   def validate_script
     if processor.invalid?(:request)
-      errors.add(:base, processor.errors.full_messages.join("; "))
+      processor.errors.full_messages.each { |error| errors.add(:base, error) }
     end
   end
 

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -121,24 +121,24 @@ class TagImplication < TagRelationship
       return if antecedent_tag.empty? || consequent_tag.empty?
 
       if antecedent_tag.post_count < MINIMUM_TAG_COUNT
-        errors.add(:base, "'#{antecedent_name}' must have at least #{MINIMUM_TAG_COUNT} posts")
+        errors.add(:base, "[[#{antecedent_name}]] must have at least #{MINIMUM_TAG_COUNT} posts")
       elsif antecedent_tag.post_count < (MINIMUM_TAG_PERCENTAGE * consequent_tag.post_count)
-        errors.add(:base, "'#{antecedent_name}' must have at least #{(MINIMUM_TAG_PERCENTAGE * consequent_tag.post_count).ceil.to_i} posts")
+        errors.add(:base, "[[#{antecedent_name}]] must have at least #{(MINIMUM_TAG_PERCENTAGE * consequent_tag.post_count).ceil.to_i} posts")
       end
 
       max_count = MAXIMUM_TAG_PERCENTAGE * PostQuery.new("~#{antecedent_name} ~#{consequent_name}").fast_count(timeout: 0).to_i
       if antecedent_tag.post_count > max_count && max_count > 0
-        errors.add(:base, "'#{antecedent_name}' can't make up more than #{(MAXIMUM_TAG_PERCENTAGE * 100).to_i}% of '#{consequent_name}'")
+        errors.add(:base, "[[#{antecedent_name}]] can't make up more than #{(MAXIMUM_TAG_PERCENTAGE * 100).to_i}% of [[#{consequent_name}]]")
       end
     end
 
     def has_wiki_page
       if !antecedent_tag.empty? && antecedent_wiki.blank?
-        errors.add(:base, "'#{antecedent_name}' must have a wiki page")
+        errors.add(:base, "[[#{antecedent_name}]] must have a wiki page")
       end
 
       if !consequent_tag.empty? && consequent_wiki.blank?
-        errors.add(:base, "'#{consequent_name}' must have a wiki page")
+        errors.add(:base, "[[#{consequent_name}]] must have a wiki page")
       end
     end
   end

--- a/app/views/bulk_update_requests/_form.html.erb
+++ b/app/views/bulk_update_requests/_form.html.erb
@@ -1,4 +1,4 @@
-<%= edit_form_for(@bulk_update_request) do |f| %>
+<%= edit_form_for(@bulk_update_request, error_separator: "\n ") do |f| %>
   <div class="prose">
     <details>
       <summary>Help: How to make a bulk update request</summary>

--- a/app/views/bulk_update_requests/_form.html.erb
+++ b/app/views/bulk_update_requests/_form.html.erb
@@ -1,4 +1,4 @@
-<%= edit_form_for(@bulk_update_request, error_separator: "\n ") do |f| %>
+<%= edit_form_for(@bulk_update_request, formatted_errors: true) do |f| %>
   <div class="prose">
     <details>
       <summary>Help: How to make a bulk update request</summary>

--- a/test/unit/bulk_update_request_test.rb
+++ b/test/unit/bulk_update_request_test.rb
@@ -57,7 +57,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "category hello -> artist")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't change category hello -> artist (the 'hello' tag doesn't exist)"], @bur.errors[:base])
+          assert_equal(["Can't change category [[hello]] -> [[artist]] ([[hello]] doesn't exist)"], @bur.errors[:base])
         end
       end
 
@@ -165,28 +165,28 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "create alias aaa -> bbb")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create alias aaa -> bbb (bbb is already aliased to ccc)"], @bur.errors.full_messages)
+          assert_equal(["Can't create alias [[aaa]] -> [[bbb]] (bbb is already aliased to ccc)"], @bur.errors.full_messages)
         end
 
         should "fail if the antecedent name is invalid" do
           @bur = build(:bulk_update_request, script: "create alias tag_ -> tag")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create alias tag_ -> tag ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
+          assert_equal(["Can't create alias [[tag_]] -> [[tag]] ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
         end
 
         should "fail if the consequent name is invalid" do
           @bur = build(:bulk_update_request, script: "create alias tag -> tag_")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create alias tag -> tag_ ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
+          assert_equal(["Can't create alias [[tag]] -> [[tag_]] ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
         end
 
         should "fail if the consequent name contains a tag type prefix" do
           @bur = build(:bulk_update_request, script: "alias blah -> char:bar")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create alias blah -> char:bar ('char:bar' cannot begin with 'char:')"], @bur.errors.full_messages)
+          assert_equal(["Can't create alias [[blah]] -> [[char:bar]] ('char:bar' cannot begin with 'char:')"], @bur.errors.full_messages)
         end
 
         should "be case-insensitive" do
@@ -214,7 +214,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "imply a -> c")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication a -> c (a already implies c through another implication)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[a]] -> [[c]] (a already implies c through another implication)"], @bur.errors.full_messages)
         end
 
         should "fail for an implication that is a duplicate of an existing implication" do
@@ -222,7 +222,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "imply a -> b")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication a -> b (Implication already exists)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[a]] -> [[b]] (Implication already exists)"], @bur.errors.full_messages)
         end
 
         should "fail for an implication that is redundant with another implication in the same BUR" do
@@ -230,7 +230,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "imply a -> b\nimply a -> c")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication a -> c (a already implies c through another implication)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[a]] -> [[c]] (a already implies c through another implication)"], @bur.errors.full_messages)
         end
 
         should "fail for an implication between tags of different categories" do
@@ -242,7 +242,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "imply hatsune_miku -> vocaloid")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication hatsune_miku -> vocaloid (Can't imply a character tag to a copyright tag)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[hatsune_miku]] -> [[vocaloid]] (Can't imply a character tag to a copyright tag)"], @bur.errors.full_messages)
         end
 
         should "fail for a child tag that is too small" do
@@ -253,11 +253,11 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "imply white_shirt -> shirt")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication white_shirt -> shirt ('white_shirt' must have at least 10 posts)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[white_shirt]] -> [[shirt]] ([[white_shirt]] must have at least 10 posts)"], @bur.errors.full_messages)
 
           @t1.update!(post_count: 99)
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication white_shirt -> shirt ('white_shirt' must have at least 100 posts)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[white_shirt]] -> [[shirt]] ([[white_shirt]] must have at least 100 posts)"], @bur.errors.full_messages)
         end
 
         should "display the correct amount of required posts" do
@@ -270,21 +270,21 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "imply speech_bubble_censor -> speech_bubble")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication speech_bubble_censor -> speech_bubble ('speech_bubble_censor' must have at least 21 posts)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[speech_bubble_censor]] -> [[speech_bubble]] ([[speech_bubble_censor]] must have at least 21 posts)"], @bur.errors.full_messages)
         end
 
         should "fail if the antecedent name is invalid" do
           @bur = build(:bulk_update_request, script: "imply tag_ -> tag")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication tag_ -> tag ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[tag_]] -> [[tag]] ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
         end
 
         should "fail if the consequent name is invalid" do
           @bur = build(:bulk_update_request, script: "imply tag -> tag_")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication tag -> tag_ ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[tag]] -> [[tag_]] ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
         end
       end
 
@@ -304,14 +304,14 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "remove alias foo -> bar")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't remove alias foo -> bar (alias doesn't exist)"], @bur.errors[:base])
+          assert_equal(["Can't remove alias [[foo]] -> [[bar]] (alias doesn't exist)"], @bur.errors[:base])
         end
 
         should "fail to validate if the alias doesn't already exist" do
           @bur = build(:bulk_update_request, script: "remove alias foo -> bar")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't remove alias foo -> bar (alias doesn't exist)"], @bur.errors[:base])
+          assert_equal(["Can't remove alias [[foo]] -> [[bar]] (alias doesn't exist)"], @bur.errors[:base])
         end
 
         should "allow reapproving a failed BUR when the alias has already been removed" do
@@ -352,14 +352,14 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "remove implication foo -> bar")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't remove implication foo -> bar (implication doesn't exist)"], @bur.errors[:base])
+          assert_equal(["Can't remove implication [[foo]] -> [[bar]] (implication doesn't exist)"], @bur.errors[:base])
         end
 
         should "fail to validate if the implication doesn't already exist" do
           @bur = build(:bulk_update_request, script: "remove implication foo -> bar")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't remove implication foo -> bar (implication doesn't exist)"], @bur.errors[:base])
+          assert_equal(["Can't remove implication [[foo]] -> [[bar]] (implication doesn't exist)"], @bur.errors[:base])
         end
 
         should "allow reapproving a failed BUR when the implication has already been removed" do
@@ -431,7 +431,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "mass update (foo -> bar")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't mass update (foo -> bar (the search `(foo` has a syntax error)"], @bur.errors.full_messages)
+          assert_equal(["Can't mass update {{(foo}} -> {{bar}} (the search {{(foo}} has a syntax error)"], @bur.errors.full_messages)
         end
       end
 
@@ -459,7 +459,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "rename aaa -> bbb")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't rename aaa -> bbb (the 'aaa' tag doesn't exist)"], @bur.errors.full_messages)
+          assert_equal(["Can't rename [[aaa]] -> [[bbb]] ([[aaa]] doesn't exist)"], @bur.errors.full_messages)
         end
 
         should "fail if the old tag has more than 200 posts" do
@@ -467,7 +467,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "rename aaa -> bbb")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't rename aaa -> bbb ('aaa' has more than 200 posts, use an alias instead)"], @bur.errors.full_messages)
+          assert_equal(["Can't rename [[aaa]] -> [[bbb]] ([[aaa]] has more than 200 posts, use an alias instead)"], @bur.errors.full_messages)
         end
 
         should "fail if the consequent name is invalid" do
@@ -475,7 +475,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "rename tag -> tag_")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't rename tag -> tag_ ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
+          assert_equal(["Can't rename [[tag]] -> [[tag_]] ('tag_' cannot end with an underscore)"], @bur.errors.full_messages)
         end
 
         context "when moving an artist" do
@@ -620,7 +620,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "imply a -> b")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't create implication a -> b ('a' must have a wiki page; 'b' must have a wiki page)"], @bur.errors.full_messages)
+          assert_equal(["Can't create implication [[a]] -> [[b]] ([[a]] must have a wiki page; [[b]] must have a wiki page)"], @bur.errors.full_messages)
         end
       end
 
@@ -684,7 +684,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
         @bur = build(:bulk_update_request, script: "deprecate no_wiki")
 
         assert_equal(false, @bur.valid?)
-        assert_equal(["Can't deprecate no_wiki (tag must have a wiki page)"], @bur.errors[:base])
+        assert_equal(["Can't deprecate [[no_wiki]] (tag must have a wiki page)"], @bur.errors[:base])
       end
     end
 


### PR DESCRIPTION
This basically just adds `[[]]` and `{{}}` around each tag name in BUR/implication errors, so that they are automatically styled by the site. 

The errors then become like this:
![image](https://github.com/user-attachments/assets/076e9fd7-21cf-4fc7-a2f6-cb43a1b117c9)

Which makes it infinitely easier to parse the error message, especially in the case of large BURs.

Compare with the status quo:

![image](https://github.com/user-attachments/assets/d85dfb55-bdda-4109-86a8-e42bbc385011)


This partially mitigates the problems in issue #5492.