### PR TITLE
Fix #5358: Pool version listing doesn't show changes to pool category

### DIFF
--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -36,7 +36,7 @@ class PoolVersion < ApplicationRecord
     end
 
     def search(params, current_user)
-      q = search_attributes(params, [:id, :created_at, :updated_at, :pool_id, :post_ids, :added_post_ids, :removed_post_ids, :updater_id, :description, :description_changed, :name, :name_changed, :version, :is_active, :is_deleted, :category], current_user: current_user)
+      q = search_attributes(params, %i[id created_at updated_at pool_id post_ids added_post_ids removed_post_ids updater_id description description_changed name name_changed version is_active is_deleted category], current_user: current_user)
 
       if params[:post_id]
         q = q.for_post_id(params[:post_id].to_i)
@@ -110,6 +110,7 @@ class PoolVersion < ApplicationRecord
       posts_changed: "Posts",
       name: "Renamed",
       description: "Description",
+      category: "Category",
       was_deleted: "Deleted",
       was_undeleted: "Undeleted",
       was_activated: "Activated",

--- a/app/views/pool_versions/_listing.html.erb
+++ b/app/views/pool_versions/_listing.html.erb
@@ -5,7 +5,7 @@
         <%= link_to_if pool_version_show_diff(pool_version, params[:type]), "diff", diff_pool_version_path(pool_version.id) %>
       <% end %>
       <% t.column "Pool", td: {class: "diff-body"} do |pool_version| %>
-        <%= link_to pool_version.pretty_name, pool_path(pool_version.pool_id), class: "pool-category-#{pool_version.pool.category}" %>
+        <%= link_to pool_version.pretty_name, pool_path(pool_version.pool_id), class: "pool-category-#{pool_version.category}" %>
         <%= link_to "»", pool_versions_path(search: { pool_id: pool_version.pool_id }, anchor: "pool-version-#{pool_version.id}"), class: "pool-category-#{pool_version.pool.category}" %>
         <%= pool_version_name_diff(pool_version, params[:type]) %>
       <% end %>


### PR DESCRIPTION
I changed the pool version listing to color the pool name based on the version's catgory instead of the pool's category to differentiate.

Fixes #5358.