### PR TITLE
Fix blacklisted post count on post page.

### DIFF
--- a/app/components/blacklist_component/blacklist_component.html.erb
+++ b/app/components/blacklist_component/blacklist_component.html.erb
@@ -11,7 +11,7 @@
       Blacklisted
     </label>
 
-    <span class="whitespace-nowrap post-count" x-text="blacklist.blacklistedPosts.length"></span>
+    <span class="whitespace-nowrap post-count" x-text="blacklist.blacklistedPostCount"></span>
     <span class="flex items-center flex-grow-1 justify-end gap-1">
       <%= render PopupMenuComponent.new do |menu| %>
         <% menu.with_item do %>
@@ -62,7 +62,7 @@
            x-show="rule.visible">
         <input type="checkbox" class="toggle-switch" x-model="rule.enabled">
         <%= link_to rule, posts_path(tags: rule), title: rule, class: "truncate", tabindex: "-1", "x-bind:class": "{ 'inactive-link': !rule.enabled }", "x-on:click.prevent": "rule.toggle()" %>
-        <span class="whitespace-nowrap post-count" x-text="rule.posts.size"></span>
+        <span class="whitespace-nowrap post-count" x-text="Alpine.raw(rule.posts).map(post => post.post.dataset.id).size"></span>
       </div>
     <% end %>
   <% end %>

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -98,6 +98,10 @@ class Blacklist {
     return this.posts.filter(post => post.blacklisted);
   }
 
+  get blacklistedPostCount() {
+    return new Set(this.blacklistedPosts.map(post => post.post.dataset.id)).size;
+  }
+
   // Remove from storage any rules that have been removed from the blacklist.
   cleanupStorage() {
     Cookie.remove("dab");


### PR DESCRIPTION
The post itself and the thumbnails in the parent/child bar are counted separately, so count unique post ids instead. I'm unsure about using `Alpine.raw` but `blacklist.posts` is a set which isn't compatible with Alpine's proxies, so calling `.map` on it throws an error. It worked in my testing, anyway.

Fixes #6085.