### PR TITLE
Fix two bugs that could cause an autocomplete search to be triggered without user input

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -17,6 +17,10 @@ Autocomplete.initialize_all = function() {
     },
     _renderItem: Autocomplete.render_item,
     search: function(value, event) {
+      if (!event.originalEvent || event.originalEvent.inputType === "") {
+        // Ignore. Not a real input event triggered by the user.
+        return;
+      }
       if ($(this).data("ui-autocomplete")) {
         $(this).data("ui-autocomplete").menu.bindings = $();
       }

--- a/app/javascript/src/javascripts/related_tag.js
+++ b/app/javascript/src/javascripts/related_tag.js
@@ -143,8 +143,8 @@ RelatedTag.toggle_tag = function(e) {
   setTimeout(function () { $field.prop('selectionStart', $field.val().length); }, 100);
   e.preventDefault();
 
-  // Artificially trigger input event so the tag counter updates.
-  $field.trigger("input");
+  // Update the tag counter without triggering an input event.
+  $field.trigger("danbooru:update-tag-counter");
 }
 
 RelatedTag.show = function(e) {

--- a/app/javascript/src/javascripts/tag_counter.js
+++ b/app/javascript/src/javascripts/tag_counter.js
@@ -6,7 +6,7 @@ export default class TagCounter {
 
   constructor($element) {
     this.$element = $element;
-    this.$target.on("input", (event) => this.update(event));
+    this.$target.on("input danbooru:update-tag-counter", (event) => this.update(event));
     this.update();
   }
 


### PR DESCRIPTION
Commit 2aaa99ef882872d24be079a35f63dd5d601033c3 fixes the issue with related tags reported here: https://github.com/danbooru/danbooru/issues/5958#issuecomment-2901883495

That issue occurs because clicking on a related tag to toggle it triggers a programmatic "input" event in order to update the tag counter, which causes an autocomplete search to be performed. It only occurs on Chrome and not Firefox for some reason. Removing the artificial input and using a custom trigger to update the tag counter fixes this.

Commit 1b7d6d08d5f6a7d89fc3a3e15fd1d04fe296bab1 fixes the issue with reopening a closed tab reported here: https://github.com/danbooru/danbooru/issues/5958#issuecomment-2910718251

That issue occurs because an "input" event is triggered when a closed tab is reopened. It only occurs on Firefox and not Chrome for some reason. I wasn't able to find exactly what was triggering this event to happen, it's not a manual `trigger("input")` call like the first bug. However, I did notice that `event.originalEvent.inputType` is equal to the empty string for this phantom input event, so I added a workaround where autocomplete searches will not trigger when the input type is an empty string. Input events triggered by the user should have a non-empty type from [this list](https://w3c.github.io/input-events/#interface-InputEvent-Attributes), so I don't think this workaround will cause any issues during normal editing.