### PR TITLE
Fix some tests.

### DIFF
--- a/app/logical/source/extractor/gelbooru.rb
+++ b/app/logical/source/extractor/gelbooru.rb
@@ -12,6 +12,10 @@
 module Source
   class Extractor
     class Gelbooru < Source::Extractor
+      def self.enabled?
+        SiteCredential.for_site("Gelbooru").present?
+      end
+
       delegate :artist_name, :profile_url, :display_name, :username, :tag_name, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
 
       def image_urls

--- a/app/logical/source/extractor/gumroad.rb
+++ b/app/logical/source/extractor/gumroad.rb
@@ -11,6 +11,8 @@ class Source::Extractor
       elsif artist_commentary_desc.present? # post
         urls = artist_commentary_desc.to_s.parse_html.css("img").pluck("src")
         urls.select { |url| Source::URL::Gumroad.parse(url)&.image_url? }
+      else
+        []
       end
     end
 

--- a/app/logical/source/extractor/newgrounds.rb
+++ b/app/logical/source/extractor/newgrounds.rb
@@ -4,6 +4,10 @@
 module Source
   class Extractor
     class Newgrounds < Source::Extractor
+      def self.enabled?
+        SiteCredential.for_site("Newgrounds").present?
+      end
+
       def image_urls
         if parsed_url.full_image_url.present?
           [parsed_url.full_image_url]

--- a/app/logical/source/extractor/twitter.rb
+++ b/app/logical/source/extractor/twitter.rb
@@ -3,6 +3,10 @@
 # @see Source::URL::Twitter
 class Source::Extractor
   class Twitter < Source::Extractor
+    def self.enabled?
+      SiteCredential.for_site("Twitter").present?
+    end
+
     # List of hashtag suffixes attached to tag other names
     # Ex: 西住みほ生誕祭2019 should be checked as 西住みほ
     # The regexes will not match if there is nothing preceding

--- a/test/functional/post_versions_controller_test.rb
+++ b/test/functional/post_versions_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class PostVersionsControllerTest < ActionDispatch::IntegrationTest
   setup do

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -899,7 +899,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
         assert_post_source_equals("https://i.pximg.net/img-original/img/2017/08/18/00/09/21/64476642_p0.jpg", "https://i.pximg.net/img-original/img/2017/08/18/00/09/21/64476642_p0.jpg", "https://www.pixiv.net/en/artworks/64476642")
 
         assert_post_source_equals("https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig", "https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig")
-        assert_post_source_equals("https://twitter.com/noizave/status/875768175136317440", "https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig", "https://twitter.com/noizave/status/875768175136317440")
+        assert_post_source_equals("https://twitter.com/noizave/status/875768175136317440", "https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig", "https://x.com/noizave/status/875768175136317440")
 
         assert_post_source_equals("https://noizave.tumblr.com/post/162206271767", "https://media.tumblr.com/3bbfcbf075ddf969c996641b264086fd/tumblr_os2buiIOt51wsfqepo1_1280.png")
 

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -146,7 +146,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "not allow approvers without 2FA to login from a proxy" do
         user = create(:approver_user, password: "password")
-        ActionDispatch::Request.any_instance.stubs(:remote_ip).returns("1.1.1.1")
+        Danbooru::IpAddress.any_instance.stubs(:is_proxy?).returns(true)
 
         post session_path, params: { session: { name: user.name, password: "password" } }
 
@@ -158,7 +158,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "not allow inactive accounts without 2FA to login from a proxy" do
         user = create(:user, password: "password", last_logged_in_at: 1.year.ago)
-        ActionDispatch::Request.any_instance.stubs(:remote_ip).returns("1.1.1.1")
+        Danbooru::IpAddress.any_instance.stubs(:is_proxy?).returns(true)
 
         post session_path, params: { session: { name: user.name, password: "password" } }
 
@@ -170,7 +170,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "allow approvers with 2FA enabled to login from a proxy" do
         user = create(:user_with_2fa, password: "password", level: User::Levels::APPROVER)
-        ActionDispatch::Request.any_instance.stubs(:remote_ip).returns("1.1.1.1")
+        Danbooru::IpAddress.any_instance.stubs(:is_proxy?).returns(true)
 
         post session_path, params: { session: { name: user.name, password: "password" } }
 

--- a/test/test_helpers/upload_test_helper.rb
+++ b/test/test_helpers/upload_test_helper.rb
@@ -3,6 +3,7 @@ module UploadTestHelper
 
   def create_upload!(source_or_file_path, user:, **params)
     if source_or_file_path =~ %r{\Ahttps?://}i
+      skip "Skipping extractor tests as configured by the environment." if ENV["DANBOORU_SKIP_EXTRACTOR_TESTS"].to_s.truthy?
       skip "Login credentials not configured for #{source_or_file_path}" unless Source::Extractor.find(source_or_file_path).class.enabled?
       source = { source: source_or_file_path }
     else

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -164,10 +164,10 @@ class ArtistTest < ActiveSupport::TestCase
     end
 
     should "normalize urls before removing duplicates" do
-      @artist = create(:artist, url_string: "https://Twitter.com/o8q https://twitter.com/o8q")
+      @artist = create(:artist, url_string: "https://X.com/o8q https://x.com/o8q")
 
       assert_equal(1, @artist.urls.count)
-      assert_equal(["https://twitter.com/o8q"], @artist.urls.map(&:to_s))
+      assert_equal(["https://x.com/o8q"], @artist.urls.map(&:to_s))
     end
 
     should "ignore pixiv.net/ and pixiv.net/img/ url matches" do
@@ -370,6 +370,7 @@ class ArtistTest < ActiveSupport::TestCase
       end
 
       should "return nothing for unknown nijie artists" do
+        skip "Nijie credentials not configured" unless Source::Extractor::Nijie.enabled?
         assert_artist_not_found("http://nijie.info/view.php?id=157953")
       end
     end

--- a/test/unit/d_text_test.rb
+++ b/test/unit/d_text_test.rb
@@ -295,7 +295,7 @@ class DTextTest < ActiveSupport::TestCase
         assert_equal('foo" bar baz ":[http://google.com]quux', DText.from_html('foo<a href="http://google.com">  bar  baz  </a>quux'))
       end
 
-      should "ignore <script> tags" do
+      should "ignore script tags" do
         assert_equal("", DText.from_html("<script>alert('lol')</script>"))
       end
 
@@ -323,7 +323,7 @@ class DTextTest < ActiveSupport::TestCase
         assert_equal("", DText.from_html("<h4><br></h4>"))
       end
 
-      should "convert <hr> tags to [hr] tags" do
+      should "convert hr tags to [hr] tags" do
         assert_equal("foo\n\n[hr]\n\nbar", DText.from_html("<p>foo</p><hr><p>bar</p>"))
       end
 

--- a/test/unit/danbooru_http_test.rb
+++ b/test/unit/danbooru_http_test.rb
@@ -239,7 +239,7 @@ class DanbooruHttpTest < ActiveSupport::TestCase
 
     context "unpolish cloudflare feature" do
       should "return the original image for polished images" do
-        skip if ENV["CI"].present?
+        skip if ENV["DANBOORU_SKIP_EXTRACTOR_TESTS"].present?
 
         url = "https://cdnb.artstation.com/p/assets/images/images/025/273/307/4k/atey-ghailan-a-sage-keyart-s-ch-04-outlined-1.jpg?1585246642"
         response = Danbooru::Http.use(:unpolish_cloudflare).get(url)

--- a/test/unit/source/extractor/weibo_extractor_test.rb
+++ b/test/unit/source/extractor/weibo_extractor_test.rb
@@ -2,11 +2,6 @@ require "test_helper"
 
 module Source::Tests::Extractor
   class WeiboExtractorTest < ActiveSupport::ExtractorTestCase
-    setup do
-      # Skip in CI to work around test failures due to rate limiting by Weibo.
-      skip if ENV["CI"].present?
-    end
-
     context "A Weibo post with multiple pictures" do
       strategy_should_work(
         "https://www.weibo.com/5501756072/J2UNKfbqV?type=comment#_rnd1590548401855",

--- a/test/unit/tag_alias_test.rb
+++ b/test/unit/tag_alias_test.rb
@@ -265,8 +265,8 @@ class TagAliasTest < ActiveSupport::TestCase
 
       should "merge existing artists if there is a conflict" do
         @tag = create(:tag, name: "aaa", category: Tag.categories.artist)
-        @artist1 = create(:artist, name: "aaa", group_name: "g_aaa", other_names: "111 222", url_string: "https://twitter.com/111\n-https://twitter.com/222")
-        @artist2 = create(:artist, name: "bbb", other_names: "111 333", url_string: "https://twitter.com/111\n-https://twitter.com/333\nhttps://twitter.com/444")
+        @artist1 = create(:artist, name: "aaa", group_name: "g_aaa", other_names: "111 222", url_string: "https://x.com/111\n-https://x.com/222")
+        @artist2 = create(:artist, name: "bbb", other_names: "111 333", url_string: "https://x.com/111\n-https://x.com/333\nhttps://x.com/444")
 
         TagAlias.approve!(antecedent_name: "aaa", consequent_name: "bbb", approver: @admin)
 
@@ -278,7 +278,7 @@ class TagAliasTest < ActiveSupport::TestCase
         assert_equal(false, @artist2.reload.is_deleted)
         assert_equal(%w[111 333 222 aaa], @artist2.other_names)
         assert_equal("g_aaa", @artist2.group_name)
-        assert_equal(%w[-https://twitter.com/222 -https://twitter.com/333 https://twitter.com/111 https://twitter.com/444], @artist2.url_array)
+        assert_equal(%w[-https://x.com/222 -https://x.com/333 https://x.com/111 https://x.com/444], @artist2.url_array)
       end
 
       should "move the is_banned flag from the old artist entry to the new artist entry" do
@@ -292,20 +292,20 @@ class TagAliasTest < ActiveSupport::TestCase
       end
 
       should "ignore the old artist if it has been deleted" do
-        @artist1 = create(:artist, name: "aaa", group_name: "g_aaa", other_names: "111 222", url_string: "https://twitter.com/111\n-https://twitter.com/222", is_deleted: true)
-        @artist2 = create(:artist, name: "bbb", other_names: "111 333", url_string: "https://twitter.com/111\n-https://twitter.com/333\nhttps://twitter.com/444")
+        @artist1 = create(:artist, name: "aaa", group_name: "g_aaa", other_names: "111 222", url_string: "https://x.com/111\n-https://x.com/222", is_deleted: true)
+        @artist2 = create(:artist, name: "bbb", other_names: "111 333", url_string: "https://x.com/111\n-https://x.com/333\nhttps://x.com/444")
 
         TagAlias.approve!(antecedent_name: "aaa", consequent_name: "bbb", approver: @admin)
 
         assert_equal(true, @artist1.reload.is_deleted)
         assert_equal(%w[111 222], @artist1.other_names)
         assert_equal("g_aaa", @artist1.group_name)
-        assert_equal(%w[-https://twitter.com/222 https://twitter.com/111], @artist1.url_array)
+        assert_equal(%w[-https://x.com/222 https://x.com/111], @artist1.url_array)
 
         assert_equal(false, @artist2.reload.is_deleted)
         assert_equal(%w[111 333], @artist2.other_names)
         assert_equal("", @artist2.group_name)
-        assert_equal(%w[-https://twitter.com/333 https://twitter.com/111 https://twitter.com/444], @artist2.url_array)
+        assert_equal(%w[-https://x.com/333 https://x.com/111 https://x.com/444], @artist2.url_array)
       end
     end
 


### PR DESCRIPTION
The <script> and &lt;hr&gt; tags in the DText test's descriptions broke the HTML output because they didn't get escaped.