### PR TITLE
Avoid double-quoting Time objects in HTML data attributes.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -372,7 +372,9 @@ module ApplicationHelper
         value = record[attr]
       end
 
-      if value.nil?
+      if value.is_a?(Time)
+        value = value.strftime("%Y-%m-%dT%H:%M:%S.%6N%:z")
+      elsif value.nil?
         value = "null"
       end
 


### PR DESCRIPTION
Call strftime on Time objects so that Rails doesn't call to_json on them, which causes them to have two sets of quotation marks. I used strftime instead of to_s or inspect, because to_s loses subsecond precision, and inspect can't be parsed automatically by JavaScript.

Old: `"2026-01-28T09:17:33.064+02:00"` (note the quotes)
New: `2026-01-28T09:17:33.064312+02:00`

Fixes #5005, but this is a breaking change for scripts that currently use the incorrectly double-quoted version.