### PR TITLE
Avoid clobbering commentary when fetching source data.

### DIFF
--- a/app/views/sources/show.js.erb
+++ b/app/views/sources/show.js.erb
@@ -5,7 +5,13 @@ Danbooru.RelatedTag.update_selected();
 
 if ($("#c-uploads #a-show").length) {
   Danbooru.Utility.alpineReady(() => {
-    $("#post_artist_commentary_original_title").val(<%= raw @source.dtext_artist_commentary_title.to_json %>);
-    $(".post_artist_commentary_original_description .dtext-editor").get(0).editor.dtext = <%= raw @source.dtext_artist_commentary_desc.to_json %>;
+    let $title = $("#post_artist_commentary_original_title");
+    let $description = $(".post_artist_commentary_original_description .dtext-editor").get(0);
+    if (!$title.val()) {
+      $title.val(<%= raw @source.dtext_artist_commentary_title.to_json %>);
+    }
+    if (!$description.editor.dtext) {
+      $description.editor.dtext = <%= raw @source.dtext_artist_commentary_desc.to_json %>;
+    }
   });
 }


### PR DESCRIPTION
Fixes #5516.

Potential caveat: if the commentary is fetched/inputted and you enter a different source to fetch again it won't be overwritten.