### PR TITLE
Fix Ctrl shortcuts ignoring separators at edges of string

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -9,8 +9,8 @@ Autocomplete.MAX_RESULTS = 20;
 
 Autocomplete.WHITESPACE = ' \\t';
 Autocomplete.WORD_SEPARATORS = Autocomplete.WHITESPACE + '_()\\[\\]{}<>`\'"-/;:,.?!';
-Autocomplete.PREV_WORD_REGEXP = new RegExp(`[^${Autocomplete.WORD_SEPARATORS}]+[${Autocomplete.WORD_SEPARATORS}]*$`);
-Autocomplete.NEXT_WORD_REGEXP = new RegExp(`^[${Autocomplete.WORD_SEPARATORS}]*[^${Autocomplete.WORD_SEPARATORS}]+`);
+Autocomplete.PREV_WORD_REGEXP = new RegExp(`[^${Autocomplete.WORD_SEPARATORS}]*[${Autocomplete.WORD_SEPARATORS}]*$`);
+Autocomplete.NEXT_WORD_REGEXP = new RegExp(`^[${Autocomplete.WORD_SEPARATORS}]*[^${Autocomplete.WORD_SEPARATORS}]*`);
 
 Autocomplete.initialize_all = function() {
   $.widget("ui.autocomplete", $.ui.autocomplete, {


### PR DESCRIPTION
There was a bug in the regex for these shortcut overrides which meant that if your caret was in this position, with only separators at the edge of the string:
`looking_at|_`
Pressing Ctrl+Right wouldn't move the caret to the end, it would be stuck before the underscore. And pressing Ctrl+Delete wouldn't delete the underscore either.