### PR TITLE
Various fixes and improvements for autocomplete

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -7,6 +7,11 @@ let Autocomplete = {};
 Autocomplete.VERSION = 2; // This should be bumped whenever the /autocomplete API changes in order to invalid client caches.
 Autocomplete.MAX_RESULTS = 20;
 
+Autocomplete.WHITESPACE = ' \\t';
+Autocomplete.WORD_SEPARATORS = Autocomplete.WHITESPACE + '_()\\[\\]{}<>`\'"-/;:,.?!';
+Autocomplete.PREV_WORD_REGEXP = new RegExp(`[^${Autocomplete.WORD_SEPARATORS}]+[${Autocomplete.WORD_SEPARATORS}]*$`);
+Autocomplete.NEXT_WORD_REGEXP = new RegExp(`^[${Autocomplete.WORD_SEPARATORS}]*[^${Autocomplete.WORD_SEPARATORS}]+`);
+
 Autocomplete.initialize_all = function() {
   $.widget("ui.autocomplete", $.ui.autocomplete, {
     options: {
@@ -87,9 +92,9 @@ Autocomplete.initialize_tag_autocomplete = function() {
         var before_caret_text = target.value.substring(0, caret);
         var after_caret_text = target.value.substring(caret);
         if (event.inputType == "deleteWordBackward") {
-          before_caret_text = before_caret_text.replace(/\S+[ \t]*$/, "");
+          before_caret_text = before_caret_text.replace(Autocomplete.PREV_WORD_REGEXP, "");
         } else if (event.inputType == "deleteWordForward") {
-          after_caret_text = after_caret_text.replace(/^[ \t]*\S+/, "");
+          after_caret_text = after_caret_text.replace(Autocomplete.NEXT_WORD_REGEXP, "");
         }
         if (after_caret_text.match(/^\S/)) {
           // There's a tag after the caret, so add a space between them so it doesn't interfere with autocomplete.
@@ -112,7 +117,7 @@ Autocomplete.initialize_tag_autocomplete = function() {
     }
     let caret = target.selectionStart;
     var before_caret_text = target.value.substring(0, caret);
-    let match = before_caret_text.match(/\S+[ \t]*$/);
+    let match = before_caret_text.match(Autocomplete.PREV_WORD_REGEXP);
     if (match) {
       target.selectionStart = target.selectionEnd = match.index;
     }
@@ -130,7 +135,7 @@ Autocomplete.initialize_tag_autocomplete = function() {
     let caret = target.selectionStart;
     var before_caret_text = target.value.substring(0, caret);
     var after_caret_text = target.value.substring(caret);
-    let match = after_caret_text.match(/^[ \t]*\S+/);
+    let match = after_caret_text.match(Autocomplete.NEXT_WORD_REGEXP);
     if (match) {
       target.selectionStart = target.selectionEnd = before_caret_text.length + match[0].length;
     }

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -1,4 +1,5 @@
 import { isBeforeInputEventAvailable }  from './utility'
+import UndoStack from './undo_stack';
 
 let Autocomplete = {};
 
@@ -68,6 +69,8 @@ Autocomplete.initialize_tag_autocomplete = function() {
       resp(results);
     }
   });
+
+  UndoStack.initialize_fields($fields_multiple);
 
   if (isBeforeInputEventAvailable()) {
     $fields_multiple.on("beforeinput", function(e) {

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -1,5 +1,6 @@
 import { isBeforeInputEventAvailable }  from './utility'
 import UndoStack from './undo_stack';
+import Utility from './utility';
 
 let Autocomplete = {};
 
@@ -100,6 +101,41 @@ Autocomplete.initialize_tag_autocomplete = function() {
       }
     });
   }
+
+  Utility.keydown("ctrl+left", "cursor_word_left", e => {
+    let target = e.target;
+    let selected = target.selectionStart !== target.selectionEnd;
+    if (selected) {
+      target.selectionEnd = target.selectionStart;
+      e.preventDefault();
+      return;
+    }
+    let caret = target.selectionStart;
+    var before_caret_text = target.value.substring(0, caret);
+    let match = before_caret_text.match(/\S+[ \t]*$/);
+    if (match) {
+      target.selectionStart = target.selectionEnd = match.index;
+    }
+    e.preventDefault();
+  }, $fields_multiple);
+
+  Utility.keydown("ctrl+right", "cursor_word_right", e => {
+    let target = e.target;
+    let selected = target.selectionStart !== target.selectionEnd;
+    if (selected) {
+      target.selectionStart = target.selectionEnd;
+      e.preventDefault();
+      return;
+    }
+    let caret = target.selectionStart;
+    var before_caret_text = target.value.substring(0, caret);
+    var after_caret_text = target.value.substring(caret);
+    let match = after_caret_text.match(/^[ \t]*\S+/);
+    if (match) {
+      target.selectionStart = target.selectionEnd = before_caret_text.length + match[0].length;
+    }
+    e.preventDefault();
+  }, $fields_multiple);
 
   $fields_multiple.on("selectionchange", function(e) {
     // Update the autocomplete results if the user moves their caret while the autocomplete menu is already open.

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -87,7 +87,11 @@ Autocomplete.initialize_tag_autocomplete = function() {
         } else if (event.inputType == "deleteWordForward") {
           after_caret_text = after_caret_text.replace(/^[ \t]*\S+/, "");
         }
-        target.value = before_caret_text + after_caret_text;
+        if (after_caret_text.match(/^\S/)) {
+          // There's a tag after the caret, so add a space between them so it doesn't interfere with autocomplete.
+          after_caret_text = " " + after_caret_text;
+        }
+        $(target).replaceFieldText(before_caret_text + after_caret_text);
         target.selectionStart = target.selectionEnd = before_caret_text.length;
         e.preventDefault();
       }

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -20,7 +20,7 @@ Autocomplete.initialize_all = function() {
     },
     _renderItem: Autocomplete.render_item,
     search: function(value, event) {
-      if (!event.originalEvent || event.originalEvent.inputType === "") {
+      if (event && (!event.originalEvent || event.originalEvent.inputType === "")) {
         // Ignore. Not a real input event triggered by the user.
         return;
       }
@@ -97,6 +97,17 @@ Autocomplete.initialize_tag_autocomplete = function() {
       }
     });
   }
+
+  $fields_multiple.on("selectionchange", function(e) {
+    // Update the autocomplete results if the user moves their caret while the autocomplete menu is already open.
+    var input = this;
+    var autocomplete = $(input).autocomplete("instance");
+    var $autocomplete_menu = autocomplete.menu.element;
+    if (!$autocomplete_menu.is(":visible")) {
+      return;
+    }
+    $(input).autocomplete("search");
+  });
 }
 
 Autocomplete.current_term = function($input) {

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -95,7 +95,7 @@ Autocomplete.insert_completion = function(input, completion) {
     after_caret_text = " " + after_caret_text;
   }
 
-  input.value = before_caret_text + after_caret_text;
+  $(input).replaceFieldText(before_caret_text + after_caret_text);
   input.selectionStart = input.selectionEnd = before_caret_text.length;
 
   $(input).trigger("input"); // Manually trigger an input event because programmatically editing the field won't trigger one.

--- a/app/javascript/src/javascripts/dtext_editor.js
+++ b/app/javascript/src/javascripts/dtext_editor.js
@@ -229,8 +229,15 @@ export default class DTextEditor {
 
     if (text.length > 0) {
       // Use execCommand so that the undo history is updated.
-      document.execCommand("insertText", false, text);
-      // this.input.setRangeText(text, start, end, "select");
+      let success = document.execCommand("insertText", false, text);
+      if (!success) {
+        // insertText is not supported by the browser.
+        // Fall back to setRangeText.
+        this.input.setRangeText(text, start, end, "select");
+        if (!selected) {
+          this.setSelectionRange(start + text.length, start + text.length);
+        }
+      }
     }
 
     // Select the new text if the replaced text was previously selected.

--- a/app/javascript/src/javascripts/undo_stack.js
+++ b/app/javascript/src/javascripts/undo_stack.js
@@ -1,0 +1,125 @@
+import Utility from './utility';
+import { isBeforeInputEventAvailable }  from './utility'
+
+class UndoItem {
+  constructor(element) {
+    this.value = element.value;
+    this.selectionStart = element.selectionStart;
+    this.selectionEnd = element.selectionEnd;
+  };
+
+  apply(element) {
+    element.value = this.value;
+    element.selectionStart = this.selectionStart;
+    element.selectionEnd = this.selectionEnd;
+  }
+};
+
+class UndoStack {
+  constructor(element) {
+    this.element = element;
+    element.undoStack = this;
+    this.undoItems = [];
+    this.redoItems = [];
+    this.currentItem = new UndoItem(this.element);
+    this.mergeWindow = 1000; // Max milliseconds between edits to consider the same
+    this.prevSaveTime = 0;
+  };
+
+  undo() {
+    this.updateCurrent();
+    while (this.undoItems.length > 0) {
+      let item = this.undoItems.pop();
+      if (item.value == this.currentItem.value) {
+        continue;
+      }
+      this.redoItems.push(this.currentItem);
+      this.currentItem = item;
+      this.currentItem.apply(this.element);
+      break;
+    }
+  }
+
+  redo() {
+    if (this.redoItems.length > 0) {
+      this.undoItems.push(this.currentItem);
+      let item = this.redoItems.pop();
+      this.currentItem = item;
+      this.currentItem.apply(this.element);
+    }
+  }
+
+  updateCurrent() {
+    this.currentItem = new UndoItem(this.element);
+  }
+
+  save(force = false) {
+    let currTime = Date.now();
+    if (!force) {
+      if (currTime - this.prevSaveTime < this.mergeWindow) {
+        return;
+      }
+      if (this.undoItems.length > 0) {
+        let last_item = this.undoItems[this.undoItems.length - 1];
+        if (this.element.value === last_item.value) {
+          return;
+        }
+      }
+    }
+    this.prevSaveTime = currTime;
+    let item = new UndoItem(this.element);
+    this.undoItems.push(item);
+    this.redoItems = [];
+  }
+
+  static initialize_fields($fields) {
+    if (!isBeforeInputEventAvailable()) {
+      // This undo implementation will not work if the "beforeinput" event is not supported.
+      // Disable this implementation and use the browser's native undo instead.
+      return;
+    };
+
+    $fields.each((_, element) => {
+      new UndoStack(element);
+    })
+
+    $fields.on("beforeinput", function(e) {
+      if (!e || !e.originalEvent) {
+        return;
+      }
+      let target = e.target;
+      let event = e.originalEvent;
+
+      if (event.inputType == "historyUndo") {
+        target.undoStack.undo();
+        e.preventDefault();
+      } else if (event.inputType == "historyRedo") {
+        target.undoStack.redo();
+        e.preventDefault();
+      } else {
+        target.undoStack.save();
+      }
+    });
+
+    $fields.on("input", function(e) {
+      if (!e) {
+        return;
+      }
+      e.target.undoStack.updateCurrent();
+    });
+
+    Utility.keydown("ctrl+z", "undo", e => {
+      let target = e.target;
+      target.undoStack.undo();
+      e.preventDefault();
+    }, $fields);
+
+    Utility.keydown("ctrl+shift+z", "redo", e => {
+      let target = e.target;
+      target.undoStack.redo();
+      e.preventDefault();
+    }, $fields);
+  }
+};
+
+export default UndoStack;

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -157,6 +157,19 @@ export async function createUpload(params, pollDelay = 250) {
   return upload;
 }
 
+$.fn.replaceFieldText = function(new_value) {
+  return this.each(function() {
+    this.focus();
+    this.setSelectionRange(0, this.value.length);
+    let success = document.execCommand("insertText", false, new_value);
+    if (!success) {
+      // insertText is not supported by the browser.
+      // Fall back to assigning to value.
+      this.value = new_value;
+    }
+  })
+}
+
 $.fn.selectEnd = function() {
   return this.each(function() {
     this.focus();

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -169,13 +169,20 @@ export async function createUpload(params, pollDelay = 250) {
 
 $.fn.replaceFieldText = function(new_value) {
   return this.each(function() {
-    this.focus();
-    this.setSelectionRange(0, this.value.length);
-    let success = document.execCommand("insertText", false, new_value);
-    if (!success) {
-      // insertText is not supported by the browser.
-      // Fall back to assigning to value.
+    if (this.undoStack) {
+      // If the element is using the custom undo stack implementation, simply assign directly to the input's value.
+      this.undoStack.save(true);
       this.value = new_value;
+    } else {
+      // Otherwise, try using execCommand to preserve the browser's native undo stack.
+      this.focus();
+      this.setSelectionRange(0, this.value.length);
+      let success = document.execCommand("insertText", false, new_value);
+      if (!success) {
+        // insertText is not supported by the browser.
+        // Fall back to assigning to value.
+        this.value = new_value;
+      }
     }
   })
 }

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -24,6 +24,16 @@ export function isMobile() {
   return window.matchMedia("(max-width: 660px)").matches;
 }
 
+// The following function returns true if beforeinput, and thus getTargetRanges, is supported.
+//
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/beforeinput_event#feature_detection
+export function isBeforeInputEventAvailable() {
+  return (
+    window.InputEvent &&
+    typeof InputEvent.prototype.getTargetRanges === "function"
+  );
+}
+
 Utility.dialog = function(title, html) {
   const $dialog = $(html).dialog({
     title: title,

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -171,7 +171,7 @@ $.fn.replaceFieldText = function(new_value) {
   return this.each(function() {
     if (this.undoStack) {
       // If the element is using the custom undo stack implementation, simply assign directly to the input's value.
-      this.undoStack.save(true);
+      this.undoStack.save("danbooru.replaceFieldText");
       this.value = new_value;
     } else {
       // Otherwise, try using execCommand to preserve the browser's native undo stack.


### PR DESCRIPTION

The first five commits are several bugfixes and quality-of-life improvements for autocomplete. Details are included in each commit. Between these five commits, I believe the following issues should now all be resolved (as well as some other issues I haven't seen reported anywhere):

* Fixes #5251
* Fixes #5958: When deleting a tag, the caret remains before the next tag, interfering with autocomplete for the next term you type
* Fixes the issue reported in the second half of [this comment](https://github.com/danbooru/danbooru/pull/5954#issuecomment-2954619440): Autocomplete results not updated when moving caret to a different term

The sixth commit is slightly different from the others, as it completely replaces the native undo/redo implementation with a custom one for tag input fields. My reasoning for this is that while the native browser undo works 'well enough' thanks to the `execCommand` trick used in several of the above commits, there are some minor issues with that trick which can be fixed by avoiding `execCommand` entirely and instead reimplementing undo from scratch so that it still works when changing an input's value.

Specifically:
* When you undo an `execCommand`, the browser's native undo is not smart enough to also revert the user's selection to its original placement. This means that the entire text field's contents get selected when you undo, which can be annoying, although it's better than undo not working at all.
* `execCommand` is technically deprecated. It currently works in all major browsers that I'm aware of, but they could decide to drop support for it at some point in the future.
* `execCommand` does not work in some minor browsers (such as Pale Moon).

I've tested my custom undo stack on Firefox and Chrome and it seems to work well. But if completely reimplementing the undo stack is considered overkill for those three problems mentioned above, then the sixth commit can be reverted and the other five will still work without it by using `execCommand` instead.