### PR TITLE
Fix #5976: Make upload page more intuitive towards URL uploads

### DIFF
--- a/app/components/file_upload_component.rb
+++ b/app/components/file_upload_component.rb
@@ -4,7 +4,7 @@
 class FileUploadComponent < ApplicationComponent
   attr_reader :url, :referer_url, :drop_target, :max_file_size, :max_files_per_upload
 
-  delegate :simple_form_for, to: :helpers
+  delegate :simple_form_for, :link_to_wiki, to: :helpers
 
   # @param url [String] Optional. The URL to upload. If present, the URL field
   #   will be prefilled in the widget and the upload will be immediately triggered.

--- a/app/components/file_upload_component/file_upload_component.html.erb
+++ b/app/components/file_upload_component/file_upload_component.html.erb
@@ -2,18 +2,25 @@
   <%= simple_form_for(Upload.new, url: uploads_path(format: :json), html: { class: "flex flex-col !m-0", autocomplete: "off" }, remote: true) do |f| %>
     <%= f.input :files, as: :file, wrapper_html: { class: "hidden" }, input_html: { "multiple": max_files_per_upload > 1 }  %>
 
-    <div class="dropzone-container relative input text-center rounded-t-lg cursor-pointer p-4 max-h-360px thin-scrollbar">
-      <div class="dropzone-hint py-4">
-        <div>Choose file or drag image here</div>
-        <div class="hint fineprint">Max size: <%= number_to_human_size(Danbooru.config.max_file_size) %>.</div>
-      </div>
+    <div class="rounded-t-lg p-4 pb-8 max-h-360px thin-scrollbar source">
+      <label id="source-label" class="w-full text-center mb-1 block !font-normal">Paste URL here</label>
+      <%= f.input :source, label: false, as: :string, placeholder: "Paste a pixiv link, Tweet, etc", input_html: { value: url, class: "text-center bg:card" }, wrapper_html: { class: "px-4 text-center !m-0" } %>
+      <span class="hint text-muted text-xs text-center w-full block mt-1">
+        <%= link_to_wiki "See here", "help:bookmarklet_notice" %> for a list of supported sites.
+      </span>
+      <%= f.input :referer_url, as: :hidden, input_html: { value: referer_url } %>
+      <%= f.submit "Upload", class: "button-primary text-center mx-auto hidden", "data-disable-with": false %>
     </div>
 
-    <p class="text-center">&mdash; or &mdash;</p>
 
-    <%= f.input :source, label: false, as: :string, placeholder: "Paste URL here", input_html: { value: url, class: "text-center" }, wrapper_html: { class: "px-4 text-center" } %>
-    <%= f.input :referer_url, as: :hidden, input_html: { value: referer_url } %>
-    <%= f.submit "Upload", class: "button-primary text-center mx-auto hidden", "data-disable-with": false %>
+    <div class="dropzone-container relative input text-center rounded-t-lg cursor-pointer p-4 pt-2 max-h-360px thin-scrollbar !m-0">
+      <p class="text-center mb-2">&mdash; or &mdash;</p>
+
+      <div class="dropzone-hint">
+        <div>Choose file or drag image here</div>
+        <div class="hint fineprint !p-0">Max size: <%= number_to_human_size(Danbooru.config.max_file_size) %>.</div>
+      </div>
+    </div>
   <% end %>
 
   <%= spinner_icon(class: "hidden absolute inset-0 m-auto h-12 link-color") %>

--- a/app/components/file_upload_component/file_upload_component.scss
+++ b/app/components/file_upload_component/file_upload_component.scss
@@ -1,7 +1,9 @@
 .file-upload-component {
-  .dropzone-container {
+  div.source {
     background: var(--uploads-dropzone-background);
+  }
 
+  .dropzone-container {
     &.error {
       background: var(--error-background-color);
     }

--- a/app/javascript/src/styles/common/utilities.scss
+++ b/app/javascript/src/styles/common/utilities.scss
@@ -12,6 +12,7 @@ $spacer: 0.25rem; /* 4px */
 .font-monospace { font-family: var(--monospace-font); }
 .font-header { font-family: var(--header-font); }
 .font-normal { font-weight: normal; }
+.\!font-normal { font-weight: normal !important; }
 .font-bold { font-weight: bold; }
 .font-italic { font-style: italic; }
 
@@ -176,6 +177,7 @@ $spacer: 0.25rem; /* 4px */
 .mr-4  { margin-right: 4 * $spacer; }
 
 .p-0    { padding: 0; }
+.\!p-0  { padding: 0 !important; }
 .p-px   { padding: 1px; }
 .p-0\.5 { padding: 0.5 * $spacer; }
 .p-1  { padding: 1 * $spacer; }
@@ -196,6 +198,7 @@ $spacer: 0.25rem; /* 4px */
 .py-4 { padding-top: 4 * $spacer; padding-bottom: 4 * $spacer; }
 .py-8 { padding-top: 8 * $spacer; padding-bottom: 8 * $spacer; }
 
+.pt-2 { padding-top: 2 * $spacer; }
 .pt-4 { padding-top: 4 * $spacer; }
 .pt-8 { padding-top: 8 * $spacer; }
 
@@ -392,6 +395,7 @@ a.text-error:hover { color: var(--error-hover-color) !important; }
 a.text-warning:hover { color: var(--warning-hover-color) !important; }
 a.text-danger:hover { color: var(--error-hover-color) !important; }
 
+.bg\:card { background-color: var(--card-background-color); }
 .bg\:primary-color { background-color: var(--link-color); }
 .bg\:error-color { background-color: var(--error-color); }
 .bg-transparent { background-color: transparent; }


### PR DESCRIPTION
Changes the layout of the upload component to indicate that URL uploads are preferred.

<img width="460" height="255" alt="image" src="https://github.com/user-attachments/assets/69de10b6-bb66-4825-a020-902ffb621a9e" />
<img width="466" height="259" alt="image" src="https://github.com/user-attachments/assets/0316e14a-a967-40e4-923c-b4555cc8770f" />

Fixes #5976.
