### PR TITLE
Fix Weibo

### DIFF
--- a/app/logical/source/extractor/weibo.rb
+++ b/app/logical/source/extractor/weibo.rb
@@ -118,7 +118,7 @@ module Source
       end
 
       memoize def page_json
-        html = http.cache(1.minute).parsed_get(mobile_page_url)
+        html = http.cookies(SUB: sub_cookie).cache(1.minute).parsed_get(mobile_page_url)
         html.to_s[/var \$render_data = \[(.*)\]\[0\]/m, 1]&.parse_json&.dig("status") || {}
       end
 
@@ -126,7 +126,7 @@ module Source
       # videos, since the mobile page doesn't return 1080p videos.
       memoize def post
         url = "https://www.weibo.com/ajax/statuses/show?id=#{illust_id}" if illust_id.present?
-        http.no_follow.cookies(SUB: sub_cookie).cache(1.minute).parsed_get(url) || {}
+        http.no_follow.cookies(SUB: sub_cookie).headers(Referer: "https://weibo.com/").cache(1.minute).parsed_get(url) || {}
       end
 
       # This `tid` value is tied to your IP and user agent.

--- a/test/unit/source/extractor/weibo_extractor_test.rb
+++ b/test/unit/source/extractor/weibo_extractor_test.rb
@@ -127,8 +127,12 @@ module Source::Tests::Extractor
         username: nil,
         tags: [],
         dtext_artist_commentary_title: "",
-        dtext_artist_commentary_desc: <<~EOS.chomp,
-          猜猜看誰被偷拍了？[嘻嘻][嘻嘻] "sandymandy的秒拍视频":[https://video.weibo.com/show?fid=1034:067e5f60923993c936abe48f1b0a11e2]
+        dtext_artist_commentary_desc: <<~EOS.chomp
+          猜猜看誰被偷拍了？"[嘻嘻]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8e/201810_xixi_mobile.png]
+          
+          "[嘻嘻]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8e/201810_xixi_mobile.png]
+          
+          "sandymandy的秒拍视频":[https://video.weibo.com/show?fid=1034:067e5f60923993c936abe48f1b0a11e2]
         EOS
       )
     end
@@ -165,8 +169,30 @@ module Source::Tests::Extractor
         username: nil,
         tags: [],
         dtext_artist_commentary_title: "",
-        dtext_artist_commentary_desc: <<~EOS.chomp,
-          诚邀首页欣赏艺术，美到要我命🆘🤯[舔屏][舔屏][舔屏][awsl][awsl][awsl][awsl][awsl][awsl][awsl][awsl][awsl]
+        dtext_artist_commentary_desc: <<~EOS.chomp
+          诚邀首页欣赏艺术，美到要我命🆘🤯"[舔屏]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/da/201810_tian_mobile.png]
+          
+          "[舔屏]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/da/201810_tian_mobile.png]
+          
+          "[舔屏]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/da/201810_tian_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
+          
+          "[awsl]":[https://face.t.sinajs.cn/t4/appstyle/expression/ext/normal/8b/moren_awsl_mobile.png]
         EOS
       )
     end


### PR DESCRIPTION
Turns out the `SUB` cookie is now required to get the status data in the mobile page URL, and the `/ajax/statuses/show` endpoint now requires a referer. Some commentaries also changed their formatting, so these were updated so the tests pass.