### PR TITLE
Dmails: send the entire comment/forum post when a user is mentioned

### DIFF
--- a/app/logical/concerns/mentionable.rb
+++ b/app/logical/concerns/mentionable.rb
@@ -27,7 +27,7 @@ module Mentionable
   def queue_mention_messages
     message_field = self.class.mentionable_option(:message_field)
     return if !send(:saved_change_to_attribute?, message_field)
-    return if self.skip_mention_notifications
+    return if skip_mention_notifications
 
     text = send(message_field)
     text_was = send(:attribute_before_last_save, message_field)
@@ -37,8 +37,8 @@ module Mentionable
     users = users.without(CurrentUser.user)
 
     users.each do |user|
-      body  = self.instance_exec(user.name, &self.class.mentionable_option(:body))
-      title = self.instance_exec(user.name, &self.class.mentionable_option(:title))
+      body  = instance_exec(&self.class.mentionable_option(:body))
+      title = instance_exec(&self.class.mentionable_option(:title))
 
       Dmail.create_automated(to: user, title: title, body: body)
     end

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -719,14 +719,6 @@ class DText
     text.gsub(/(#{Regexp.union(SHORTLINKS - allowed_shortlinks)}) #(\d+)/i, '\1 &num;\2') # post #1234 -> post &num;1234
   end
 
-  # Return the first paragraph the search string `needle` occurs in.
-  #
-  # @param needle [String] the string to search for
-  # @return [String] the first paragraph mentioning the search string
-  def extract_mention(needle)
-    ActionController::Base.helpers.excerpt(dtext.gsub(/\r\n|\r|\n/, "\n"), needle, separator: "\n\n", radius: 1, omission: "")
-  end
-
   # Generate a short plain text excerpt from a DText string.
   #
   # @param length [Integer] the max length of the output

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -34,8 +34,16 @@ class Comment < ApplicationRecord
 
   mentionable(
     message_field: :body,
-    title: ->(_user_name) {"#{creator.name} mentioned you in a comment on post ##{post_id}"},
-    body: ->(user_name) {"@#{creator.name} mentioned you in comment ##{id} on post ##{post_id}:\n\n[quote]\n#{DText.new(body).extract_mention("@#{user_name}")}\n[/quote]\n"}
+    title: -> {"#{creator.name} mentioned you in a comment on post ##{post_id}"},
+    body: lambda {
+      <<~EOF
+        @#{creator.name} mentioned you in comment ##{id} on post ##{post_id}:
+
+        [quote]
+        #{body}
+        [/quote]
+      EOF
+    },
   )
 
   module SearchMethods

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -36,13 +36,13 @@ class ForumPost < ApplicationRecord
   has_dtext_links :body
   mentionable(
     message_field: :body,
-    title: ->(_user_name) {%{#{creator.name} mentioned you in topic ##{topic_id} (#{topic.title})}},
-    body: lambda { |user_name|
+    title: -> { "#{creator.name} mentioned you in topic ##{topic_id} (#{topic.title})}" },
+    body: lambda {
       <<~EOF
         @#{creator.name} mentioned you in forum ##{id} ("#{topic.title}":[#{Routes.forum_topic_path(topic, page: forum_topic_page)}]):
 
         [quote]
-        #{DText.new(body).extract_mention("@#{user_name}")}
+        #{body}
         [/quote]
       EOF
     },


### PR DESCRIPTION
The previous behavior was to send an excerpt, but this is confusing because it's not clear that it's an excerpt unless you go open the post/comment itself and compare it with the dmail.

This also makes it so that if you have email notifications you can read the whole post via email.

Fixes #5717.