### PR TITLE
arca.live: fix image downloads

### DIFF
--- a/app/logical/danbooru/url.rb
+++ b/app/logical/danbooru/url.rb
@@ -184,6 +184,14 @@ module Danbooru
       self.class.new(url.merge(components))
     end
 
+    # Return a new URL with the given query params appended.
+    #
+    # @param params [Hash] The query params to append.
+    # @return [Danbooru::URL] The new URL.
+    def with_params(**params)
+      with(params: self.params.merge(params))
+    end
+
     # Return a new URL with the given components removed. For example, return a new URL with the path or query params removed.
     #
     # @param components [Array<String, Symbol>] The URL components to override (scheme, authority, userinfo, user,

--- a/app/logical/source/extractor/arca_live.rb
+++ b/app/logical/source/extractor/arca_live.rb
@@ -20,7 +20,7 @@ module Source
       end
 
       def extract_image_url(element)
-        url = element.attr("src")
+        url = element.attr("data-originalurl") || element.attr("src")
         url = "https:#{url}" if url.starts_with?("//")
         url = Source::URL.parse(url)
 
@@ -87,6 +87,10 @@ module Source
 
       def http
         super.headers("User-Agent": "net.umanle.arca.android.playstore/0.9.75")
+      end
+
+      def http_downloader
+        super.disable_feature(:spoof_referrer)
       end
 
       memoize def api_response

--- a/app/logical/source/url/arca_live.rb
+++ b/app/logical/source/url/arca_live.rb
@@ -21,10 +21,11 @@ class Source::URL::ArcaLive < Source::URL
     # https://ac-o.namu.la/20221211sac/7f73beefc4f18a2f986bc4c6821caba706e27f4c94cb828fc16e2af1253402d9.gif?type=orig
     # https://ac.namu.la/20221211sac/7f73beefc4f18a2f986bc4c6821caba706e27f4c94cb828fc16e2af1253402d9.mp4 (.gif sample)
     in _, "namu.la", date, /\A\h{64}/
+      candidate_url = with_params(type: "orig")
       if file_ext == "mp4"
-        @candidate_full_image_urls = %w[gif webp mp4].map { |ext| "#{site}/#{date}/#{filename}.#{ext}?type=orig" }
+        @candidate_full_image_urls = %w[gif webp mp4].map { |ext| candidate_url.with(file_ext: ext).to_s }
       else
-        @full_image_url = "#{site}/#{date}/#{filename}.#{file_ext}?type=orig"
+        @full_image_url = candidate_url.to_s
       end
 
     # https://arca.live/b/arknights/66031722

--- a/test/unit/source/extractor/arca_live_extractor_test.rb
+++ b/test/unit/source/extractor/arca_live_extractor_test.rb
@@ -5,8 +5,8 @@ module Source::Tests::Extractor
     context "An Arca.live page URL" do
       strategy_should_work(
         "https://arca.live/b/arknights/66031722?p=1",
-        image_urls: %w[
-          https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig
+        image_urls: [
+          %r{https://ac\.namu\.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5\.jpg\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         media_files: [{ file_size: 273_206 }],
         profile_urls: %w[https://arca.live/u/@Si리링],
@@ -21,10 +21,10 @@ module Source::Tests::Extractor
 
     context "An Arca.live image URL with a referer" do
       strategy_should_work(
-        "https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg",
+        "https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg\?expires=1750243516&key=mQiH3KTgkEkAEDjO4GfTlA",
         referer: "https://arca.live/b/arknights/66031722?p=1",
-        image_urls: %w[
-          https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig
+        image_urls: [
+          %r{https://ac\.namu\.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5\.jpg\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         media_files: [{ file_size: 273_206 }],
         profile_urls: %w[https://arca.live/u/@Si리링],
@@ -39,9 +39,9 @@ module Source::Tests::Extractor
 
     context "An Arca.live image URL without a referer" do
       strategy_should_work(
-        "https://ac2.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg",
-        image_urls: %w[
-          https://ac2.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig
+        "https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg\?expires=1750243516&key=mQiH3KTgkEkAEDjO4GfTlA",
+        image_urls: [
+          %r{https://ac\.namu\.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5\.jpg\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         media_files: [{ file_size: 273_206 }],
         profile_urls: [],
@@ -57,8 +57,8 @@ module Source::Tests::Extractor
     context "An Arca.live /b/breaking page URL" do
       strategy_should_work(
         "https://arca.live/b/breaking/66031722",
-        image_urls: %w[
-          https://ac.namu.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5.jpg?type=orig
+        image_urls: [
+          %r{https://ac\.namu\.la/20221225sac2/e06dcf8edd29c597240898a6752c74dbdd0680fc932cfd0ecc898795f1db34b5\.jpg\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         media_files: [{ file_size: 273_206 }],
         profile_urls: %w[https://arca.live/u/@Si리링],
@@ -74,10 +74,10 @@ module Source::Tests::Extractor
     context "An Arca.live page URL with an animated .gif" do
       strategy_should_work(
         "https://arca.live/b/bluearchive/65031202",
-        image_urls: %w[
-          https://ac.namu.la/20221211sac/5ea7fbca5e49ec16beb099fc6fc991690d37552e599b1de8462533908346241e.png?type=orig
-          https://ac.namu.la/20221211sac/7f73beefc4f18a2f986bc4c6821caba706e27f4c94cb828fc16e2af1253402d9.gif?type=orig
-          https://ac.namu.la/20221211sac2/3e72f9e05ca97c0c3c0fe5f25632b06eb21ab9f211e9ea22816e16468ee241ca.png?type=orig
+        image_urls: [
+          %r{https://ac\.namu\.la/20221211sac/5ea7fbca5e49ec16beb099fc6fc991690d37552e599b1de8462533908346241e\.png\?expires=\d+&key=[\w_-]+&type=orig},
+          %r{https://ac\.namu\.la/20221211sac/7f73beefc4f18a2f986bc4c6821caba706e27f4c94cb828fc16e2af1253402d9\.gif\?expires=\d+&key=[\w_-]+&type=orig},
+          %r{https://ac\.namu\.la/20221211sac2/3e72f9e05ca97c0c3c0fe5f25632b06eb21ab9f211e9ea22816e16468ee241ca\.png\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         media_files: [
           { file_size: 28_519 },
@@ -97,9 +97,9 @@ module Source::Tests::Extractor
     context "An Arca.live page URL with an animated .webp" do
       strategy_should_work(
         "https://arca.live/b/arknights/122263340",
-        image_urls: %w[
-          https://ac.namu.la/20241126sac/b2175d9ef4504945d3d989526120dbb6aded501ddedfba8ecc44a64e7aae9059.gif?type=orig
-          https://ac.namu.la/20241126sac/bc1f3cb388a3a2d099ab67bc09b28f0a93c2c4755152b3ef9190690a9f0a28fb.webp?type=orig
+        image_urls: [
+          %r{https://ac\.namu\.la/20241126sac/b2175d9ef4504945d3d989526120dbb6aded501ddedfba8ecc44a64e7aae9059\.gif\?expires=\d+&key=[\w_-]+&type=orig},
+          %r{https://ac\.namu\.la/20241126sac/bc1f3cb388a3a2d099ab67bc09b28f0a93c2c4755152b3ef9190690a9f0a28fb\.webp\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         media_files: [
           { file_size: 749_653 },
@@ -121,7 +121,9 @@ module Source::Tests::Extractor
     context "An Arca.live page URL with an .mp4 video" do
       strategy_should_work(
         "https://arca.live/b/bluearchive/117240135",
-        image_urls: %w[https://ac.namu.la/20240926sac/16f07778a97f91b935c8a3394ead01a223d96b2a619fdb25c4628ddba88b5fad.mp4?type=orig],
+        image_urls: [
+          %r{https://ac\.namu\.la/20240926sac/16f07778a97f91b935c8a3394ead01a223d96b2a619fdb25c4628ddba88b5fad\.mp4\?expires=\d+&key=[\w_-]+&type=orig},
+        ],
         media_files: [{ file_size: 1_687_382 }],
         page_url: "https://arca.live/b/bluearchive/117240135",
         profile_urls: %w[https://arca.live/u/@horuhara/77430289],
@@ -139,7 +141,9 @@ module Source::Tests::Extractor
     context "An Arca.live page URL with a fake .mp4 GIF" do
       strategy_should_work(
         "https://arca.live/b/bluearchive/111191955",
-        image_urls: %w[https://ac.namu.la/20240714sac/c8fcadeb0b578e5121eb7a7e8fb05984cb87c68e7a6e0481a1c8869bf0ecfd2b.gif?type=orig],
+        image_urls: [
+          %r{https://ac\.namu\.la/20240714sac/c8fcadeb0b578e5121eb7a7e8fb05984cb87c68e7a6e0481a1c8869bf0ecfd2b\.gif\?expires=\d+&key=[\w_-]+&type=orig},
+        ],
         media_files: [{ file_size: 1_284_465 }],
         page_url: "https://arca.live/b/bluearchive/111191955",
         profile_urls: %w[https://arca.live/u/@horuhara/77430289],
@@ -157,8 +161,8 @@ module Source::Tests::Extractor
     context "An Arca.live page URL with a static emoticon" do
       strategy_should_work(
         "https://arca.live/b/arknights/49406926",
-        image_urls: %w[
-          https://ac.namu.la/20220428sac2/41f472adcea674aff75f15f146e81c27032bc4d6c8073bd7c19325bd1c97d335.png?type=orig
+        image_urls: [
+          %r{https://ac\.namu\.la/20220428sac2/41f472adcea674aff75f15f146e81c27032bc4d6c8073bd7c19325bd1c97d335\.png\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         profile_urls: %w[https://arca.live/u/@유즈비],
         page_url: "https://arca.live/b/arknights/49406926",
@@ -173,9 +177,9 @@ module Source::Tests::Extractor
     context "An Arca.live page URL with an animated emoticon" do
       strategy_should_work(
         "https://arca.live/b/commission/63658702",
-        image_urls: %w[
-          https://ac.namu.la/20221123sac2/14925c5e22ab9f17f2923ae60a39b7af0794c43e478ecaba054ab6131e57e022.png?type=orig
-          https://ac.namu.la/20221123sac2/50c385a4004bca44271a2f6133990f086cfefd29a7968514e9c14d6017d61265.png?type=orig
+        image_urls: [
+          %r{https://ac\.namu\.la/20221123sac2/14925c5e22ab9f17f2923ae60a39b7af0794c43e478ecaba054ab6131e57e022\.png\?expires=\d+&key=[\w_-]+&type=orig},
+          %r{https://ac\.namu\.la/20221123sac2/50c385a4004bca44271a2f6133990f086cfefd29a7968514e9c14d6017d61265\.png\?expires=\d+&key=[\w_-]+&type=orig},
         ],
         profile_urls: %w[https://arca.live/u/@크림/55256970],
         page_url: "https://arca.live/b/commission/63658702",


### PR DESCRIPTION
Direct image URLs now require `expires` and `key` params present, as well as `type=orig`.
The signature seems to affect the entire path, including the extension.

This make tests a bit flaky:
- some have hard-coded signed url (for tests with direct image urls);
- .webp test fails as there is no signed url for original .webp file present;
- old format fake .mp4 .gif test fails as the file seems to be just gone from the servers.