### PR TITLE
mode menu: include old post tag string in edit mode form

### DIFF
--- a/app/javascript/src/javascripts/post_mode_menu.js
+++ b/app/javascript/src/javascripts/post_mode_menu.js
@@ -78,8 +78,10 @@ PostModeMenu.initialize_edit_form = function() {
 
   $(document).on("click.danbooru", "#quick-edit-form input[type=submit]", async function(e) {
     e.preventDefault();
-    let post_id = $("#quick-edit-form").attr("data-post-id");
-    await Post.update(post_id, "quick-edit", { post: { tag_string: $("#post_tag_string").val() }});
+    const post_id = $("#quick-edit-form").attr("data-post-id");
+    const old_tag_string = $("#post_old_tag_string").val();
+    const tag_string = $("#post_tag_string").val();
+    await Post.update(post_id, "quick-edit", { post: { old_tag_string, tag_string } });
   });
 }
 
@@ -133,6 +135,7 @@ PostModeMenu.open_edit = function(post_id) {
   var $post = $("#post_" + post_id);
   $("#quick-edit-div").slideDown("fast");
   $("#quick-edit-form").attr("data-post-id", post_id);
+  $('#post_old_tag_string').val($post.data("tags"));
   $("#post_tag_string").val($post.data("tags") + " ").focus().selectEnd();
 }
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -101,6 +101,7 @@
     <h2>Edit</h2>
 
     <%= edit_form_for(:post, html: { id: "quick-edit-form" }) do |f| %>
+      <%= f.input :old_tag_string, as: :hidden %>
       <%= f.input :tag_string, label: "Tags", as: :text, input_html: { class: "text-sm", "data-autocomplete": "tag-edit" } %>
       <%= f.submit "Submit", data: { disable_with: false } %>
       <%= f.button :button, "Cancel", name: :cancel, type: :button %>

--- a/app/views/posts/update.js.erb
+++ b/app/views/posts/update.js.erb
@@ -1,7 +1,9 @@
 <% if @post.valid? %>
-  var postElement = $("#post_<%= @post.id %>").get(0);
+  var $postElement = $("#post_<%= @post.id %>");
+  var postElement = $postElement.get(0);
   var html = "<%= j post_preview(@post, fit: :compact, show_deleted: true, show_votes: @show_votes, size: @preview_size) %>";
   Alpine.morph(postElement, html);
+  $postElement.removeData();
   postElement.post.applyRules();
 
   <% if params[:mode] == "quick-edit" %>


### PR DESCRIPTION
Fixes the error where edit mode would completely overwrite existing tags if another edit occurred after the page load.