### PR TITLE
Another minor tweak to Ctrl+Right

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -92,12 +92,13 @@ Autocomplete.initialize_tag_autocomplete = function() {
         let caret = target.selectionStart;
         var before_caret_text = target.value.substring(0, caret);
         var after_caret_text = target.value.substring(caret);
+        let orig_after_caret_text = after_caret_text;
         if (event.inputType == "deleteWordBackward") {
           before_caret_text = before_caret_text.replace(Autocomplete.PREV_WORD_REGEXP, "");
         } else if (event.inputType == "deleteWordForward") {
           after_caret_text = after_caret_text.replace(Autocomplete.NEXT_WORD_REGEXP, "");
         }
-        if (after_caret_text.match(/^\S/)) {
+        if (after_caret_text.match(/^\S/) && orig_after_caret_text.match(/^\S/)) {
           // There's a tag after the caret, so add a space between them so it doesn't interfere with autocomplete.
           after_caret_text = " " + after_caret_text;
         }

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -10,7 +10,7 @@ Autocomplete.MAX_RESULTS = 20;
 Autocomplete.WHITESPACE = ' \\t\\r\\n';
 Autocomplete.WORD_SEPARATORS = Autocomplete.WHITESPACE + '_()\\[\\]{}<>`\'"-/;:,.?!';
 Autocomplete.PREV_WORD_REGEXP = new RegExp(`[^${Autocomplete.WORD_SEPARATORS}]*[${Autocomplete.WORD_SEPARATORS}]*$`);
-Autocomplete.NEXT_WORD_REGEXP = new RegExp(`^[${Autocomplete.WORD_SEPARATORS}]*[^${Autocomplete.WORD_SEPARATORS}]*[${Autocomplete.WORD_SEPARATORS}]*`);
+Autocomplete.NEXT_WORD_REGEXP = new RegExp(`^[^${Autocomplete.WORD_SEPARATORS}]*[${Autocomplete.WORD_SEPARATORS}]*`);
 
 Autocomplete.initialize_all = function() {
   $.widget("ui.autocomplete", $.ui.autocomplete, {


### PR DESCRIPTION
Related to commit 35494be3c60e6540b2da847348dbf777857acb2f

> Now Ctrl+Right moves past spaces at the end of tags, which matches normal browser behavior.

I was confused by this statement as when I tested it on both Firefox and Chrome Ctrl+Right did not move past the final space. After some more testing, it would seem this behavior actually varies not on your browser but your operating system. On Windows it skips the final space in both browsers, but on Linux it doesn't. (Unsure about Mac.)

Furthermore, desktop GUI frameworks like Qt seem to have the Windows behavior even on Linux. So not skipping the space is something that specifically only browsers do, and only on Linux.

If we wanted to emulate native behavior as closely as possible we would need to detect the user's operating system and change the regex, but I'm not sure if this is necessary. I think the behavior of skipping the space makes more sense, and it's unclear why browsers conditionally disable this anyway.

Instead this PR is just further tweaking Ctrl+Right to be closer to the Windows behavior, as on master it is now currently a hybrid between the two. Ctrl+Right normally would only skip one run of separators and one run of non-separators on both platforms, and only the order of the two runs varies between platforms.

For example, if your caret was here:
`1girl| 1boy `
The current behavior of Danbooru's Ctrl+Right  override on master would place it here, skipping the first space, the word, and the final space:
`1girl 1boy |`
But the native browser behavior on Windows would place the caret here, moving only a single space, so that's what this new PR does:
`1girl |1boy `
For comparison, the native browser behavior on Linux would place the caret here, moving one space and one word, but not the final space, which is what my original PR did:
`1girl 1boy| `