### PR TITLE
Add pending posts link to contributor users profile page

### DIFF
--- a/app/views/uploads/_single_asset_upload.html.erb
+++ b/app/views/uploads/_single_asset_upload.html.erb
@@ -149,9 +149,9 @@
                 <%= f.submit "Post", class: "button-primary button-sm" %>
 
                 <% if CurrentUser.is_contributor? %>
-                  <%= f.input :is_pending, as: :boolean, label: "Upload for approval", wrapper_html: { class: "inline-block !m-0" }, input_html: { checked: post.is_pending? } %>
+                  <%= f.input :is_pending, as: :boolean, label: "Post for approval", wrapper_html: { class: "inline-block !m-0" }, input_html: { checked: post.is_pending? } %>
                 <% else %>
-                  <span id="upload-limit" class="fineprint">Upload limit: <%= render "users/upload_limit", user: CurrentUser.user %></span>
+                  <span id="upload-limit" class="fineprint">Post limit: <%= render "users/upload_limit", user: CurrentUser.user %></span>
                 <% end %>
 
                 <% if CurrentUser.post_upload_count < 10 %>

--- a/app/views/users/_upload_limit.html.erb
+++ b/app/views/users/_upload_limit.html.erb
@@ -1,14 +1,12 @@
 <%# user %>
 
+<%= link_to user.upload_limit.used_upload_slots, posts_path(tags: "user:#{user.name} status:pending") %> /
 <% if user.is_contributor? %>
   none
+<% elsif user.upload_limit.maxed? %>
+  <%= tag.abbr user.upload_limit.upload_slots, title: "Maximum amount of upload slots reached." %>
 <% else %>
-  <%= link_to user.upload_limit.used_upload_slots, posts_path(tags: "user:#{user.name} status:pending") %> /
-  <% if user.upload_limit.maxed? %>
-    <%= tag.abbr user.upload_limit.upload_slots, title: "Maximum amount of upload slots reached." %>
-  <% else %>
-    <%= tag.abbr user.upload_limit.upload_slots, title: "#{pluralize(user.upload_limit.approvals_for_next_level - user.upload_limit.approvals_on_current_level, "approved post")} needed for next level (progress: #{user.upload_limit.approvals_on_current_level} / #{user.upload_limit.approvals_for_next_level}) " %>
-  <% end %>
+  <%= tag.abbr user.upload_limit.upload_slots, title: "#{pluralize(user.upload_limit.approvals_for_next_level - user.upload_limit.approvals_on_current_level, "approved post")} needed for next level (progress: #{user.upload_limit.approvals_on_current_level} / #{user.upload_limit.approvals_for_next_level}) " %>
 <% end %>
 
 (<%= link_to_wiki "help", "about:upload_limits" %>)


### PR DESCRIPTION
The issue here is that I am used to click the upload limits on own profile page to quickly access own pending posts.
And now, after promotion, I can't do that for the posts that I occasionally send to the queue and have to search for `user:hdk5 status:pending` manually instead.

Also fix Posts/Uploads wording on the upload page.