### PR TITLE
BURs: fix error if BUR creation failed

### DIFF
--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -12,7 +12,7 @@ class BulkUpdateRequestsController < ApplicationController
     @bulk_update_request = authorize BulkUpdateRequest.new(user: CurrentUser.user, **permitted_attributes(BulkUpdateRequest))
     @bulk_update_request.save
     if request.format.html?
-      respond_with(@bulk_update_request.forum_post || @bulk_update_request.forum_topic)
+      respond_with(@bulk_update_request.forum_post || @bulk_update_request.forum_topic || @bulk_update_request)
     else
       respond_with(@bulk_update_request)
     end


### PR DESCRIPTION
I tried to create a BUR in my test instance and got error:

> ArgumentError at /bulk_update_requests
> Nil location provided. Can't build URI.

It turns out the BUR creation failed (due to reasons like "Reason can't be blank"), but the page isn't returned correctly.

Seems to be introduced in d1634aeba007b89423ec4235a17b5bf220fb26b5. This fix works for me but correct me if I'm wrong.