### PR TITLE
Replace wiki links with bulk update request links for tag aliases

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -224,6 +224,10 @@ module ApplicationHelper
     link_to text, wiki_page_path(title), class: "wiki-link #{classes}", **options
   end
 
+  def link_to_bulk_update_requests(text, tag_name = text, classes: nil, **options)
+    link_to text, bulk_update_requests_path(commit: "Search", search: { status: "approved", tags_include_any: tag_name }), class: "bulk-update-link #{classes}", **options
+  end
+
   def link_to_wikis(*wiki_titles, **options)
     links = wiki_titles.map do |title|
       link_to_wiki title.tr("_", " "), title

--- a/app/views/tag_relationships/_alias_and_implication_list.html.erb
+++ b/app/views/tag_relationships/_alias_and_implication_list.html.erb
@@ -9,7 +9,7 @@
   <% if tag.consequent_aliases.present? %>
     <p class="fineprint">
       The following tags are aliased to this tag:
-      <%= to_sentence(tag.consequent_aliases.sort_by(&:antecedent_name).map { |ta| link_to_wiki ta.antecedent_name }) %>
+      <%= to_sentence(tag.consequent_aliases.sort_by(&:antecedent_name).map { |ta| link_to_bulk_update_requests ta.antecedent_name }) %>
       (<%= link_to_wiki "learn more", "help:tag_aliases" %>).
     </p>
   <% end %>


### PR DESCRIPTION
## Problem
Tag aliases on artist pages currently link to empty wiki pages, providing no useful information to users.

## Solution
Replace wiki links for tag aliases with links to approved bulk update requests. This allows users to:
- See when the alias was added
- View the actual bulk update request that created the alias
- Access meaningful information instead of empty wiki pages

## Changes
- Added `link_to_bulk_update_requests` helper method
- Updated tag alias display to use bulk update request links instead of wiki links

## Example
**Before:** `https://danbooru.donmai.us/wiki_pages/abc` (empty page)
**After:** `https://danbooru.donmai.us/bulk_update_requests?commit=Search&search[status]=approved&search[tags_include_any]=abc` (shows actual bulk update history)