### PR TITLE
Modqueue: hide posts even on approval/disapproval fail

### DIFF
--- a/app/views/post_approvals/create.js.erb
+++ b/app/views/post_approvals/create.js.erb
@@ -1,5 +1,10 @@
 <% if @approval.errors.any? %>
-  Danbooru.Notice.error("Error: " + <%= @approval.errors.full_messages.join("; ").to_json.html_safe %>);
+  if ($("#c-modqueue").length) {
+    $("#post_<%= @approval.post.id %>").hide();
+    Danbooru.Notice.error("<%= j format_text("Error on post ##{@approval.post.id}: #{@approval.errors.full_messages.join("; ")}", inline: true) %>");
+  } else {
+    Danbooru.Notice.error("Error: " + <%= @approval.errors.full_messages.join("; ").to_json.html_safe %>);
+  }
 <% else %>
   if ($("#c-posts #a-show").length) {
     location.reload();

--- a/app/views/post_disapprovals/create.js.erb
+++ b/app/views/post_disapprovals/create.js.erb
@@ -1,5 +1,10 @@
 <% if @post_disapproval.errors.any? %>
-  Danbooru.Notice.error("Error: " + <%= @post_disapproval.errors.full_messages.join("; ").to_json.html_safe %>);
+  if ($("#c-modqueue").length) {
+    $("#post_<%= @post_disapproval.post.id %>").hide();
+    Danbooru.Notice.error("<%= j format_text("Error on post ##{@post_disapproval.post.id}: #{@post_disapproval.errors.full_messages.join("; ")}", inline: true) %>");
+  } else {
+    Danbooru.Notice.error("Error: " + <%= @post_disapproval.errors.full_messages.join("; ").to_json.html_safe %>);
+  }
 <% else %>
   if ($("#c-posts #a-show").length) {
     location.reload();


### PR DESCRIPTION
Fixes #5864, fixes #5689.

Worst case scenario if the error is a noop is that the post will be shown again on next refresh.