### PR TITLE
Fix #5716: one-hour drawing challenge tag not suggested in TL tags

### DIFF
--- a/app/logical/source/extractor.rb
+++ b/app/logical/source/extractor.rb
@@ -324,11 +324,7 @@ module Source
     end
 
     def normalized_tags
-      tags.map { |tag, _url| normalize_tag(tag) }.sort.uniq
-    end
-
-    def normalize_tag(tag)
-      WikiPage.normalize_other_name(tag).downcase
+      tags.flat_map { |tag, _url| TagNormalizer.normalize(tag) }.sort.uniq
     end
 
     def translated_tags

--- a/app/logical/source/extractor/newgrounds.rb
+++ b/app/logical/source/extractor/newgrounds.rb
@@ -62,9 +62,8 @@ module Source
         end
       end
 
-      def normalize_tag(tag)
-        tag = tag.tr("-", "_")
-        super(tag)
+      def normalized_tags
+        super.map { [it, it.tr("-", "_")] }.flatten.uniq
       end
 
       def display_name

--- a/app/logical/source/extractor/pixiv.rb
+++ b/app/logical/source/extractor/pixiv.rb
@@ -181,10 +181,6 @@ module Source
         tags
       end
 
-      def normalize_tag(tag)
-        tag.gsub(/\d+users入り\z/i, "")
-      end
-
       def download_file!(url)
         url = Source::URL.parse(url)
 

--- a/app/logical/source/extractor/tumblr.rb
+++ b/app/logical/source/extractor/tumblr.rb
@@ -89,11 +89,6 @@ class Source::Extractor
       end.uniq
     end
 
-    def normalize_tag(tag)
-      tag = tag.tr("-", "_")
-      super(tag)
-    end
-
     # The commentary with reblogs presented as a linear list of quotes, rather than as nested quotes.
     def linear_artist_commentary_desc
       return artist_commentary_desc if post[:trail].blank?

--- a/app/logical/source/extractor/twitter.rb
+++ b/app/logical/source/extractor/twitter.rb
@@ -7,22 +7,6 @@ class Source::Extractor
       SiteCredential.for_site("Twitter").present?
     end
 
-    # List of hashtag suffixes attached to tag other names
-    # Ex: 西住みほ生誕祭2019 should be checked as 西住みほ
-    # The regexes will not match if there is nothing preceding
-    # the pattern to avoid creating empty strings.
-    COMMON_TAG_REGEXES = [
-      /(?<!\A)生誕祭(?:\d*)\z/,
-      /(?<!\A)誕生祭(?:\d*)\z/,
-      /(?<!\A)版もうひとつの深夜の真剣お絵描き60分一本勝負(?:_\d+)?\z/,
-      /(?<!\A)版深夜の真剣お絵描き60分一本勝負(?:_\d+)?\z/,
-      /(?<!\A)版深夜の真剣お絵かき60分一本勝負(?:_\d+)?\z/,
-      /(?<!\A)深夜の真剣お絵描き60分一本勝負(?:_\d+)?\z/,
-      /(?<!\A)版深夜のお絵描き60分一本勝負(?:_\d+)?\z/,
-      /(?<!\A)版真剣お絵描き60分一本勝(?:_\d+)?\z/,
-      /(?<!\A)版お絵描き60分一本勝負(?:_\d+)?\z/,
-    ]
-
     def image_urls
       # https://pbs.twimg.com/media/EBGbJe_U8AA4Ekb.jpg:orig
       if parsed_url.full_image_url.present?
@@ -94,16 +78,6 @@ class Source::Extractor
       graphql_tweet.dig(:legacy, :entities, :hashtags).to_a.map do |hashtag|
         [hashtag[:text], "https://x.com/hashtag/#{hashtag[:text]}"]
       end
-    end
-
-    def normalize_tag(tag)
-      COMMON_TAG_REGEXES.each do |rg|
-        norm_tag = tag.gsub(rg, "")
-        if norm_tag != tag
-          return norm_tag
-        end
-      end
-      tag
     end
 
     def dtext_artist_commentary_desc

--- a/app/logical/tag_normalizer.rb
+++ b/app/logical/tag_normalizer.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module TagNormalizer
+  module_function
+
+  # List of tag suffixes attached to tag other names
+  # Ex: 西住みほ生誕祭2019 should be checked as 西住みほ
+  # The regexes will not match if there is nothing preceding
+  # the pattern to avoid creating empty strings.
+  COMMON_TAG_REGEXES = [
+    /(?<!\A)(生誕祭)(?:\d*)\z/,
+    /(?<!\A)(誕生祭)(?:\d*)\z/,
+    /(?<!\A)(版もうひとつの深夜の真剣お絵描き60分一本勝負)(?:_\d+)?\z/,
+    /(?<!\A)(版深夜の真剣お絵描き60分一本勝負)(?:_\d+)?\z/,
+    /(?<!\A)(版深夜の真剣お絵かき60分一本勝負)(?:_\d+)?\z/,
+    /(?<!\A)(深夜の真剣お絵描き60分一本勝負)(?:_\d+)?\z/,
+    /(?<!\A)(版深夜のお絵描き60分一本勝負)(?:_\d+)?\z/,
+    /(?<!\A)(版真剣お絵描き60分一本勝)(?:_\d+)?\z/,
+    /(?<!\A)(版お絵描き60分一本勝負)(?:_\d+)?\z/,
+  ]
+
+  # List of extra terms to strip from the tag.
+  STRIP_TAG_REGEXES = [
+    /\d+users入り\z/i,
+  ]
+
+  # Converts to tag into its canonical representation(s). Extractors may override this if
+  # their site uses unusual conventions, such as Twitter's "one-hour drawing challenge" tags
+  # counting as both "one-hour drawing challenge" and the respective copyright.
+  #
+  # @returns {Array<String>}
+  def normalize(tag)
+    tag = WikiPage.normalize_other_name(tag).downcase
+    tag = tag.gsub(Regexp.union(STRIP_TAG_REGEXES), "")
+    [
+      tag,
+      *tag.split(Regexp.union(COMMON_TAG_REGEXES)),
+    ].sort.uniq
+  end
+end

--- a/test/unit/source/extractor/twitter_extractor_test.rb
+++ b/test/unit/source/extractor/twitter_extractor_test.rb
@@ -506,7 +506,7 @@ module Source::Tests::Extractor
       strategy_should_work(
         "https://twitter.com/kasaishin100/status/1186658635226607616",
         tags: ["西住みほ生誕祭2019"],
-        normalized_tags: ["西住みほ"],
+        normalized_tags: ["生誕祭", "西住みほ", "西住みほ生誕祭2019"],
         dtext_artist_commentary_desc: <<~EOS.chomp,
           みぽりん誕生日おめでとうございます！！🎂
           ボコボコ探検隊🙌✨

--- a/test/unit/tag_normalizer_test.rb
+++ b/test/unit/tag_normalizer_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class TagNormalizerTest < ActiveSupport::TestCase
+  def assert_normalizes(terms, tag)
+    assert_equal(terms.sort, TagNormalizer.normalize(tag))
+  end
+
+  context "normalize_tag" do
+    should "work" do
+      assert_normalizes(["アークナイツ", "版深夜の真剣お絵かき60分一本勝負", "アークナイツ版深夜の真剣お絵かき60分一本勝負"], "アークナイツ版深夜の真剣お絵かき60分一本勝負")
+      assert_normalizes(["アークナイツ"], "アークナイツ10000users入り")
+      assert_normalizes(["アークナイツ"], "アークナイツ")
+    end
+  end
+end


### PR DESCRIPTION
The Twitter extractor's normalize_tag function will now try to match the full tag, the common suffix, and the base tag, instead of just the base tag. For example, in `アークナイツ版深夜の真剣お絵かき60分一本勝負`, it will match `アークナイツ`, `版深夜の真剣お絵かき60分一本勝負`, and `アークナイツ版深夜の真剣お絵かき60分一本勝負`. The base extractor's normalize_tags function was changed to use flat_map to allow this.

Fixes #5716.