### PR TITLE
feat(search): enhance artist version sorting with multi-field and direction support

### DIFF
--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -19,8 +19,10 @@ class ArtistVersion < ApplicationRecord
     def search(params, current_user)
       q = search_attributes(params, [:id, :created_at, :updated_at, :is_deleted, :is_banned, :name, :group_name, :urls, :other_names, :updater, :artist], current_user: current_user)
 
-      if params[:order] == "name"
-        q = q.order("artist_versions.name").default_order
+      case params[:order]
+      when /\A(id|created_at|updated_at|name)(?:_(asc|desc))?\z/i
+        dir = $2 || :desc
+        q = q.order($1 => dir).order(id: :desc)
       else
         q = q.apply_default_order(params)
       end

--- a/app/views/artist_versions/_listing.html.erb
+++ b/app/views/artist_versions/_listing.html.erb
@@ -1,6 +1,7 @@
 <%= search_form_for(artist_versions_path) do |f| %>
   <%= f.input :updater_name, label: "Updater", input_html: { value: params.dig(:search, :updater_name), "data-autocomplete": "user" } %>
   <%= f.input :name, label: "Artist", input_html: { value: params.dig(:search, :name), "data-autocomplete": "artist" } %>
+  <%= f.input :order, collection: [["ID", "id"], ["Created", "created_at"], ["Updated", "updated_at"], ["Name", "name"]], selected: params.dig(:search, :order) %>
   <%= f.submit "Search" %>
 <% end %>
 


### PR DESCRIPTION
Added comprehensive sorting functionality to artist version search following the same pattern used in artist URLs search logic.

Enhanced the `ArtistVersion.search` method to support sorting by `id`, `created_at`, `updated_at`, and `name` with ascending/descending directions, and added a sorting dropdown to the search form.

Uses regex pattern to parse sort parameters with descending as default order, bringing artist version search capabilities in line with existing artist URLs functionality.