### PR TITLE
Fix #6156: Support relative dates in created_at/updated_at parameters…

### DIFF
--- a/app/logical/concerns/searchable.rb
+++ b/app/logical/concerns/searchable.rb
@@ -369,7 +369,16 @@ module Searchable
       relation = self.relation
 
       if params[key].present?
-        relation = visible(relation, attr).where_numeric_matches(attr, params[key], type)
+        if type == :datetime
+          # Try to parse dates as relative (like <1w) first,
+          # and it that fails then try again as date strings.
+          relation = visible(relation, attr).where_numeric_matches(attr, params[key], :age)
+          if relation.none?
+            relation = visible(self.relation, attr).where_numeric_matches(attr, params[key], type)
+          end
+        else
+          relation = visible(relation, attr).where_numeric_matches(attr, params[key], type)
+        end
       end
 
       if params[:"#{key}_not"].present?

--- a/test/unit/concerns/searchable_test.rb
+++ b/test/unit/concerns/searchable_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class SearchableTest < ActiveSupport::TestCase
   context "#search method" do
@@ -338,6 +338,27 @@ class SearchableTest < ActiveSupport::TestCase
         @ai_tag2 = create(:ai_tag)
 
         assert_search_equals([@ai_tag1], post: { id: @post.id })
+      end
+    end
+
+    context "timestamps" do
+      should "work with relative times" do
+        freeze_time do
+          @post = create(:post, last_comment_bumped_at: 35.hours.ago)
+
+          assert_search_equals([@post], last_comment_bumped_at: "1d..2d")
+          assert_search_equals([@post], last_comment_bumped_at: "<1w")
+          assert_search_equals([], last_comment_bumped_at: ">3d")
+        end
+      end
+
+      should "work with absolute times" do
+        @post = create(:post, last_comment_bumped_at: "2026-02-01T01:23:45Z")
+
+        assert_search_equals([@post], last_comment_bumped_at: "..2026-02-03T00:00:00Z")
+        assert_search_equals([@post], last_comment_bumped_at: "2026-02-01T00:00:00Z..2026-02-02T00:00:00Z")
+        assert_search_equals([@post], last_comment_bumped_at: ">2026-02-01T00:00:00Z")
+        assert_search_equals([], last_comment_bumped_at: "<2026-02-01T00:00:00Z")
       end
     end
   end


### PR DESCRIPTION
… sitewide

Fixes #6156.