### PR TITLE
Add icon to dtext search links.

### DIFF
--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -118,6 +118,17 @@
     background-color: currentcolor;
   }
 
+  a.dtext-post-search-link::after {
+    content: "";
+    padding: 0 0.275em;
+    margin: 0 0.125rem;
+    // https://fontawesome.com/icons/magnifying-glass?f=classic&s=solid
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M480 272C480 317.9 465.1 360.3 440 394.7L566.6 521.4C579.1 533.9 579.1 554.2 566.6 566.7C554.1 579.2 533.8 579.2 521.3 566.7L394.7 440C360.3 465.1 317.9 480 272 480C157.1 480 64 386.9 64 272C64 157.1 157.1 64 272 64C386.9 64 480 157.1 480 272zM272 416C351.5 416 416 351.5 416 272C416 192.5 351.5 128 272 128C192.5 128 128 192.5 128 272C128 351.5 192.5 416 272 416z'%3E%3C/path%3E%3C/svg%3E");
+    mask-repeat: no-repeat;
+    mask-position: center;
+    background-color: currentColor;
+  }
+
   a.dtext-wiki-does-not-exist, a.dtext-tag-does-not-exist, a.dtext-artist-does-not-exist {
     text-decoration: dotted underline;
   }


### PR DESCRIPTION
People requested differentiation between dtext searches `{{tag}}` and wiki links `[[tag]]`. This commit adds a magnifying glass icon similar to the current external link to search links.
<img width="244" height="29" alt="image" src="https://github.com/user-attachments/assets/5fc75ee7-0833-40b6-b850-b6dadb2a37ae" />

I worry it would confuse people into thinking it's a Google link or something but I guess it's worth a shot.