### PR TITLE
Fix #5950: Rework translated commentary buttons

### DIFF
--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class ArtistCommentary < ApplicationRecord
-  class RevertError < StandardError; end
+  COMMENTARY_TAGS = [
+    "commentary",
+    "check_commentary",
+    "partial_commentary",
+    "commentary_request",
+    "untranslatable_commentary",
+  ]
 
-  attr_accessor(
-    :remove_commentary_tag, :remove_commentary_request_tag,
-    :remove_commentary_check_tag, :remove_partial_commentary_tag,
-    :add_commentary_tag, :add_commentary_request_tag, :add_commentary_check_tag,
-    :add_partial_commentary_tag
-  )
+  class RevertError < StandardError; end
 
   dtext_attribute :original_title, disable_mentions: true, inline: true
   dtext_attribute :translated_title, disable_mentions: true, inline: true
@@ -23,8 +24,8 @@ class ArtistCommentary < ApplicationRecord
   validates :original_description, length: { maximum: 55_000 }, if: :original_description_changed?
   validates :translated_description, length: { maximum: 55_000 }, if: :translated_description_changed?
   belongs_to :post
-  has_many :versions, -> {order("artist_commentary_versions.id ASC")}, :class_name => "ArtistCommentaryVersion", :dependent => :destroy, :foreign_key => :post_id, :primary_key => :post_id
-  has_one :previous_version, -> {order(id: :desc)}, :class_name => "ArtistCommentaryVersion", :foreign_key => :post_id, :primary_key => :post_id
+  has_many :versions, -> {order("artist_commentary_versions.id ASC")}, class_name: "ArtistCommentaryVersion", dependent: :destroy, foreign_key: :post_id, primary_key: :post_id
+  has_one :previous_version, -> {order(id: :desc)}, class_name: "ArtistCommentaryVersion", foreign_key: :post_id, primary_key: :post_id
   after_save :create_version
   after_commit :tag_post
 
@@ -81,6 +82,8 @@ class ArtistCommentary < ApplicationRecord
       else
         q = q.apply_default_order(params)
       end
+
+      q
     end
   end
 
@@ -94,22 +97,6 @@ class ArtistCommentary < ApplicationRecord
 
   def any_field_present?
     original_present? || translated_present?
-  end
-
-  def tag_post
-    post.remove_tag("commentary") if remove_commentary_tag.to_s.truthy?
-    post.add_tag("commentary") if add_commentary_tag.to_s.truthy?
-
-    post.remove_tag("commentary_request") if remove_commentary_request_tag.to_s.truthy?
-    post.add_tag("commentary_request") if add_commentary_request_tag.to_s.truthy?
-
-    post.remove_tag("check_commentary") if remove_commentary_check_tag.to_s.truthy?
-    post.add_tag("check_commentary") if add_commentary_check_tag.to_s.truthy?
-
-    post.remove_tag("partial_commentary") if remove_partial_commentary_tag.to_s.truthy?
-    post.add_tag("partial_commentary") if add_partial_commentary_tag.to_s.truthy?
-
-    post.save if post.tag_string_changed?
   end
 
   module VersionMethods
@@ -132,16 +119,16 @@ class ArtistCommentary < ApplicationRecord
         original_title: original_title,
         original_description: original_description,
         translated_title: translated_title,
-        translated_description: translated_description
+        translated_description: translated_description,
       )
     end
 
     def create_new_version
       versions.create(
-        :original_title => original_title,
-        :original_description => original_description,
-        :translated_title => translated_title,
-        :translated_description => translated_description
+        original_title: original_title,
+        original_description: original_description,
+        translated_title: translated_title,
+        translated_description: translated_description,
       )
     end
 
@@ -164,6 +151,20 @@ class ArtistCommentary < ApplicationRecord
 
   extend SearchMethods
   include VersionMethods
+
+  def commentary_tags
+    (post.tag_array & COMMENTARY_TAGS).first || "none"
+  end
+
+  def commentary_tags=(value)
+    @commentary_tag = value if value.in?(COMMENTARY_TAGS)
+  end
+
+  def tag_post
+    return unless @commentary_tag.present?
+    post.tag_string = ((post.tag_array - COMMENTARY_TAGS.without(@commentary_tag)) << @commentary_tag).join(" ")
+    post.save!
+  end
 
   def self.available_includes
     [:post]

--- a/app/policies/artist_commentary_policy.rb
+++ b/app/policies/artist_commentary_policy.rb
@@ -27,10 +27,7 @@ class ArtistCommentaryPolicy < ApplicationPolicy
     %i[
       original_description original_title
       translated_description translated_title
-      remove_commentary_tag remove_commentary_request_tag
-      remove_commentary_check_tag remove_partial_commentary_tag
-      add_commentary_tag add_commentary_request_tag
-      add_commentary_check_tag add_partial_commentary_tag
+      commentary_tags
     ]
   end
 end

--- a/app/views/artist_commentaries/_form.html.erb
+++ b/app/views/artist_commentaries/_form.html.erb
@@ -17,27 +17,5 @@
   <%= f.input :translated_title, as: :string, input_html: { value: artist_commentary.try(:translated_title) } %>
   <%= f.input :translated_description, input_html: { value: artist_commentary.try(:translated_description) } %>
 
-  <% if post.has_tag?("commentary") %>
-    <%= f.input :remove_commentary_tag, as: :boolean %>
-  <% else %>
-    <%= f.input :add_commentary_tag, as: :boolean %>
-  <% end %>
-
-  <% if post.has_tag?("commentary_request") %>
-    <%= f.input :remove_commentary_request_tag, as: :boolean %>
-  <% else %>
-    <%= f.input :add_commentary_request_tag, as: :boolean %>
-  <% end %>
-
-  <% if post.has_tag?("check_commentary") %>
-    <%= f.input :remove_commentary_check_tag, as: :boolean %>
-  <% else %>
-    <%= f.input :add_commentary_check_tag, as: :boolean %>
-  <% end %>
-
-  <% if post.has_tag?("partial_commentary") %>
-    <%= f.input :remove_partial_commentary_tag, as: :boolean %>
-  <% else %>
-    <%= f.input :add_partial_commentary_tag, as: :boolean %>
-  <% end %>
+  <%= f.input :commentary_tags, label: false, wrapper_html: { class: "radio-button-group thin-x-scrollbar text-xs m-auto w-fit" }, collection: ArtistCommentary::COMMENTARY_TAGS.map { [it.titleize, it] } + [["None", "none"]], as: :radio_buttons, boolean_style: :inline %>
 <% end %>

--- a/test/unit/artist_commentary_test.rb
+++ b/test/unit/artist_commentary_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ArtistCommentaryTest < ActiveSupport::TestCase
   setup do
@@ -58,8 +58,16 @@ class ArtistCommentaryTest < ActiveSupport::TestCase
       end
 
       should "add tags if requested" do
-        @artcomm.update(translated_title: "bar", add_commentary_tag: "1")
-        assert_equal(true, @artcomm.post.reload.has_tag?("commentary"))
+        @artcomm.update(translated_title: "bar", commentary_tags: "commentary")
+        assert(@artcomm.post.reload.has_tag?("commentary"))
+        @artcomm.update(commentary_tags: "partial_commentary")
+        assert_not(@artcomm.post.reload.has_tag?("commentary"))
+        assert(@artcomm.post.has_tag?("partial_commentary"))
+      end
+
+      should "not add unrelated tags" do
+        @artcomm.update(commentary_tags: "foo")
+        assert_not(@artcomm.post.reload.has_tag?("foo"))
       end
 
       should "not create new version if nothing changed" do
@@ -90,7 +98,7 @@ class ArtistCommentaryTest < ActiveSupport::TestCase
           original_title: "  foo\u00A0\t\n",
           original_description: " foo\u00A0\t\n",
           translated_title: "  foo\u00A0\t\n",
-          translated_description: "  foo\u00A0\n"
+          translated_description: "  foo\u00A0\n",
         )
 
         assert_equal("foo", @artcomm.original_title)


### PR DESCRIPTION
[From Discord](https://discord.com/channels/310432830138089472/310846683376517121/1468282761440923711), it was suggested they be radio buttons. That requires us including an option for "None". The new "Untranslatable Commentary" was also requested.

Fixes #5950.