### PR TITLE
Fix #3503: Additional site links for translated tags

### DIFF
--- a/app/components/external_tag_link_component.rb
+++ b/app/components/external_tag_link_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This component is used to render the other names list on wiki pages.
+class ExternalTagLinkComponent < ApplicationComponent
+  SITE_LIST = Danbooru.config.tag_lookup_sites
+
+  attr_reader :name
+
+  delegate :external_site_icon, to: :helpers
+
+  # @param tag [String] Tag tag tag tag.
+  def initialize(name)
+    super
+    @name = name
+  end
+end

--- a/app/components/external_tag_link_component/external_tag_link_component.html.erb
+++ b/app/components/external_tag_link_component/external_tag_link_component.html.erb
@@ -1,0 +1,15 @@
+<div class="chip-primary flex break-keep text-sm w-fit h-24px">
+  <%= render PopupMenuComponent.new(button_classes: "") do |menu| %>
+    <% menu.with_button do %>
+      <%= tag.span name, href: "javascript:void(0)", class: "link-color hover:link-color wiki-other-name" %>
+    <% end %>
+
+    <% SITE_LIST.each do |site, func| %>
+      <% menu.with_item do %>
+        <%= external_link_to func.call(name), target: "_blank" do %>
+          <%= external_site_icon site.to_s %> <%= site %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/helpers/wiki_pages_helper.rb
+++ b/app/helpers/wiki_pages_helper.rb
@@ -2,10 +2,10 @@
 
 module WikiPagesHelper
   def wiki_page_other_names_list(wiki_page)
-    names_html = wiki_page.other_names.map do |name|
-      link_to(name, "https://www.pixiv.net/tags/#{u(name)}/artworks", class: "wiki-other-name chip-primary text-sm truncate")
+    html = wiki_page.other_names.map do |name|
+      render ExternalTagLinkComponent.new(name)
     end
 
-    tag.p safe_join(names_html, " "), class: "flex flex-wrap gap-1"
+    tag.div safe_join(html, " "), class: "flex gap-1 flex-wrap"
   end
 end

--- a/app/javascript/src/styles/common/utilities.scss
+++ b/app/javascript/src/styles/common/utilities.scss
@@ -66,6 +66,7 @@ $spacer: 0.25rem; /* 4px */
 
 .break-all { word-break: break-all; overflow-wrap: anywhere; }
 .break-words { word-break: break-word !important; overflow-wrap: anywhere; }
+.break-keep { word-break: keep-all; }
 .whitespace-nowrap { white-space: nowrap; }
 .whitespace-pre { white-space: pre; }
 .whitespace-pre-wrap { white-space: pre-wrap; }
@@ -380,6 +381,7 @@ $spacer: 0.25rem; /* 4px */
 .z-9999 { z-index: 9999; }
 
 .link-color { color: var(--link-color); }
+.hover\:link-color:hover { color: var(--link-hover-color); }
 
 .text-success { color: var(--success-color) !important; }
 .text-error { color: var(--error-color) !important; }

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -915,6 +915,19 @@ module Danbooru
     def reactions
       {}
     end
+
+    # A hash of site names to a function taking a tag name and returning a URL for
+    # tag searches on that site. Used to render other names links on wiki pages.
+    def tag_lookup_sites
+      {
+        pixiv: ->(name) { "https://www.pixiv.net/tags/#{name}/artworks" },
+        Twitter: ->(name) { "https://x.com/hashtag/#{name}" },
+        Bluesky: ->(name) { "https://bsky.app/hashtag/#{name}" },
+        Weibo: ->(name) { "https://s.weibo.com/weibo?q=%23#{name}%23" },
+        Lofter: ->(name) { "https://www.lofter.com/tag/#{name}" },
+        Tumblr: ->(name) { "https://www.tumblr.com/tagged/#{name.tr('_', ' ')}" },
+      }
+    end
   end
 
   EnvironmentConfiguration = Struct.new(:config) do


### PR DESCRIPTION
Changes the other names links to show a dropdown with other sites.
<img width="178" height="237" alt="image" src="https://github.com/user-attachments/assets/ef6349b1-22e7-4605-a09a-ef6c3a895b35" />

These six were picked based on Discord users' feedback.

Fixes #3503.