### PR TITLE
Forums/Comments: Add link to quoted object in reply

### DIFF
--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -450,12 +450,11 @@ class DText
 
   # Wrap a DText message in a [quote] block.
   #
-  # @param message [String] the DText to quote
-  # @param creator_name [String] the name of the user to quote.
+  # @param object [String] the object being quoted (a forum post, a comment, etc)
   # @return [String] the quoted DText
-  def quote(creator_name)
+  def quote(object)
     stripped_body = strip_blocks("quote")
-    "[quote]\n#{creator_name} said:\n\n#{stripped_body}\n[/quote]\n\n"
+    "[quote]\n#{object.creator.name} said in #{object.dtext_shortlink}:\n\n#{stripped_body}\n[/quote]\n\n"
   end
 
   # Remove all [<tag>] blocks from the DText.

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -122,7 +122,7 @@ class Comment < ApplicationRecord
   end
 
   def quoted_response
-    DText.new(body).quote(creator.name)
+    DText.new(body).quote(self)
   end
 
   def self.available_includes

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -159,7 +159,7 @@ class ForumPost < ApplicationRecord
   end
 
   def quoted_response
-    DText.new(body).quote(creator.name)
+    DText.new(body).quote(self)
   end
 
   def forum_topic_page
@@ -191,7 +191,7 @@ class ForumPost < ApplicationRecord
 
   def build_response
     dup.tap do |x|
-      x.body = x.quoted_response
+      x.body = quoted_response
     end
   end
 


### PR DESCRIPTION
Fixes #5260. Changes the format of replies so that a shortlink is added:

<img width="708" height="303" alt="image" src="https://github.com/user-attachments/assets/8473d214-7262-4016-a5a6-a8639505e880" />
<img width="696" height="343" alt="image" src="https://github.com/user-attachments/assets/38812d18-c7cd-45b1-817a-858837e19966" />
