### PR TITLE
Tag autocomplete: Treat the caret as a wildcard in the middle of a term

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -148,10 +148,20 @@ Autocomplete.initialize_tag_autocomplete = function() {
 
 Autocomplete.current_term = function($input, caret = $input.get(0).selectionStart) {
   let query = $input.get(0).value;
+  let term_before_caret = query.substring(0, caret);
   let term_after_caret = query.substring(caret).match(/\S*/)[0];
-  caret += term_after_caret.length;
+  let term = term_before_caret;
+  if (term_after_caret) {
+    // If the caret is in the middle of tag, treat it as a wildcard asterisk.
+    // This allows the user to get useful autocomplete results by only typing the first few characters of a word between two other words.
+    term += "*" + term_after_caret;
+    if (!term_before_caret.includes("*") && !term_after_caret.includes("*")) {
+      // If the user did not manually type an asterisk then we need to add one at the end to simulate the normal prefix search behavior.
+      term += "*";
+    }
+  }
   let regexp = new RegExp(`^[-~(]*(${Autocomplete.tag_prefixes().join("|")})?`);
-  let match = query.substring(0, caret).match(/\S*$/)[0].replace(regexp, "").toLowerCase();
+  let match = term.match(/\S*$/)[0].replace(regexp, "").toLowerCase();
   return match;
 };
 

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -92,15 +92,22 @@ Autocomplete.initialize_tag_autocomplete = function() {
         let caret = target.selectionStart;
         var before_caret_text = target.value.substring(0, caret);
         var after_caret_text = target.value.substring(caret);
-        let orig_after_caret_text = after_caret_text;
         if (event.inputType == "deleteWordBackward") {
-          before_caret_text = before_caret_text.replace(Autocomplete.PREV_WORD_REGEXP, "");
+          before_caret_text = before_caret_text.replace(Autocomplete.PREV_WORD_REGEXP, function(match) {
+            if (!match.startsWith(" ") && match.endsWith(" ")) {
+              // Add an extra space after the caret when deleting the final word in a tag.
+              after_caret_text = " " + after_caret_text;
+            }
+            return "";
+          });
         } else if (event.inputType == "deleteWordForward") {
-          after_caret_text = after_caret_text.replace(Autocomplete.NEXT_WORD_REGEXP, "");
-        }
-        if (after_caret_text.match(/^\S/) && orig_after_caret_text.match(/^\S/)) {
-          // There's a tag after the caret, so add a space between them so it doesn't interfere with autocomplete.
-          after_caret_text = " " + after_caret_text;
+          after_caret_text = after_caret_text.replace(Autocomplete.NEXT_WORD_REGEXP, function(match) {
+            if (!match.startsWith(" ") && match.endsWith(" ")) {
+              // Add an extra space after the caret when deleting the final word in a tag.
+              return " ";
+            }
+            return "";
+          });
         }
         $(target).replaceFieldText(before_caret_text + after_caret_text);
         target.selectionStart = target.selectionEnd = before_caret_text.length;


### PR DESCRIPTION
https://github.com/danbooru/danbooru/pull/6074#issuecomment-3030057174

> I think this will require some further tuning to get things working just right. One issue is that it's currently hard to delete words in the middle of a tag. For example, if you have `hand_on_own_hip`, you should be to easily delete `own` and replace it with `another's` to get `hand_on_another's_hip`. Or if you have `artoria_pendragon_(lancer)_(fate)`, you should be able to easily delete `lancer` and replace it with `swimsuit_ruler`.
> 
> Currently it's hard because it inserts spaces after deleting words, which breaks deleting words inside tags. But even if you get rid of that, there are still issues with it not working how you would like in some cases. For example, if you're at the start of `lancer` in `artoria_pendragon_(lancer)_(fate)`, and you try to Ctrl+Delete it hoping to get `artoria_pendragon_()_(fate)` so you can insert `swimsuit_ruler`, instead you get `artoria_pendragon_(|fate)`.
> 
> I experimented with different ways to solve this problem, but couldn't find something that felt good. One way is to make Ctrl+Left/Right move between the ends of words, instead of the beginnings of words. That way you can use Ctrl+Left to move to the end of a word and use Ctrl+Backspace to delete it. But then it feels weird because this is not how Ctrl+Left/Right normally works.

I think I came up with a better way to delete words in the middle of a tag and type new ones. When the caret is in the middle of a tag, treating it as a hidden wildcard asterisk allows autocomplete to work even in scenarios where the user hasn't finished typing the middle word yet, such as `hand_on_ano|hip` or `artoria_pendragon_(swi|fate)`

With this change in place, the "add a space when deleting a word" feature becomes unnecessary in the case where you deleted a word in the middle of a tag, as the leftover suffix of a tag no longer interferes with autocomplete results and actually improves them thanks to the wildcard. Now the extra space is only needed when deleting the final word of a tag and the space that followed it, in order to prevent the next tag over from interfering with autocomplete.

The combination of these two changes allows for things like this:
![output](https://github.com/user-attachments/assets/2e1b8bb9-316b-4076-a843-c0f70b4e2a36)

You're technically still in the `artoria_pendragon_(|fate)` state instead of `artoria_pendragon_(|)_(fate)` temporarily, but this doesn't matter in practice because now you don't have to type the `)_(` back manually, it just autocompletes with the rest of the tag, overwriting the entire suffix.