### PR TITLE
Add sqs mock for local development

### DIFF
--- a/db/migrate/20250601164355_align_pool_versions_to_prod.rb
+++ b/db/migrate/20250601164355_align_pool_versions_to_prod.rb
@@ -1,0 +1,40 @@
+class AlignPoolVersionsToProd < ActiveRecord::Migration[7.1]
+  def up
+    change_column :pool_versions, :id, :integer
+    change_column_null :pool_versions, :created_at, true
+    change_column_null :pool_versions, :updated_at, true
+    change_column :pool_versions, :pool_id, :integer
+    change_column :pool_versions, :updater_id, :integer, null: true
+
+    change_column_null :pool_versions, :name, true
+    change_column_default :pool_versions, :name, from: '', to: nil
+
+    change_column_null :pool_versions, :description, true
+    change_column_default :pool_versions, :description, from: '', to: nil
+
+    change_column_null :pool_versions, :category, true
+    change_column_default :pool_versions, :category, from: '', to: nil
+
+    add_column :pool_versions, :boolean, :boolean, default: false, null: false
+
+  end
+
+  def down
+    change_column :pool_versions, :id, :bigint
+    change_column_null :pool_versions, :created_at, false
+    change_column_null :pool_versions, :updated_at, false
+    change_column :pool_versions, :pool_id, :bigint
+    change_column :pool_versions, :updater_id, :bigint, null: false
+
+    change_column_null :pool_versions, :name, false
+    change_column_default :pool_versions, :name, from: nil, to: ''
+
+    change_column_null :pool_versions, :description, false
+    change_column_default :pool_versions, :description, from: nil, to: ''
+
+    change_column_null :pool_versions, :category, false
+    change_column_default :pool_versions, :category, from: nil, to: ''
+
+    remove_column :pool_versions, :boolean
+  end
+end

--- a/db/migrate/20250601164357_align_post_versions_to_prod.rb
+++ b/db/migrate/20250601164357_align_post_versions_to_prod.rb
@@ -1,0 +1,39 @@
+class AlignPostVersionsToProd < ActiveRecord::Migration[7.1]
+  def up
+    change_column :post_versions, :id, :integer
+
+    remove_column :post_versions, :created_at
+
+    change_column :post_versions, :updated_at, :timestamp, null: false
+    change_column :post_versions, :post_id, :integer
+    change_column :post_versions, :updater_id, :integer, null: true
+
+    change_column_null :post_versions, :rating, true
+    change_column_default :post_versions, :rating, from: '', to: nil
+
+    change_column_null :post_versions, :source, true
+    change_column_default :post_versions, :source, from: '', to: nil
+
+    change_column_null :post_versions, :tags, false
+    change_column_default :post_versions, :tags, from: '', to: nil
+  end
+
+  def down
+    change_column :post_versions, :id, :bigint
+
+    add_column :post_versions, :created_at, :timestamp, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+
+    change_column :post_versions, :updated_at, :timestamp, null: false
+    change_column :post_versions, :post_id, :bigint
+    change_column :post_versions, :updater_id, :bigint, null: false
+
+    change_column_null :post_versions, :rating, false
+    change_column_default :post_versions, :rating, from: nil, to: ''
+
+    change_column_null :post_versions, :source, false
+    change_column_default :post_versions, :source, from: nil, to: ''
+
+    change_column_null :post_versions, :tags, false
+    change_column_default :post_versions, :tags, from: nil, to: ''
+  end
+end

--- a/db/migrate/20250601164359_add_missing_post_versions_index.rb
+++ b/db/migrate/20250601164359_add_missing_post_versions_index.rb
@@ -1,0 +1,9 @@
+class AddMissingPostVersionsIndex < ActiveRecord::Migration[7.1]
+  def up
+    add_index :post_versions, [:updater_id, :id], name: "index_post_versons_on_updater_id_and_id"
+  end
+
+  def down
+    remove_index :post_versions, name: "index_post_versons_on_updater_id_and_id"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1266,22 +1266,23 @@ ALTER SEQUENCE public.notes_id_seq OWNED BY public.notes.id;
 --
 
 CREATE TABLE public.pool_versions (
-    id bigint NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    pool_id bigint NOT NULL,
-    updater_id bigint NOT NULL,
+    id integer NOT NULL,
+    created_at timestamp(6) without time zone,
+    updated_at timestamp(6) without time zone,
+    pool_id integer NOT NULL,
+    updater_id integer,
     version integer DEFAULT 1 NOT NULL,
-    name text NOT NULL,
-    description text DEFAULT ''::text NOT NULL,
-    category character varying NOT NULL,
+    name text,
+    description text,
+    category character varying,
     is_active boolean DEFAULT true NOT NULL,
     is_deleted boolean DEFAULT false NOT NULL,
     description_changed boolean DEFAULT false NOT NULL,
     name_changed boolean DEFAULT false NOT NULL,
     post_ids integer[] DEFAULT '{}'::integer[] NOT NULL,
     added_post_ids integer[] DEFAULT '{}'::integer[] NOT NULL,
-    removed_post_ids integer[] DEFAULT '{}'::integer[] NOT NULL
+    removed_post_ids integer[] DEFAULT '{}'::integer[] NOT NULL,
+    "boolean" boolean DEFAULT false NOT NULL
 );
 
 
@@ -1632,19 +1633,18 @@ ALTER SEQUENCE public.post_replacements_id_seq OWNED BY public.post_replacements
 --
 
 CREATE TABLE public.post_versions (
-    id bigint NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    post_id bigint NOT NULL,
-    updater_id bigint NOT NULL,
+    id integer NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    post_id integer NOT NULL,
+    updater_id integer,
     version integer DEFAULT 1 NOT NULL,
     parent_changed boolean DEFAULT false NOT NULL,
     rating_changed boolean DEFAULT false NOT NULL,
     source_changed boolean DEFAULT false NOT NULL,
     parent_id integer,
-    rating character varying(1) NOT NULL,
-    source text DEFAULT ''::text NOT NULL,
-    tags text DEFAULT ''::text NOT NULL,
+    rating character varying(1),
+    source text,
+    tags text NOT NULL,
     added_tags text[] DEFAULT '{}'::text[] NOT NULL,
     removed_tags text[] DEFAULT '{}'::text[] NOT NULL
 );
@@ -5215,13 +5215,6 @@ CREATE INDEX index_post_versions_on_added_tags ON public.post_versions USING btr
 
 
 --
--- Name: index_post_versions_on_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_post_versions_on_created_at ON public.post_versions USING btree (created_at);
-
-
---
 -- Name: index_post_versions_on_parent_changed; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5275,6 +5268,13 @@ CREATE INDEX index_post_versions_on_updater_id ON public.post_versions USING btr
 --
 
 CREATE INDEX index_post_versions_on_version ON public.post_versions USING btree (version);
+
+
+--
+-- Name: index_post_versons_on_updater_id_and_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_versons_on_updater_id_and_id ON public.post_versions USING btree (updater_id, id);
 
 
 --
@@ -6978,6 +6978,9 @@ ALTER TABLE ONLY public.user_upgrades
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250601164359'),
+('20250601164357'),
+('20250601164355'),
 ('20250530193107'),
 ('20250530193106'),
 ('20250530091115'),

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -23,6 +23,14 @@
 
 name: devbooru
 
+x-sqs-env: &sqs-env
+  # Required to have working post and pool versions
+  DANBOORU_AWS_SQS_REGION: us-east-1
+  DANBOORU_AWS_ACCESS_KEY_ID: dummy
+  DANBOORU_AWS_SECRET_ACCESS_KEY: dummy
+  DANBOORU_AWS_SQS_ARCHIVES_URL: http://sqs:9324/000000000000/danbooru.fifo
+  DANBOORU_AWS_SQS_HOST: http://sqs:9324
+
 x-base-template: &base-template
   # Use the latest development image from master, instead of the production image. The development
   # image contains files needed to rebuild the JS/CSS files.
@@ -38,6 +46,8 @@ x-base-template: &base-template
   entrypoint: ["tini", "-g", "bin/danbooru-dev-entrypoint", "--"]
 
   environment:
+    <<: *sqs-env
+
     DANBOORU_APP_NAME: "Devbooru"
 
     # The public URL of your site. You can set this if you have a domain name for your site.
@@ -174,6 +184,36 @@ services:
       SHAKAPACKER_DEV_SERVER_HOST: 0.0.0.0
     command: ["bin/shakapacker-dev-server"]
 
+  sqs:
+    image: softwaremill/elasticmq-native
+    expose:
+    - 9324
+    volumes:
+      - sqs-data:/data"
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
+  archives-service:
+    depends_on:
+      sqs:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/danbooru/archives:latest
+    environment:
+      <<: *sqs-env
+      RUN: 1
+      #db config
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: danbooru
+      POSTGRES_USER: danbooru
+      # POSTGRES_PASSWORD=
+    command: ["scripts/docker-bootstrap.sh"]
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
 configs:
   nginx:
     file: config/nginx.conf
@@ -187,3 +227,5 @@ volumes:
     name: ${COMPOSE_PROJECT_NAME}-iqdb-data
   webpack-data:
     name: ${COMPOSE_PROJECT_NAME}-webpack-data
+  sqs-data:
+    name: ${COMPOSE_PROJECT_NAME}-sqs-data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,14 @@
 # This doesn't change the name of the site, it only affects the name used by Docker Compose.
 name: danbooru
 
+x-sqs-env: &sqs-env
+  # Required to have working post and pool versions
+  DANBOORU_AWS_SQS_REGION: us-east-1
+  DANBOORU_AWS_ACCESS_KEY_ID: dummy
+  DANBOORU_AWS_SECRET_ACCESS_KEY: dummy
+  DANBOORU_AWS_SQS_ARCHIVES_URL: http://sqs:9324/000000000000/danbooru.fifo
+  DANBOORU_AWS_SQS_HOST: http://sqs:9324
+
 x-base-template: &base-template
   # You can set DANBOORU_IMAGE to `ghcr.io/danbooru/danbooru:master` to get the latest unstable release,
   # or e.g. `ghcr.io/danbooru/danbooru:production-2024.01.12-055003-utc` to get a specific stable version.
@@ -97,6 +105,7 @@ x-base-template: &base-template
     retries: 1
 
   environment:
+    <<: *sqs-env
     # The public URL of your site. You can set this if you have a domain name for your site.
     DANBOORU_CANONICAL_URL: ${DANBOORU_CANONICAL_URL:-}
 
@@ -204,6 +213,36 @@ services:
   autotagger:
     image: ghcr.io/danbooru/autotagger:latest
 
+  sqs:
+    image: softwaremill/elasticmq-native
+    expose:
+    - 9324
+    volumes:
+      - sqs-data:/data"
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
+  archives-service:
+    depends_on:
+      sqs:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/danbooru/archives:latest
+    environment:
+      <<: *sqs-env
+      RUN: 1
+      #db config
+      POSTGRES_HOST: postgres
+      POSTGRES_DB: danbooru
+      POSTGRES_USER: danbooru
+      # POSTGRES_PASSWORD=
+    command: ["scripts/docker-bootstrap.sh"]
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
 configs:
   danbooru_local_config:
     file: config/danbooru_local_config.rb
@@ -219,3 +258,5 @@ volumes:
     name: ${COMPOSE_PROJECT_NAME}-data
   iqdb-data:
     name: ${COMPOSE_PROJECT_NAME}-iqdb-data
+  sqs-data:
+    name: ${COMPOSE_PROJECT_NAME}-sqs-data


### PR DESCRIPTION
This pull adds a local SQS mock that makes post versions available locally and to codespaces for development and testing.

Still a WIP, I need to add it to the non-dev docker compose file as well and figure out the various options.

This pull also contains migrations that align the schema to the one used by danbooru in production.

Fixes #5255.