### PR TITLE
artists: make artist URLs hierarchical

### DIFF
--- a/app/logical/source/extractor.rb
+++ b/app/logical/source/extractor.rb
@@ -305,7 +305,7 @@ module Source
       Artist.new(
         name: tag_name,
         other_names: other_names,
-        url_string: profile_urls.join("\n")
+        url_string: profile_urls.join("\n+")
       )
     end
 

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -57,8 +57,11 @@
 
       <ul>
         <% artist.sorted_urls.each do |url| %>
-          <li>
-            <%= external_link_to url.url, external_site_icon(url.site_name, class: "h-4") %>
+          <li class="flex items-center">
+            <%= external_link_to url.url, external_site_icon(url.site_name, class: "h-4"), class: "mr-2" %>
+            <% if url.parent_id.present? -%>
+              <span class="nested-artist-icon text-muted select-none mr-1">↳</span>
+            <% end %>
             <% if url.is_active? %>
               <%= external_link_to url.url %>
             <% else %>

--- a/db/migrate/20251212190901_add_parent_id_to_artist_urls.rb
+++ b/db/migrate/20251212190901_add_parent_id_to_artist_urls.rb
@@ -1,0 +1,6 @@
+class AddParentIdToArtistURLs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :artist_urls, :parent_id, :integer
+    add_foreign_key :artist_urls, :artist_urls, column: :parent_id, deferrable: :deferred
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -256,7 +256,8 @@ CREATE TABLE public.artist_urls (
     url character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    is_active boolean DEFAULT true NOT NULL
+    is_active boolean DEFAULT true NOT NULL,
+    parent_id integer
 );
 
 
@@ -3342,7 +3343,6 @@ ALTER TABLE ONLY public.ip_bans
 
 ALTER TABLE ONLY public.ip_geolocations
     ADD CONSTRAINT ip_geolocations_pkey PRIMARY KEY (id);
-
 
 
 --
@@ -7083,6 +7083,14 @@ ALTER TABLE ONLY public.artist_versions
 
 
 --
+-- Name: artist_urls fk_rails_f3be4457e9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.artist_urls
+    ADD CONSTRAINT fk_rails_f3be4457e9 FOREIGN KEY (parent_id) REFERENCES public.artist_urls(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
 -- Name: post_votes fk_rails_f3edc07390; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7113,6 +7121,7 @@ ALTER TABLE ONLY public.user_upgrades
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251212190901'),
 ('20250720155738'),
 ('20250718142035'),
 ('20250716202530'),


### PR DESCRIPTION
Closes #5903. 

The "issue a warning on adding an unparented secondary URL" part is not implemented.
These changed will break clients that write `url_string` property. 