### PR TITLE
feat(artist): add `other_names=` method to prevent duplicate artist names

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -94,6 +94,13 @@ class Artist < ApplicationRecord
     def pretty_name
       name.tr("_", " ")
     end
+    
+    def other_names=(names)
+      super(names)
+      if name.present? && other_names.present?
+        self[:other_names] = other_names - [name]
+      end
+    end
   end
 
   module VersionMethods

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -650,5 +650,24 @@ class ArtistTest < ActiveSupport::TestCase
         assert_includes(artist.urls.map(&:url), "https://www.pixiv.net/stacc/niceandcool")
       end
     end
+
+    context "when setting other_names" do
+      should "remove elements that match the artist name exactly" do
+        artist = create(:artist, name: "test_artist")
+        
+        artist.other_names_string = "test_artist another_name"
+        assert_equal(["another_name"], artist.other_names)
+        assert_equal("another_name", artist.other_names_string)
+        
+        artist.other_names = ["test_artist", "another_name", "third_name"]
+        assert_equal(["another_name", "third_name"], artist.other_names)
+        
+        artist.other_names = ["Test_Artist", "another_name"]
+        assert_equal(["Test_Artist", "another_name"], artist.other_names)
+        
+        artist.update(other_names_string: "test_artist different_name")
+        assert_equal(["different_name"], artist.reload.other_names)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Override `other_names=` to automatically remove elements that exactly match the artist name
- Add comprehensive test cases covering various scenarios including case sensitivity
- Ensure other_names array stays clean without main artist name duplicates