### PR TITLE
Fix #6203: Deleted Forum Posts are Viewable Through the API

### DIFF
--- a/app/components/forum_post_component.rb
+++ b/app/components/forum_post_component.rb
@@ -28,7 +28,7 @@ class ForumPostComponent < ApplicationComponent
   end
 
   def render?
-    policy(forum_post).show_deleted?
+    !forum_post.is_deleted? || policy(forum_post).show_deleted?
   end
 
   def reported?

--- a/app/controllers/dtext_links_controller.rb
+++ b/app/controllers/dtext_links_controller.rb
@@ -4,7 +4,7 @@ class DtextLinksController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @dtext_links = authorize DtextLink.paginated_search(params)
+    @dtext_links = authorize DtextLink.visible(CurrentUser.user).paginated_search(params)
     @dtext_links = @dtext_links.includes(linked_wiki: :tag, model: :tag) if request.format.html?
 
     respond_with(@dtext_links)

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -50,11 +50,15 @@ class ForumPost < ApplicationRecord
 
   module SearchMethods
     def visible(user)
-      where(topic_id: ForumTopic.visible(user))
+      if policy(user).show_deleted?
+        where(topic_id: ForumTopic.visible(user))
+      else
+        undeleted.where(topic_id: ForumTopic.visible(user))
+      end
     end
 
     def not_visible(user)
-      where.not(topic_id: ForumTopic.visible(user))
+      visible(user).invert_where
     end
 
     def wiki_link_matches(title)

--- a/app/policies/forum_post_policy.rb
+++ b/app/policies/forum_post_policy.rb
@@ -6,7 +6,7 @@ class ForumPostPolicy < ApplicationPolicy
   end
 
   def show?
-    policy(record.topic).show?
+    policy(record.topic).show? && (!record.is_deleted? || show_deleted?)
   end
 
   def create?
@@ -38,7 +38,7 @@ class ForumPostPolicy < ApplicationPolicy
   end
 
   def show_deleted?
-    !record.is_deleted? || user.is_moderator?
+    user.is_moderator?
   end
 
   def can_see_updater_notice?

--- a/test/.rubocop.yml
+++ b/test/.rubocop.yml
@@ -3,3 +3,5 @@ inherit_from:
 
 Metrics/ClassLength:
   Enabled: false
+Lint/AmbiguousBlockAssociation:
+  Enabled: false

--- a/test/functional/dtext_links_controller_test.rb
+++ b/test/functional/dtext_links_controller_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class DtextLinksControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user)
+    @mod = create(:mod_user)
+    @secret_forum = create(:forum_post, topic: build(:forum_topic, title: "mod thread", min_level: 40), body: "[[hidden link]]")
     as(@user) do
       @wiki = create(:wiki_page, title: "case", body: "[[test]]")
       @forum = create(:forum_post, topic: build(:forum_topic, title: "blah"), body: "[[case]]")
@@ -18,6 +20,7 @@ class DtextLinksControllerTest < ActionDispatch::IntegrationTest
     end
 
     should respond_to_search({}).with { @pool.dtext_links + @forum.dtext_links + @wiki.dtext_links }
+    should respond_to_search(ForumPost: { topic: { min_level: 40 } }).with { [] }
 
     context "using includes" do
       should respond_to_search(model_type: "WikiPage").with { @wiki.dtext_links }
@@ -28,5 +31,13 @@ class DtextLinksControllerTest < ActionDispatch::IntegrationTest
       should respond_to_search(ForumPost: {topic: {title_matches: "blah"}}).with { @forum.dtext_links }
       should respond_to_search(ForumPost: {topic: {title_matches: "nah"}}).with { [] }
     end
+  end
+
+  context "as a mod" do
+    setup do
+      CurrentUser.user = create(:mod_user)
+    end
+
+    should respond_to_search(ForumPost: { topic: { min_level: 40 } }).with { @secret_forum.dtext_links }
   end
 end

--- a/test/functional/forum_posts_controller_test.rb
+++ b/test/functional/forum_posts_controller_test.rb
@@ -74,10 +74,10 @@ class ForumPostsControllerTest < ActionDispatch::IntegrationTest
           assert_response :success
         end
 
-        should respond_to_search({}).with { [@bur_forum, @unrelated_forum, @linked_forum, @forum_post] }
+        should respond_to_search({}).with { [@bur_forum, @linked_forum, @forum_post] }
         should respond_to_search(body_matches: "xxx").with { @forum_post }
         should respond_to_search(body_matches: "bababa").with { [] }
-        should respond_to_search(is_deleted: "true").with { @unrelated_forum }
+        should respond_to_search(is_deleted: "true").with { [] }
         should respond_to_search(linked_to: "yyy").with { [@bur_forum, @linked_forum] }
 
         context "using includes" do
@@ -131,6 +131,13 @@ class ForumPostsControllerTest < ActionDispatch::IntegrationTest
       should "redirect to the forum topic" do
         get forum_post_path(@forum_post)
         assert_redirected_to forum_topic_path(@forum_post.topic, anchor: "forum_post_#{@forum_post.id}")
+      end
+
+      should "not allow viewing deleted posts" do
+        deleted_forum_post = create(:forum_post, is_deleted: true)
+        get_auth forum_post_path(deleted_forum_post), @user
+
+        assert_response 403
       end
     end
 


### PR DESCRIPTION
Fixes #6203. Also fixes #6220 which I ran into whilst testing this.