### PR TITLE
fanbox: ensure extractor works for direct urls when api is not available

### DIFF
--- a/app/logical/source/extractor/fanbox.rb
+++ b/app/logical/source/extractor/fanbox.rb
@@ -36,6 +36,8 @@ module Source
       def page_url
         if username.present? && illust_id.present?
           "https://#{username}.fanbox.cc/posts/#{illust_id}"
+        elsif illust_id.present?
+          "https://www.fanbox.cc/manage/posts/#{illust_id}"
         elsif parsed_url.image_url? && username.present?
           # Cover images
           "https://#{username}.fanbox.cc"

--- a/app/logical/source/extractor/fanbox.rb
+++ b/app/logical/source/extractor/fanbox.rb
@@ -5,8 +5,10 @@ module Source
   class Extractor
     class Fanbox < Source::Extractor
       def image_urls
-        if parsed_url.image_url?
+        if parsed_url.full_image_url.present?
           [parsed_url.full_image_url]
+        elsif parsed_url.candidate_full_image_urls.present?
+          [parsed_url.candidate_full_image_urls.find { |url| http_exists?(url) } || url.to_s]
         elsif api_response.present?
           file_list
         else

--- a/app/logical/source/url/fanbox.rb
+++ b/app/logical/source/url/fanbox.rb
@@ -81,11 +81,18 @@ class Source::URL::Fanbox < Source::URL
   end
 
   def full_image_url
-    # https://downloads.fanbox.cc/images/post/39714/w/1200/JvjJal8v1yLgc5DPyEI05YpT.jpeg (full: https://downloads.fanbox.cc/images/post/39714/JvjJal8v1yLgc5DPyEI05YpT.png)
+    # https://downloads.fanbox.cc/images/post/39714/JvjJal8v1yLgc5DPyEI05YpT.png
+    return to_s if image_url? && !to_s.match?(%r{/[cw]/\w+/})
+  end
+
+  def candidate_full_image_urls
+    # https://downloads.fanbox.cc/images/post/39714/w/1200/JvjJal8v1yLgc5DPyEI05YpT.jpeg
     # https://downloads.fanbox.cc/images/post/39714/c/1200x630/JvjJal8v1yLgc5DPyEI05YpT.jpeg
     # https://pixiv.pximg.net/c/936x600_90_a2_g5/fanbox/public/images/plan/4635/cover/L6AZNneFuHW6r25CHHlkpHg4.jpeg
     # https://pixiv.pximg.net/c/400x400_90_a2_g5/fanbox/public/images/creator/1566167/profile/BtxSp9MImFhnEZtjEZs2RPqL.jpeg
-    to_s.gsub(%r{/[cw]/\w+/}, "/") if image_url?
+    return [] unless image_url?
+    candidate_url = to_s.gsub(%r{/[cw]/\w+/}, "/")
+    %w[jpg jpeg png gif].map { |ext| candidate_url.sub(/(\.\w+)\z/, ".#{ext}") }
   end
 
   def page_url


### PR DESCRIPTION
At the moment post info api is being blocked by cloudflare.

Direct image url can be converted to https://www.fanbox.cc/manage/posts/XXXXX url. I deliberately add it only to extractor, not url parser, as otherwise proper post URLs with artist username are more preferable. There is still a way to improve it, as it actually 302s to one.

`full_image_url` at url parser did not account for different file extensions.