### PR TITLE
feat(patreon): support 'cw' URL format

### DIFF
--- a/app/logical/source/url/patreon.rb
+++ b/app/logical/source/url/patreon.rb
@@ -40,7 +40,8 @@ class Source::URL::Patreon < Source::URL
     # https://www.patreon.com/join/twistedgrim/checkout?rid=704013&redirect_uri=/posts/noi-dorohedoro-39394158
     # https://www.patreon.com/m/1041uuu/about
     # https://www.patreon.com/c/yaisirdrawz
-    in _, "patreon.com", ("checkout" | "join" | "m" | "c"), username, *rest unless username.in?(RESERVED_USERNAMES)
+    # https://www.patreon.com/cw/iwanokenta
+    in _, "patreon.com", ("checkout" | "join" | "m" | "c", "cw"), username, *rest unless username.in?(RESERVED_USERNAMES)
       @username = username
 
     # https://www.patreon.com/bePatron?u=4045578

--- a/app/logical/source/url/patreon.rb
+++ b/app/logical/source/url/patreon.rb
@@ -41,7 +41,7 @@ class Source::URL::Patreon < Source::URL
     # https://www.patreon.com/m/1041uuu/about
     # https://www.patreon.com/c/yaisirdrawz
     # https://www.patreon.com/cw/iwanokenta
-    in _, "patreon.com", ("checkout" | "join" | "m" | "c", "cw"), username, *rest unless username.in?(RESERVED_USERNAMES)
+    in _, "patreon.com", ("checkout" | "join" | "m" | "c" | "cw"), username, *rest unless username.in?(RESERVED_USERNAMES)
       @username = username
 
     # https://www.patreon.com/bePatron?u=4045578

--- a/test/unit/source/url/patreon_url_test.rb
+++ b/test/unit/source/url/patreon_url_test.rb
@@ -25,6 +25,7 @@ module Source::Tests::URL
           "https://www.patreon.com/user/posts?u=84592583",
           "https://www.patreon.com/api/user/4045578",
           "https://www.patreon.com/profile/creators?u=7422057",
+          "https://www.patreon.com/cw/iwanokenta",
         ],
       )
     end
@@ -35,6 +36,9 @@ module Source::Tests::URL
 
       url_parser_should_work("https://www.patreon.com/c/yaisirdrawz",
                              profile_url: "https://www.patreon.com/yaisirdrawz",)
+
+      url_parser_should_work("https://www.patreon.com/cw/iwanokenta",
+                             profile_url: "https://www.patreon.com/iwanokenta",)
     end
   end
 end


### PR DESCRIPTION
Currently, when a user adds a link such as `https://www.patreon.com/cw/iwanokenta`, it is processed as `https://www.patreon.com/cw`.