### PR TITLE
Implement tracking of source publication date for posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For help, ask in the [#technical](https://discord.com/channels/31043283013808947
 
 ## Services
 
-Danboou depends on a couple of cloud services and several microservices to
+Danbooru depends on a couple of cloud services and several microservices to
 implement certain features.
 
 ### Amazon Web Services

--- a/app/components/source_data_component/source_data_component.html.erb
+++ b/app/components/source_data_component/source_data_component.html.erb
@@ -51,6 +51,18 @@
             <% end %>
           </td>
         </tr>
+
+        <tr class="source-data-publication-date">
+          <th>Published</th>
+          <td>
+            <% if @source.published_at.blank? %>
+              <em>None</em>
+            <% else %>
+              <%= helpers.compact_time(@source.published_at) %>
+              (<%= link_to "Fill", "javascript:void(0)", "x-on:click": "$('#post_published_at_string').val(#{@source.published_at_string.to_json});" %>)
+            <% end %>
+          </td>
+        </tr>
       </tbody>
     </table>
   <% end %>

--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -10,6 +10,7 @@ module PostVersionsHelper
     added_tags << "rating:#{post_version_value(post_version.rating)}" if post_version.rating_changed
     added_tags << "parent:#{post_version_value(post_version.parent_id)}" if post_version.parent_changed
     added_tags << "source:#{post_version_source(post_version.source)}" if post_version.source_changed
+    added_tags << "published:#{post_version_time(post_version.published_at)}" if post_version.published_at_changed
 
     removed_tags = post_version.removed_tags.compact
 
@@ -21,6 +22,7 @@ module PostVersionsHelper
       other_tags << "rating:#{post_version_value(other.rating)}"
       other_tags << "parent:#{post_version_value(other.parent_id)}"
       other_tags << "source:#{post_version_source(other.source)}"
+      other_tags << "published:#{post_version_time(other.published_at)}"
       obsolete_added_tags = added_tags - other_tags
       obsolete_removed_tags = removed_tags & other_tags
     end
@@ -40,11 +42,18 @@ module PostVersionsHelper
   end
 
   def post_version_field(post_version, field)
-    value = post_version_value(post_version.send(field))
-    prefix = ((field == :parent_id) ? "parent" : field.to_s)
+    if field == :published_at
+      value = post_version_time(post_version.send(field))
+      prefix = "published"
+      title = "Published"
+    else
+      value = post_version_value(post_version.send(field))
+      prefix = ((field == :parent_id) ? "parent" : field.to_s)
+      title = field.to_s.titleize
+    end
     search = "#{prefix}:#{value}"
     display = ((field == :rating) ? post_version.pretty_rating : value)
-    %{<b>#{field.to_s.titleize}:</b> #{link_to(display, posts_path(:tags => search))}}.html_safe
+    %{<b>#{title}:</b> #{link_to(display, posts_path(:tags => search))}}.html_safe
   end
 
   def post_version_value(value)
@@ -60,5 +69,9 @@ module PostVersionsHelper
       # This turns non-web sources with spaces (e.g., "File provided by the artist") into a single clickable entity.
       %{"#{source}"}
     end
+  end
+
+  def post_version_time(time)
+    time&.iso8601 || "none"
   end
 end

--- a/app/logical/post_edit.rb
+++ b/app/logical/post_edit.rb
@@ -14,7 +14,7 @@ class PostEdit
   CATEGORIZATION_METATAGS = TagCategory.mapping.keys
 
   # Pre-metatags affect the post itself, so they must be applied before the post is saved.
-  PRE_METATAGS = %w[parent -parent rating source status] + CATEGORIZATION_METATAGS
+  PRE_METATAGS = %w[parent -parent rating source published status] + CATEGORIZATION_METATAGS
 
   # Post-metatags rely on the post's ID, so they must be applied after the post is saved to ensure the ID has been created.
   POST_METATAGS = %w[newpool pool -pool favgroup -favgroup fav -fav child -child upvote downvote disapproved status -status]

--- a/app/logical/post_query.rb
+++ b/app/logical/post_query.rb
@@ -10,7 +10,7 @@ class PostQuery
   UNLIMITED_METATAGS = %w[
     status rating limit is id date age filesize filetype parent child md5 width
     height duration mpixels ratio score upvote downvotes favcount embedded
-    tagcount pixiv_id pixiv
+    tagcount pixiv_id pixiv published publishedage
   ]
 
   # Metatags that define the order of search results. These metatags can't be used more than once per query.
@@ -159,8 +159,8 @@ class PostQuery
   # True if the search depends on the current user because of permissions or privacy settings.
   def is_user_dependent_search?
     metatags.any? do |metatag|
-      # XXX date: is user dependent because it depends on the current user's time zone
-      metatag.name.in?(%w[date upvoter upvote downvoter downvote commenter comm search flagger fav ordfav favgroup ordfavgroup]) ||
+      # XXX date: and published: are user dependent because they depend on the current user's time zone
+      metatag.name.in?(%w[date published upvoter upvote downvoter downvote commenter comm search flagger fav ordfav favgroup ordfavgroup]) ||
       metatag.name == "status" && metatag.value == "unmoderated" ||
       metatag.name == "disapproved" && !metatag.value.downcase.in?(PostDisapproval::REASONS)
     end

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -34,7 +34,7 @@ class PostQueryBuilder
     ordpool note comment commentary id rating source status filetype
     disapproved parent child search embedded md5 pixelhash width height mpixels ratio
     score upvotes downvotes favcount filesize date age order limit tagcount pixiv_id pixiv
-    unaliased exif duration random is has ai
+    unaliased exif duration random is has ai published publishedage
   ] + COUNT_METATAGS + COUNT_METATAG_SYNONYMS + CATEGORY_COUNT_METATAGS
 
   ORDER_METATAGS = %w[
@@ -45,6 +45,7 @@ class PostQueryBuilder
     downvotes downvotes_asc
     favcount favcount_asc
     created_at created_at_asc
+    published published_asc
     change change_asc
     comment comment_asc
     comment_bumped comment_bumped_asc

--- a/app/logical/source/extractor.rb
+++ b/app/logical/source/extractor.rb
@@ -17,6 +17,7 @@
 # * tags - The artist's tags for the work. Used by translated tags.
 # * artist_commentary_title - The artist's title of the work. Used for artist commentaries.
 # * artist_commentary_desc - The artist's description of the work. Used for artist commentaries.
+# * published_at - The time that the post was published at the source.
 #
 module Source
   class Extractor
@@ -344,6 +345,14 @@ module Source
       end
 
       translated_tags
+    end
+
+    def published_at
+      nil
+    end
+
+    def published_at_string
+      published_at&.getutc&.iso8601
     end
 
     def dtext_artist_commentary_title

--- a/app/logical/source/extractor/bluesky.rb
+++ b/app/logical/source/extractor/bluesky.rb
@@ -145,6 +145,11 @@ class Source::Extractor::Bluesky < Source::Extractor
     end
   end
 
+  def published_at
+    created_at_string = api_response&.dig("thread", "post", "record", "createdAt")
+    Time.iso8601(created_at_string).utc if created_at_string
+  end
+
   # https://www.docs.bsky.app/docs/api/app-bsky-feed-get-post-thread
   memoize def api_response
     return {} unless post_id.present?

--- a/app/logical/source/extractor/danbooru2.rb
+++ b/app/logical/source/extractor/danbooru2.rb
@@ -7,7 +7,7 @@ module Source
   class Extractor
     # The class is called `Danbooru2` instead of `Danbooru` to avoid ambiguity with the top-level `Danbooru` class.
     class Danbooru2 < Source::Extractor
-      delegate :artist_name, :profile_url, :display_name, :username, :tag_name, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
+      delegate :artist_name, :profile_url, :display_name, :username, :tag_name, :published_at, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
 
       def image_urls
         if parsed_url.full_image_url.present?

--- a/app/logical/source/extractor/deviant_art.rb
+++ b/app/logical/source/extractor/deviant_art.rb
@@ -156,6 +156,10 @@ module Source
         tags
       end
 
+      def published_at
+        Time.iso8601(deviation["publishedTime"]).utc if deviation["publishedTime"]
+      end
+
       def dtext_artist_commentary_desc
         DText.from_html(artist_commentary_desc, base_url: "https://www.deviantart.com", allowed_shortlinks: ["deviantart"]) do |element|
           case element.name

--- a/app/logical/source/extractor/e621.rb
+++ b/app/logical/source/extractor/e621.rb
@@ -2,7 +2,7 @@
 
 # @see Source::URL::E621
 class Source::Extractor::E621 < Source::Extractor
-  delegate :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
+  delegate :published_at, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
 
   def image_urls
     if parsed_url.full_image_url.present?

--- a/app/logical/source/extractor/gelbooru.rb
+++ b/app/logical/source/extractor/gelbooru.rb
@@ -16,7 +16,7 @@ module Source
         SiteCredential.for_site("Gelbooru").present?
       end
 
-      delegate :artist_name, :profile_url, :display_name, :username, :tag_name, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
+      delegate :artist_name, :profile_url, :display_name, :username, :tag_name, :published_at, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
 
       def image_urls
         if parsed_url.full_image_url.present?

--- a/app/logical/source/extractor/google.rb
+++ b/app/logical/source/extractor/google.rb
@@ -6,7 +6,7 @@
 #
 # @see Source::URL::Google
 class Source::Extractor::Google < Source::Extractor
-  delegate :page_url, :profile_url, :artist_name, :display_name, :username, :tag_name, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
+  delegate :page_url, :profile_url, :artist_name, :display_name, :username, :tag_name, :published_at, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
 
   # Don't ignore the referer URL when it's from a different site (Youtube, Blogger, Opensea, etc).
   def allow_referer?

--- a/app/logical/source/extractor/kakao.rb
+++ b/app/logical/source/extractor/kakao.rb
@@ -4,7 +4,7 @@
 # We can't tell which extractor to use based on the URL itself, but if the referer URL is present we can use it to
 # delegate to the real extractor.
 class Source::Extractor::Kakao < Source::Extractor
-  delegate :page_url, :profile_url, :artist_name, :display_name, :username, :tag_name, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
+  delegate :page_url, :profile_url, :artist_name, :display_name, :username, :tag_name, :published_at, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
 
   def allow_referer?
     # Ex: https://panchokworkshop.com/520, https://panchok.tistory.com/520, https://post.naver.com/viewer/postView.naver?volumeNo=28956950&memberNo=23461945

--- a/app/logical/source/extractor/mastodon.rb
+++ b/app/logical/source/extractor/mastodon.rb
@@ -72,6 +72,10 @@ class Source::Extractor
       end
     end
 
+    def published_at
+      Time.iso8601(api_response["created_at"]).utc if api_response["created_at"]
+    end
+
     def dtext_artist_commentary_desc
       DText.from_html(artist_commentary_desc, base_url: "https://#{domain}") do |element|
         if element.name == "a"

--- a/app/logical/source/extractor/mihuashi.rb
+++ b/app/logical/source/extractor/mihuashi.rb
@@ -101,6 +101,23 @@ module Source
         end
       end
 
+      def published_at
+        date_string = nil
+        if work.present?
+          date_string = work[:created_at]
+        elsif stall.present?
+          # Individual stall images have their upload date in their URLs, but it's a different date for each image.
+          date_string = nil
+        elsif project.present?
+          date_string = project[:created_at]
+        elsif character_card.present?
+          date_string = character_card[:created_at]
+        elsif activity_work.present?
+          date_string = activity_work[:created_at]
+        end
+        Time.iso8601(date_string).utc if date_string
+      end
+
       def user_id
         user[:id] || parsed_url.user_id || parsed_referer&.user_id unless project.present? || character_card.present?
       end

--- a/app/logical/source/extractor/moebooru.rb
+++ b/app/logical/source/extractor/moebooru.rb
@@ -4,7 +4,7 @@
 module Source
   class Extractor
     class Moebooru < Source::Extractor
-      delegate :artist_name, :profile_url, :display_name, :username, :tag_name, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
+      delegate :artist_name, :profile_url, :display_name, :username, :tag_name, :published_at, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
       delegate :site_name, :domain, to: :parsed_url
 
       def image_urls

--- a/app/logical/source/extractor/null.rb
+++ b/app/logical/source/extractor/null.rb
@@ -51,6 +51,10 @@ module Source
         sub_extractor&.tags || []
       end
 
+      def published_at
+        sub_extractor&.published_at
+      end
+
       def artist_commentary_title
         sub_extractor&.artist_commentary_title
       end

--- a/app/logical/source/extractor/pixiv.rb
+++ b/app/logical/source/extractor/pixiv.rb
@@ -79,6 +79,12 @@ module Source
         [display_name, (username unless username&.starts_with?("user_"))].compact_blank.uniq(&:downcase)
       end
 
+      def published_at
+        # Parse the date from the first image URL.
+        # The dates from from the API response (createDate/uploadDate) lack seconds.
+        Source::URL.parse(image_urls[0])&.parsed_date
+      end
+
       def artist_commentary_title
         api_response[:title]&.normalize_whitespace
       end

--- a/app/logical/source/extractor/tumblr.rb
+++ b/app/logical/source/extractor/tumblr.rb
@@ -86,6 +86,10 @@ class Source::Extractor
       super(tag)
     end
 
+    def published_at
+      Time.at(post[:timestamp]).utc if post[:timestamp]
+    end
+
     # The commentary with reblogs presented as a linear list of quotes, rather than as nested quotes.
     def linear_artist_commentary_desc
       return artist_commentary_desc if post[:trail].blank?

--- a/app/logical/source/extractor/twitter.rb
+++ b/app/logical/source/extractor/twitter.rb
@@ -71,6 +71,19 @@ class Source::Extractor
       graphql_tweet.dig(:core, :user_results, :result, :legacy, :name)
     end
 
+    def graphql_tweet_created_at
+      date_string = graphql_tweet.dig(:legacy, :created_at)
+      if date_string.present?
+        Time.strptime(date_string, "%a %b %d %H:%M:%S %z %Y")
+      end
+    end
+
+    def published_at
+      # The tweet URL's status ID is a snowflake that contains the exact timestamp the tweet was created at.
+      # We only need to fall back to parsing the GraphQL json's created_at field for tweets made before the snowflake system was implemented.
+      parsed_url.parsed_date || parsed_referer&.parsed_date || graphql_tweet_created_at
+    end
+
     def artist_commentary_desc
       graphql_tweet.dig(:note_tweet, :note_tweet_results, :result, :text) || graphql_tweet.dig(:legacy, :full_text)
     end

--- a/app/logical/source/extractor/url_shortener.rb
+++ b/app/logical/source/extractor/url_shortener.rb
@@ -4,7 +4,7 @@
 #
 # TODO: Add more shorteners from https://wiki.archiveteam.org/index.php/URLTeam. Use data dumps to unshorten dead URLs?
 class Source::Extractor::URLShortener < Source::Extractor
-  delegate :page_url, :profile_url, :artist_name, :display_name, :username, :tag_name, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
+  delegate :page_url, :profile_url, :artist_name, :display_name, :username, :tag_name, :published_at, :artist_commentary_title, :artist_commentary_desc, :dtext_artist_commentary_title, :dtext_artist_commentary_desc, to: :sub_extractor, allow_nil: true
   delegate :domain, :site, :host, :path, :path_segments, :params, to: :parsed_url
 
   def image_urls

--- a/app/logical/source/url/mihuashi.rb
+++ b/app/logical/source/url/mihuashi.rb
@@ -57,7 +57,8 @@ module Source
 
         # https://www.mihuashi.com/activities/houkai3-stigmata/artworks/8523
         # https://www.mihuashi.com/activities/jw3-exterior-12/artworks/10515?type=zjjh
-        in _, "mihuashi.com", "activities", a_work_activity, "artworks", a_work_id
+        # https://www.mihuashi.com/activities/color-lost-world/activity_artworks/797
+        in _, "mihuashi.com", "activities", a_work_activity, ("artworks" | "activity_artworks"), a_work_id
           @a_work_id = a_work_id
           @a_work_activity = a_work_activity
           @a_work_type = params[:type]

--- a/app/logical/source/url/pixiv.rb
+++ b/app/logical/source/url/pixiv.rb
@@ -54,6 +54,14 @@ module Source
         parse_filename
         @username = username
 
+      # https://i.pximg.net/user-profile/img/2014/12/18/10/31/23/8733472_7dc7310db6cc37163af145d04499e411_170.jpg
+      in *, "user-profile", "img", year, month, day, hour, min, sec, _ if image_url?
+        @date = [year, month, day, hour, min, sec]
+
+      # https://i.pximg.net/background/img/2015/10/25/08/45/27/198128_77ddf78cdb162e3d1c0d5134af185813.jpg
+      in *, "background", "img", year, month, day, hour, min, sec, _ if image_url?
+        @date = [year, month, day, hour, min, sec]
+
       # https://i.pximg.net/imgaz/upload/20240417/163474511.jpg
       # contest images?
       in _, _, "imgaz", "upload", _year_month_day, _ if image_url?
@@ -292,7 +300,7 @@ module Source
 
     def parsed_date
       # Dates in image URLs are in JST (UTC+9)
-      Time.new(*date, "+09:00").in_time_zone("UTC") if date.present?
+      Time.new(*date, "+09:00").utc if date.present?
     end
   end
 end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -97,18 +97,18 @@ class PostPolicy < ApplicationPolicy
   end
 
   def permitted_attributes_for_create
-    [:upload_id, :media_asset_id, :upload_media_asset_id, :tag_string, :rating, :parent_id, :source, :is_pending,
+    [:upload_id, :media_asset_id, :upload_media_asset_id, :tag_string, :rating, :parent_id, :source, :is_pending, :published_at_string,
      { artist_commentary: %i[original_title original_description translated_title translated_description] }]
   end
 
   # XXX For UploadsController#show action
   def permitted_attributes_for_show
-    [:tag_string, :rating, :parent_id, :source, :is_pending,
+    [:tag_string, :rating, :parent_id, :source, :published_at_string, :is_pending,
      { artist_commentary: %i[original_title original_description translated_title translated_description] }]
   end
 
   def permitted_attributes_for_update
-    %i[tag_string old_tag_string parent_id old_parent_id source old_source rating old_rating has_embedded_notes]
+    %i[tag_string old_tag_string parent_id old_parent_id source old_source rating old_rating has_embedded_notes published_at_string]
   end
 
   def api_attributes

--- a/app/views/post_versions/_listing.html.erb
+++ b/app/views/post_versions/_listing.html.erb
@@ -21,6 +21,7 @@
         <div>
           <%= post_version_field(post_version, :rating) %>
           <%= post_version_field(post_version, :parent_id) %>
+          <%= post_version_field(post_version, :published_at) %>
         </div>
         <div>
           <b>Tags:</b>

--- a/app/views/post_versions/search.html.erb
+++ b/app/views/post_versions/search.html.erb
@@ -19,6 +19,7 @@
       <%= f.input :rating_changed, as: :select, include_blank: true, selected: params.dig(:search, :rating_changed) %>
       <%= f.input :parent_changed, as: :select, include_blank: true, selected: params.dig(:search, :parent_changed) %>
       <%= f.input :source_changed, as: :select, include_blank: true, selected: params.dig(:search, :source_changed) %>
+      <%= f.input :published_at_changed, label: "Publication date changed", as: :select, include_blank: true, selected: params.dig(:search, :published_at_changed) %>
       <%= f.submit "Search" %>
     <% end %>
   </div>

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -17,6 +17,7 @@
   <%= f.input :has_embedded_notes, label: "Embed notes", as: :boolean, wrapper: "inline-toggle-switch" %>
   <%= f.input :parent_id, label: "Parent", as: :string %>
   <%= f.input :source %>
+  <%= f.input :published_at_string, label: "Publication date", hint: "When the image was published at the source, not when it was drawn." %>
 
   <div class="input fixed-width-container">
     <div class="flex justify-between">

--- a/app/views/posts/show.html+tooltip.erb
+++ b/app/views/posts/show.html+tooltip.erb
@@ -5,6 +5,12 @@
     <%= time_ago_in_words_tagged(@post.created_at, compact: true) %>
   <% end %>
 
+  <% if @post.published_at %>
+    <%= link_to posts_path(tags: "published:#{@post.published_at.strftime("%Y-%m-%d")}"), class: "post-tooltip-date inactive-link" do %>
+      (<%= time_ago_in_words_tagged(@post.published_at, compact: true) %>)
+    <% end %>
+  <% end %>
+
   <span class="post-tooltip-score">
     <%= render_post_votes @post, current_user: CurrentUser.user %>
   </span>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -28,8 +28,14 @@
       </li>
 
       <li id="post-info-date">
-        Date: <%= link_to time_ago_in_words_tagged(@post.created_at), posts_path(tags: "date:#{@post.created_at.to_date}") %>
+        Upload Date: <%= link_to time_ago_in_words_tagged(@post.created_at), posts_path(tags: "date:#{@post.created_at.to_date}") %>
       </li>
+
+      <% if @post.published_at %>
+        <li id="post-info-published-date">
+          Publication Date: <%= link_to time_ago_in_words_tagged(@post.published_at), posts_path(tags: "published:#{@post.published_at.to_date}") %>
+        </li>
+      <% end %>
 
       <% if @post.approver %>
         <li id="post-info-approver">

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -94,6 +94,12 @@
                 Source: <%= external_link_to @source.page_url, class: "inactive-link" %>
               </div>
             <% end %>
+
+            <% if @source.published_at_string.present? %>
+              <div class="prose text-xs text-muted">
+                Publication Date: <%= compact_time(@source.published_at) %>
+              </div>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/views/sources/show.js.erb
+++ b/app/views/sources/show.js.erb
@@ -12,5 +12,10 @@ if ($("#c-uploads #a-show").length) {
       $("#post_artist_commentary_original_title").val(sourceTitle);
       $(".post_artist_commentary_original_description .dtext-editor").get(0).editor.dtext = sourceDesc;
     }
+
+    let publishedAt = <%= raw @source.published_at_string.to_json %>;
+    if (publishedAt) {
+      $("#post_published_at_string").val(publishedAt);
+    }
   });
 }

--- a/app/views/uploads/_single_asset_upload.html.erb
+++ b/app/views/uploads/_single_asset_upload.html.erb
@@ -170,6 +170,8 @@
 
             <%= f.input :source, as: :string, input_html: { value: post.source } %>
 
+            <%= f.input :published_at_string, label: "Publication date", hint: "When the image was published at the source, not when it was drawn." %>
+
             <%= f.simple_fields_for :artist_commentary, post.artist_commentary do |fa| %>
               <%= fa.input :original_title, as: :string %>
               <%= fa.input :original_description, as: :dtext, label: "Original description" %>

--- a/db/migrate/20260130190008_add_published_at_to_posts.rb
+++ b/db/migrate/20260130190008_add_published_at_to_posts.rb
@@ -1,0 +1,9 @@
+class AddPublishedAtToPosts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :posts, :published_at, :datetime
+    add_index :posts, :published_at
+    add_column :post_versions, :published_at, :datetime
+    add_column :post_versions, :published_at_changed, :boolean, null: false, default: false
+    add_index :post_versions, :published_at_changed
+  end
+end

--- a/db/populate.rb
+++ b/db/populate.rb
@@ -63,7 +63,9 @@ def populate_posts(n, search: "is:sfw", batch_size: 200, timeout: 30.seconds)
           upload.upload_media_assets.first,
           tag_string: prepared_tag_string,
           source: danbooru_post["source"],
-          rating: danbooru_post["rating"]
+          rating: danbooru_post["rating"],
+          # XXX Uncomment this later, after published_at is live on the production site.
+          # published_at: danbooru_post["published_at"],
         )
         post.save
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1562,7 +1562,8 @@ CREATE TABLE public.posts (
     last_commented_at timestamp without time zone,
     has_active_children boolean DEFAULT false,
     bit_flags bigint DEFAULT 0 NOT NULL,
-    tag_count_meta integer DEFAULT 0 NOT NULL
+    tag_count_meta integer DEFAULT 0 NOT NULL,
+    published_at timestamp(6) without time zone
 );
 
 
@@ -1681,7 +1682,9 @@ CREATE TABLE public.post_versions (
     source text,
     tags text NOT NULL,
     added_tags text[] DEFAULT '{}'::text[] NOT NULL,
-    removed_tags text[] DEFAULT '{}'::text[] NOT NULL
+    removed_tags text[] DEFAULT '{}'::text[] NOT NULL,
+    published_at timestamp(6) without time zone,
+    published_at_changed boolean DEFAULT false NOT NULL
 );
 
 
@@ -3342,7 +3345,6 @@ ALTER TABLE ONLY public.ip_bans
 
 ALTER TABLE ONLY public.ip_geolocations
     ADD CONSTRAINT ip_geolocations_pkey PRIMARY KEY (id);
-
 
 
 --
@@ -5330,6 +5332,13 @@ CREATE INDEX index_post_versions_on_post_id ON public.post_versions USING btree 
 
 
 --
+-- Name: index_post_versions_on_published_at_changed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_versions_on_published_at_changed ON public.post_versions USING btree (published_at_changed);
+
+
+--
 -- Name: index_post_versions_on_rating_changed; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5488,6 +5497,13 @@ CREATE INDEX index_posts_on_parent_id ON public.posts USING btree (parent_id) WH
 --
 
 CREATE INDEX index_posts_on_pixiv_id ON public.posts USING btree (pixiv_id) WHERE (pixiv_id IS NOT NULL);
+
+
+--
+-- Name: index_posts_on_published_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_published_at ON public.posts USING btree (published_at);
 
 
 --
@@ -7113,6 +7129,7 @@ ALTER TABLE ONLY public.user_upgrades
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260130190008'),
 ('20250720155738'),
 ('20250718142035'),
 ('20250716202530'),

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -193,7 +193,7 @@ services:
     expose:
     - 9324
     volumes:
-      - sqs-data:/data"
+      - sqs-data:/data
     restart: unless-stopped
     stdin_open: true
     tty: true
@@ -204,7 +204,9 @@ services:
         condition: service_started
       postgres:
         condition: service_healthy
-    image: ghcr.io/danbooru/archives:latest
+    # XXX Switch this back once the image has been updated
+    # image: ghcr.io/danbooru/archives:latest
+    build: https://github.com/ToksT/archives.git#publish-time
     environment:
       <<: *sqs-env
       RUN: 1

--- a/script/fixes/141_populate_published_at_from_urls.rb
+++ b/script/fixes/141_populate_published_at_from_urls.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+require_relative "base"
+
+CurrentUser.user = User.system
+
+fix = ENV.fetch("FIX", "false").truthy?
+
+Post.where(published_at: nil).where.not(pixiv_id: nil).find_each do |post|
+  parsed_time = Source::URL.parse(post.source)&.parsed_date
+  next if parsed_time.nil?
+  puts ({ id: post.id, source: post.source, published_at: parsed_time }).to_json
+  post.update!(published_at: parsed_time) if fix
+rescue StandardError => e
+  puts ({ id: post.id, source: post.source, error: e.message }).to_json
+end
+
+twitter_hosts = %w[
+  twitter.com
+  x.com
+  fxtwitter.com
+  vxtwitter.com
+  twittpr.com
+  fixvx.com
+  fixupx.com
+  nitter.net
+  xcancel.com
+  nitter.poast.org
+]
+twitter_hosts.each do |host|
+  ["https", "http"].each do |protocol|
+    prefix = "#{protocol}://#{host}*"
+    Post.where(published_at: nil).where_ilike(:source, prefix).find_each do |post|
+      parsed_time = Source::URL.parse(post.source)&.parsed_date
+      next if parsed_time.nil?
+      puts ({ id: post.id, source: post.source, published_at: parsed_time }).to_json
+      post.update!(published_at: parsed_time) if fix
+    rescue StandardError => e
+      puts ({ id: post.id, source: post.source, error: e.message }).to_json
+    end
+  end
+end

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -899,7 +899,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
         assert_post_source_equals("https://i.pximg.net/img-original/img/2017/08/18/00/09/21/64476642_p0.jpg", "https://i.pximg.net/img-original/img/2017/08/18/00/09/21/64476642_p0.jpg", "https://www.pixiv.net/en/artworks/64476642")
 
         assert_post_source_equals("https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig", "https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig")
-        assert_post_source_equals("https://twitter.com/noizave/status/875768175136317440", "https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig", "https://x.com/noizave/status/875768175136317440")
+        assert_post_source_equals("https://x.com/noizave/status/875768175136317440", "https://pbs.twimg.com/media/DCdZ_FhUIAAYKFN.jpg:orig", "https://x.com/noizave/status/875768175136317440")
 
         assert_post_source_equals("https://noizave.tumblr.com/post/162206271767", "https://media.tumblr.com/3bbfcbf075ddf969c996641b264086fd/tumblr_os2buiIOt51wsfqepo1_1280.png")
 

--- a/test/test_helpers/post_archive_test_helper.rb
+++ b/test/test_helpers/post_archive_test_helper.rb
@@ -21,6 +21,7 @@ module PostArchiveTestHelper
       json["parent_changed"] = (prev.nil? || json.key?("parent_id") && prev.parent_id != json["parent_id"])
       json["source_changed"] = (prev.nil? || json.key?("source") && prev.source != json["source"])
       json["rating_changed"] = (prev.nil? || json.key?("rating") && prev.rating != json["rating"])
+      json["published_at_changed"] = (prev.nil? || json.key?("published_at") && prev.published_at != json["published_at"])
       if merge?(prev, json)
         prev.update_columns(json)
       else

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -766,6 +766,27 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([], "age:<60")
     end
 
+    should "return posts for the published:<d> metatag" do
+      post = create(:post, published_at: Time.zone.parse("2017-05-15 12:00"))
+
+      assert_tag_match([post], "published:2017-05-15")
+
+      assert_tag_match([], "-published:2017-05-15")
+    end
+
+    should "return posts for the publishedage:<n> metatag" do
+      post = create(:post, published_at: Time.zone.now)
+
+      assert_tag_match([post], "publishedage:<60s")
+
+      assert_tag_match([], "publishedage:>1y")
+
+      assert_tag_match([post], "-publishedage:>1y")
+      assert_tag_match([], "-publishedage:<1y")
+
+      assert_tag_match([], "publishedage:<60")
+    end
+
     should "return posts for the ratio:<x:y> metatag" do
       post = create(:post_with_file, filename: "test.jpg")
 
@@ -1322,7 +1343,8 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
           image_height: 100 * n * n,
           image_width: 100 * (3 - n) * n,
           tag_string: tags[n - 1],
-          media_asset: build(:media_asset, image_height: 100 * n * n, image_width: 100 * (3 - n) * n, file_size: 1.megabyte * n)
+          media_asset: build(:media_asset, image_height: 100 * n * n, image_width: 100 * (3 - n) * n, file_size: 1.megabyte * n),
+          published_at: Time.find_zone("UTC").local(2000, 1, 1, 0, 0, n),
         )
 
         u = create(:user, created_at: 2.weeks.ago)
@@ -1360,6 +1382,7 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match(posts.reverse, "order:md5")
       assert_tag_match(posts.reverse, "order:md5_desc")
       assert_tag_match(posts.reverse, "order:duration_desc")
+      assert_tag_match(posts.reverse, "order:published_desc")
 
       assert_tag_match(posts, "order:id_asc")
       assert_tag_match(posts, "order:score_asc")
@@ -1383,6 +1406,7 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match(posts, "order:notes_asc")
       assert_tag_match(posts, "order:md5_asc")
       assert_tag_match(posts, "order:duration_asc")
+      assert_tag_match(posts, "order:published_asc")
 
       # ordering is unpredictable so can't be tested.
       assert_tag_match([posts.first], "id:#{posts.first.id} order:none")

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1259,6 +1259,50 @@ class PostTest < ActiveSupport::TestCase
           end
         end
 
+        context "for published:<date>" do
+          should "set the publication date with explicit time zone" do
+            @post.update(:tag_string => "published:2026-01-01T12:34:56-0500")
+            assert_equal(Time.find_zone("UTC").local(2026, 1, 1, 17, 34, 56), @post.published_at)
+          end
+
+          should "set the publication date without explicit time zone to UTC instead of the user's time zone" do
+            Time.zone = "Pacific Time (US & Canada)"
+            @post.update(:tag_string => "published:2026-01-01T12:34:56")
+            assert_equal(Time.find_zone("UTC").local(2026, 1, 1, 12, 34, 56), @post.published_at)
+            Time.zone = "Eastern Time (US & Canada)"
+          end
+
+          should "set the publication date without seconds" do
+            @post.update(:tag_string => "published:2026-01-01T12:34Z")
+            assert_equal(Time.find_zone("UTC").local(2026, 1, 1, 12, 34, 0), @post.published_at)
+          end
+
+          should "set the publication date without time" do
+            @post.update(:tag_string => "published:2026-01-01")
+            assert_equal(Time.find_zone("UTC").local(2026, 1, 1, 0, 0, 0), @post.published_at)
+          end
+
+          should "set the publication date before 1970" do
+            @post.update(:tag_string => "published:1952-04-03")
+            assert_equal(Time.find_zone("UTC").local(1952, 4, 3, 0, 0, 0), @post.published_at)
+          end
+
+          should "fail to set the publication date to the future" do
+            @post.update(:tag_string => "published:9999-01-01")
+            assert_nil(@post.published_at)
+          end
+
+          should "clear the publication date" do
+            @post.update(:tag_string => "published:none")
+            assert_nil(@post.published_at)
+          end
+
+          should "fail to set the publication date to an invalid value" do
+            @post.update(:tag_string => "published:foo")
+            assert_nil(@post.published_at)
+          end
+        end
+
         context "of" do
           setup do
             @gold = FactoryBot.create(:gold_user)

--- a/test/unit/source/extractor/bluesky_extractor_test.rb
+++ b/test/unit/source/extractor/bluesky_extractor_test.rb
@@ -20,11 +20,16 @@ module Source::Tests::Extractor
         display_name: "Ixy(いくしー)",
         username: "ixy",
         tags: [],
+        published_at: Time.utc(2024, 2, 8, 11, 21, 50, 410_000),
         dtext_artist_commentary_desc: "らき☆すた原作２０周年おめでとうございます",
       )
     end
 
     context "A post with 'app.bsky.embed.images.view' embed and alt text" do
+      setup do
+        skip "Deleted post"
+      end
+
       strategy_should_work(
         "https://bsky.app/profile/magicianhero.bsky.social/post/3ljtkgqzwvc2t",
         dtext_artist_commentary_title: "",
@@ -41,6 +46,10 @@ module Source::Tests::Extractor
     end
 
     context "A post url with 'app.bsky.embed.recordWithMedia.view' embed and alt text" do
+      setup do
+        skip "Deleted post"
+      end
+
       strategy_should_work(
         "https://bsky.app/profile/yourbaguette.bsky.social/post/3kjarhifsmg26",
         image_urls: [
@@ -112,6 +121,7 @@ module Source::Tests::Extractor
         display_name: "Hi-GO!",
         username: "go-guiltism",
         tags: [],
+        published_at: Time.utc(2024, 2, 15, 7, 12, 37, 327_000),
         dtext_artist_commentary_desc: "Copy-X FullArmed 2",
       )
     end
@@ -126,6 +136,7 @@ module Source::Tests::Extractor
         display_name: "temmie",
         username: "tuyoki",
         tags: [],
+        published_at: Time.utc(2024, 9, 15, 17, 16, 34, 147_000),
         dtext_artist_commentary_desc: "victory pose",
       )
     end
@@ -175,6 +186,7 @@ module Source::Tests::Extractor
         display_name: "Ixy(いくしー)",
         username: "ixy",
         tags: [],
+        published_at: Time.utc(2024, 2, 8, 11, 21, 50, 410_000),
         dtext_artist_commentary_desc: "らき☆すた原作２０周年おめでとうございます",
       )
     end
@@ -193,6 +205,7 @@ module Source::Tests::Extractor
           ["逃げ若", "https://bsky.app/hashtag/逃げ若"],
           ["逃げ上手の若君", "https://bsky.app/hashtag/逃げ上手の若君"],
         ],
+        published_at: Time.utc(2024, 9, 15, 8, 24, 51, 499_000),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           8日目 北条時行
@@ -215,6 +228,7 @@ module Source::Tests::Extractor
         display_name: "轟将",
         username: "masarustrongest",
         tags: [],
+        published_at: Time.utc(2025, 4, 28, 4, 19, 54, 45_000),
         dtext_artist_commentary_desc: "Happy 6th Anniversary🌿",
       )
     end
@@ -233,6 +247,7 @@ module Source::Tests::Extractor
         display_name: /Banditelli/,
         username: "banditelli",
         tags: [],
+        published_at: Time.utc(2025, 5, 13, 10, 8, 43, 344_000),
         dtext_artist_commentary_desc: <<~EOS.chomp,
           Hops for all. "#birds":[https://bsky.app/hashtag/birds]
 
@@ -258,6 +273,7 @@ module Source::Tests::Extractor
         image_urls: ["https://bsky.social/xrpc/com.atproto.sync.getBlob?did=did:plc:3jogsxcisdcdzwjobhxbav2w&cid=bafkreiawa4vn5k37h2mlpwuhaqmeog3hsfe3z47iot7reqxjlff6juyge4"],
         media_files: [{ file_size: 398_747 }],
         profile_urls: ["https://bsky.app/profile/did:plc:3jogsxcisdcdzwjobhxbav2w"],
+        published_at: nil,
       )
     end
 

--- a/test/unit/source/extractor/deviant_art_extractor_test.rb
+++ b/test/unit/source/extractor/deviant_art_extractor_test.rb
@@ -9,13 +9,14 @@ module Source::Tests::Extractor
     context "A deviantart post" do
       strategy_should_work(
         "https://www.deviantart.com/aeror404/art/Holiday-Elincia-424551484",
-        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/11a24395-0f24-446d-ae73-a9f812e79e55/d70rm0s-e5b6b5e6-5795-44bb-a0ba-27b5c2349be7.jpg\?token=}],
+        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/11a24395-0f24-446d-ae73-a9f812e79e55/d70rm0s-e5b6b5e6-5795-44bb-a0ba-27b5c2349be7\.jpg\?token=}],
         media_files: [{ file_size: 877_987, width: 1620, height: 1380 }],
         page_url: "https://www.deviantart.com/aeror404/art/Holiday-Elincia-424551484",
         display_name: "aeror404",
         username: "aeror404",
         profile_url: "https://www.deviantart.com/aeror404",
         tags: [],
+        published_at: Time.utc(2014, 1, 4, 8, 56, 39),
         artist_commentary_title: "Holiday Elincia",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           Christmas sketch commission! Elincia from Fire Emblem! Thanks!
@@ -34,6 +35,7 @@ module Source::Tests::Extractor
         username: "nickbeja",
         profile_url: "https://www.deviantart.com/nickbeja",
         tags: [],
+        published_at: nil,
         artist_commentary_title: nil, # XXX use filename?
         artist_commentary_desc: nil,
       )
@@ -42,13 +44,14 @@ module Source::Tests::Extractor
     context "An old downloadable deviantart image" do
       strategy_should_work(
         "https://pre00.deviantart.net/b5e6/th/pre/f/2016/265/3/5/legend_of_galactic_heroes_by_hideyoshi-daihpha.jpg",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/b1f96af6-56a3-47a8-b7f4-406f243af3a3/daihpha-9f1fcd2e-7557-4db5-951b-9aedca9a3ae7.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcL2IxZjk2YWY2LTU2YTMtNDdhOC1iN2Y0LTQwNmYyNDNhZjNhM1wvZGFpaHBoYS05ZjFmY2QyZS03NTU3LTRkYjUtOTUxYi05YWVkY2E5YTNhZTcuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.YWZwVhPQHRLzRZUU2cTDXuWuA6ExFH57oFfGzAkxO6Y&filename=legend_of_galactic_heroes_by_hideyoshi_daihpha.jpg"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/b1f96af6-56a3-47a8-b7f4-406f243af3a3/daihpha-9f1fcd2e-7557-4db5-951b-9aedca9a3ae7\.jpg\?token=.+&filename=legend_of_galactic_heroes_by_hideyoshi_daihpha\.jpg}],
         media_files: [{ file_size: 906_621, width: 1600, height: 1044 }],
         page_url: "https://www.deviantart.com/hideyoshi/art/Legend-of-Galactic-Heroes-635721022",
         display_name: "Hideyoshi",
         username: "hideyoshi",
         profile_url: "https://www.deviantart.com/hideyoshi",
         tags: %w[barbarossa bay brunhild flare hangar odin planet ship spaceship sun sunset brünhild legendsofgalacticheroes],
+        published_at: Time.utc(2016, 9, 21, 13, 23, 4),
         artist_commentary_title: "Legend of Galactic Heroes",
         dtext_artist_commentary_desc: "Shamefully I have to say I didn't know this anime show before. wat? o_O Yet was approached to create a commissioned piece.. This is the result - Barbarossa and Brunhild landing on Odin.",
       )
@@ -57,13 +60,14 @@ module Source::Tests::Extractor
     context "A deviantart post without a downloadable or /intermediary/ image" do
       strategy_should_work(
         "https://www.deviantart.com/gregmks/art/Rhino-Castle-811778248",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/8c03bd02-63bf-407e-9c3e-c3fd21ab4bd5/ddfb83s-64c3b1fd-a554-498c-87dd-7ce83721a3d0.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzhjMDNiZDAyLTYzYmYtNDA3ZS05YzNlLWMzZmQyMWFiNGJkNVwvZGRmYjgzcy02NGMzYjFmZC1hNTU0LTQ5OGMtODdkZC03Y2U4MzcyMWEzZDAuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.ASOB3VvK4P7B2cRWr6mcgqWRIhhttAqVYa_u1WrUmuc&filename=rhino_castle_by_gregmks_ddfb83s.jpg"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/8c03bd02-63bf-407e-9c3e-c3fd21ab4bd5/ddfb83s-64c3b1fd-a554-498c-87dd-7ce83721a3d0\.jpg\?token=.+&filename=rhino_castle_by_gregmks_ddfb83s\.jpg}],
         media_files: [{ size: 662_982, width: 1200, height: 1500 }],
         page_url: "https://www.deviantart.com/gregmks/art/Rhino-Castle-811778248",
         display_name: "gregmks",
         username: "gregmks",
         profile_url: "https://www.deviantart.com/gregmks",
         tags: [],
+        published_at: Time.utc(2019, 9, 1, 17, 6, 5),
         artist_commentary_title: "Rhino Castle",
         dtext_artist_commentary_desc: 'Started as a simple Rhino sketch and it escalated quickly ":P (Lick)":[https://e.deviantart.net/emoticons/letters/=p.gif]',
       )
@@ -72,13 +76,14 @@ module Source::Tests::Extractor
     context "A downloadable deviantart origin-orig image" do
       strategy_should_work(
         "http://origin-orig.deviantart.net/7b5b/f/2017/160/c/5/test_post_please_ignore_by_noizave-dbc3a48.png",
-        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dbc3a48-10b9e2e8-b176-4820-ab9e-23449c11e7c9.png\?token=}],
+        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dbc3a48-10b9e2e8-b176-4820-ab9e-23449c11e7c9\.png\?token=}],
         media_files: [{ file_size: 3_619, width: 1152, height: 648 }],
         page_url: "https://www.deviantart.com/noizave/art/test-post-please-ignore-685436408",
         display_name: "noizave",
         username: "noizave",
         profile_url: "https://www.deviantart.com/noizave",
         tags: %w[bar baz foo],
+        published_at: Time.utc(2017, 6, 9, 14, 42, 34),
         artist_commentary_title: "test post please ignore",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           blah blah
@@ -109,22 +114,24 @@ module Source::Tests::Extractor
     context "A img00.deviantart.net sample" do
       strategy_should_work(
         "https://img00.deviantart.net/a233/i/2017/160/5/1/test_post_please_ignore_by_noizave-dbc3a48.png",
-        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dbc3a48-10b9e2e8-b176-4820-ab9e-23449c11e7c9.png\?token=}],
+        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dbc3a48-10b9e2e8-b176-4820-ab9e-23449c11e7c9\.png\?token=}],
         media_files: [{ file_size: 3_619, width: 1152, height: 648 }],
         page_url: "https://www.deviantart.com/noizave/art/test-post-please-ignore-685436408",
+        published_at: Time.utc(2017, 6, 9, 14, 42, 34),
       )
     end
 
     context "A th00.deviantart.net/*/PRE/* thumbnail" do
       strategy_should_work(
         "http://th00.deviantart.net/fs71/PRE/f/2014/065/3/b/goruto_by_xyelkiltrox-d797tit.png",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/d8995973-0b32-4a7d-8cd8-d847d083689a/d797tit-1eac22e0-38b6-4eae-adcb-1b72843fd62a.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcL2Q4OTk1OTczLTBiMzItNGE3ZC04Y2Q4LWQ4NDdkMDgzNjg5YVwvZDc5N3RpdC0xZWFjMjJlMC0zOGI2LTRlYWUtYWRjYi0xYjcyODQzZmQ2MmEucG5nIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.lMnggSrSiuWOhlBmd-1D0_SojJzb9LmwoLpbq1n9d4k&filename=goruto_by_xyelkiltrox_d797tit.png"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/d8995973-0b32-4a7d-8cd8-d847d083689a/d797tit-1eac22e0-38b6-4eae-adcb-1b72843fd62a\.png\?token=.+&filename=goruto_by_xyelkiltrox_d797tit\.png}],
         media_files: [{ file_size: 3_391_584, width: 2078, height: 3201 }],
         page_url: "https://www.deviantart.com/xyelkiltrox/art/Goruto-438744629",
         display_name: "XYelkiltroX",
         username: "xyelkiltrox",
         profile_url: "https://www.deviantart.com/xyelkiltrox",
         tags: [],
+        published_at: Time.utc(2014, 3, 7, 5, 16, 51),
         artist_commentary_title: "Goruto",
         dtext_artist_commentary_desc: "Fusión de Goku y Naruto al estilo de Akira Toriyama",
       )
@@ -140,6 +147,7 @@ module Source::Tests::Extractor
         username: "noizave",
         profile_url: "https://www.deviantart.com/noizave",
         tags: [],
+        published_at: Time.utc(2017, 8, 7, 21, 17, 27),
         artist_commentary_title: "test, no download",
         dtext_artist_commentary_desc: "",
       )
@@ -148,13 +156,14 @@ module Source::Tests::Extractor
     context "A deviantart page with download disabled for a huge file" do
       strategy_should_work(
         "https://www.deviantart.com/anatofinnstark/art/The-Blade-of-Miquella-914166242",
-        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/3d079e1f-386b-4bd0-84fc-cce9913fbc0c/df49r6q-b19fcb03-8c2e-4638-8c12-98d443c7ee33.jpg/v1/fill/w_900,h_507/the_blade_of_miquella_by_anatofinnstark_df49r6q.jpg\?token=}],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/3d079e1f-386b-4bd0-84fc-cce9913fbc0c/df49r6q-b19fcb03-8c2e-4638-8c12-98d443c7ee33\.jpg/v1/fill/w_900,h_507/the_blade_of_miquella_by_anatofinnstark_df49r6q\.jpg\?token=}],
         media_files: [{ file_size: 155_461, width: 900, height: 507 }],
         page_url: "https://www.deviantart.com/anatofinnstark/art/The-Blade-of-Miquella-914166242",
         display_name: "AnatoFinnstark",
         username: "anatofinnstark",
         profile_url: "https://www.deviantart.com/anatofinnstark",
         tags: [],
+        published_at: Time.utc(2022, 4, 25, 17, 2, 26),
         artist_commentary_title: "The Blade of Miquella",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           Another Malenia Art, and not the last ":) (Smile)":[https://e.deviantart.net/emoticons/s/smile.gif]
@@ -175,6 +184,7 @@ module Source::Tests::Extractor
         display_name: "Len1",
         username: "len1",
         profile_url: "https://www.deviantart.com/len1",
+        published_at: Time.utc(2018, 11, 29, 14, 21, 35),
         artist_commentary_title: "All that Glitters II",
       )
     end
@@ -182,13 +192,14 @@ module Source::Tests::Extractor
     context "A *.deviantart.net/*/:title_by_:artist.jpg image with an artist name containing underscores" do
       strategy_should_work(
         "https://orig00.deviantart.net/4274/f/2010/230/8/a/pkmn_king_and_queen_by_mikoto_chan.jpg",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/654817c0-5ba7-4591-9fd7-badae289cf88/d2wq7wl-b7f18546-753e-4d53-8051-ddb1879776c2.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzY1NDgxN2MwLTViYTctNDU5MS05ZmQ3LWJhZGFlMjg5Y2Y4OFwvZDJ3cTd3bC1iN2YxODU0Ni03NTNlLTRkNTMtODA1MS1kZGIxODc5Nzc2YzIuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.3-uVYYvKA4UvdXCv1cHTgeky5VSGFbMj7oayLgLZAxc&filename=pkmn_king_and_queen_by_mikotoazure_d2wq7wl.jpg"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/654817c0-5ba7-4591-9fd7-badae289cf88/d2wq7wl-b7f18546-753e-4d53-8051-ddb1879776c2\.jpg\?token=.+&filename=pkmn_king_and_queen_by_mikotoazure_d2wq7wl\.jpg}],
         media_files: [{ size: 401_175, width: 700, height: 543 }],
         page_url: "https://www.deviantart.com/mikotoazure/art/PKMN-King-and-Queen-175903365",
         display_name: "MikotoAzure",
         username: "mikotoazure",
         profile_url: "https://www.deviantart.com/mikotoazure",
         tags: [],
+        published_at: Time.utc(2010, 8, 19, 0, 33, 49),
         artist_commentary_title: "PKMN-King and Queen",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           Commision for "wolfathegoddess2010":[https://wolfathegoddess2010.deviantart.com/]
@@ -206,12 +217,13 @@ module Source::Tests::Extractor
     context "A *.deviantart.net/*/:hash.jpg image without referer" do
       strategy_should_work(
         "http://pre06.deviantart.net/8497/th/pre/f/2009/173/c/c/cc9686111dcffffffb5fcfaf0cf069fb.jpg",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/8b472d70-a0d6-41b5-9a66-c35687090acc/d23jbr4-8a06af02-70cb-46da-8a96-42a6ba73cdb4.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzhiNDcyZDcwLWEwZDYtNDFiNS05YTY2LWMzNTY4NzA5MGFjY1wvZDIzamJyNC04YTA2YWYwMi03MGNiLTQ2ZGEtOGE5Ni00MmE2YmE3M2NkYjQuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.dEDJSkIs-mbcGXDbSL1wRteRaHyl3rpc50EhsU5aZeE&filename=silverhawks_quicksilver_by_edsfox_d23jbr4.jpg"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/8b472d70-a0d6-41b5-9a66-c35687090acc/d23jbr4-8a06af02-70cb-46da-8a96-42a6ba73cdb4\.jpg\?token=.+&filename=silverhawks_quicksilver_by_edsfox_d23jbr4\.jpg}],
         media_files: [{ file_size: 390_108, width: 791, height: 1_024 }],
         page_url: "https://www.deviantart.com/edsfox/art/Silverhawks-Quicksilver-126872896",
         display_name: "edsfox",
         username: "edsfox",
         profile_url: "https://www.deviantart.com/edsfox",
+        published_at: Time.utc(2009, 6, 22, 21, 58, 23),
         artist_commentary_title: "Silverhawks Quicksilver",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           First of all.. I love this cartoon from the 80's.. so I decide to make this Fan art of Quicksilver flying into the earth's sky..
@@ -230,12 +242,13 @@ module Source::Tests::Extractor
     context "A *.deviantart.net/*/:hash.jpg image" do
       strategy_should_work(
         "http://pre06.deviantart.net/8497/th/pre/f/2009/173/c/c/cc9686111dcffffffb5fcfaf0cf069fb.jpg",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/8b472d70-a0d6-41b5-9a66-c35687090acc/d23jbr4-8a06af02-70cb-46da-8a96-42a6ba73cdb4.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzhiNDcyZDcwLWEwZDYtNDFiNS05YTY2LWMzNTY4NzA5MGFjY1wvZDIzamJyNC04YTA2YWYwMi03MGNiLTQ2ZGEtOGE5Ni00MmE2YmE3M2NkYjQuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.dEDJSkIs-mbcGXDbSL1wRteRaHyl3rpc50EhsU5aZeE&filename=silverhawks_quicksilver_by_edsfox_d23jbr4.jpg"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/8b472d70-a0d6-41b5-9a66-c35687090acc/d23jbr4-8a06af02-70cb-46da-8a96-42a6ba73cdb4\.jpg\?token=.+&filename=silverhawks_quicksilver_by_edsfox_d23jbr4\.jpg}],
         media_files: [{ file_size: 390_108, width: 791, height: 1_024 }],
         page_url: "https://www.deviantart.com/edsfox/art/Silverhawks-Quicksilver-126872896",
         display_name: "edsfox",
         username: "edsfox",
         profile_url: "https://www.deviantart.com/edsfox",
+        published_at: Time.utc(2009, 6, 22, 21, 58, 23),
         artist_commentary_title: "Silverhawks Quicksilver",
       )
     end
@@ -243,12 +256,13 @@ module Source::Tests::Extractor
     context "A images-wixmp-.* /intermediary/ sample" do
       strategy_should_work(
         "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/intermediary/f/8b472d70-a0d6-41b5-9a66-c35687090acc/d23jbr4-8a06af02-70cb-46da-8a96-42a6ba73cdb4.jpg/v1/fill/w_786,h_1017,q_70,strp/silverhawks_quicksilver_by_edsfox_d23jbr4-pre.jpg",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/8b472d70-a0d6-41b5-9a66-c35687090acc/d23jbr4-8a06af02-70cb-46da-8a96-42a6ba73cdb4.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzhiNDcyZDcwLWEwZDYtNDFiNS05YTY2LWMzNTY4NzA5MGFjY1wvZDIzamJyNC04YTA2YWYwMi03MGNiLTQ2ZGEtOGE5Ni00MmE2YmE3M2NkYjQuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.dEDJSkIs-mbcGXDbSL1wRteRaHyl3rpc50EhsU5aZeE&filename=silverhawks_quicksilver_by_edsfox_d23jbr4.jpg"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/8b472d70-a0d6-41b5-9a66-c35687090acc/d23jbr4-8a06af02-70cb-46da-8a96-42a6ba73cdb4\.jpg\?token=.+&filename=silverhawks_quicksilver_by_edsfox_d23jbr4\.jpg}],
         media_files: [{ file_size: 390_108, width: 791, height: 1_024 }],
         page_url: "https://www.deviantart.com/edsfox/art/Silverhawks-Quicksilver-126872896",
         display_name: "edsfox",
         username: "edsfox",
         profile_url: "https://www.deviantart.com/edsfox",
+        published_at: Time.utc(2009, 6, 22, 21, 58, 23),
         artist_commentary_title: "Silverhawks Quicksilver",
       )
     end
@@ -256,13 +270,14 @@ module Source::Tests::Extractor
     context "A api-da.wixmp.com sample" do
       strategy_should_work(
         "https://api-da.wixmp.com/_api/download/file?downloadToken=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsImV4cCI6MTU5MDkwMTUzMywiaWF0IjoxNTkwOTAwOTIzLCJqdGkiOiI1ZWQzMzhjNWQ5YjI0Iiwib2JqIjpudWxsLCJhdWQiOlsidXJuOnNlcnZpY2U6ZmlsZS5kb3dubG9hZCJdLCJwYXlsb2FkIjp7InBhdGgiOiJcL2ZcL2U0NmE0OGViLTNkMGItNDQ5ZS05MGRjLTBhMWIzMWNiMTM2MVwvZGQzcDF4OS1mYjQ3YmM4Zi02NTNlLTQyYTItYmI0ZC1hZmFmOWZjMmI3ODEuanBnIn19.-zo8E2eDmkmDNCK-sMabBajkaGtVYJ2Q20iVrUtt05Q",
-        image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/e46a48eb-3d0b-449e-90dc-0a1b31cb1361/dd3p1x9-fb47bc8f-653e-42a2-bb4d-afaf9fc2b781.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcL2U0NmE0OGViLTNkMGItNDQ5ZS05MGRjLTBhMWIzMWNiMTM2MVwvZGQzcDF4OS1mYjQ3YmM4Zi02NTNlLTQyYTItYmI0ZC1hZmFmOWZjMmI3ODEuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.NtrspZ7pPL_ZHX62NEKn3x_0DnsmQJnn0xRz3Y0j-to&filename=ten_miles_of_cherry_blossoms_by_akizero1510_dd3p1x9.jpg"],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/e46a48eb-3d0b-449e-90dc-0a1b31cb1361/dd3p1x9-fb47bc8f-653e-42a2-bb4d-afaf9fc2b781\.jpg\?token=.+&filename=ten_miles_of_cherry_blossoms_by_akizero1510_dd3p1x9\.jpg}],
         media_files: [{ size: 1_289_162, width: 1415, height: 1000 }],
         page_url: "https://www.deviantart.com/akizero1510/art/Ten-miles-of-cherry-blossoms-792268029",
         display_name: "AkiZero1510",
         username: "akizero1510",
         profile_url: "https://www.deviantart.com/akizero1510",
         tags: [],
+        published_at: Time.utc(2019, 4, 3, 11, 37, 24),
         artist_commentary_title: "Ten miles of cherry blossoms",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           Commission for "shrimpHEBY":[https://www.deviantart.com/shrimpheby]
@@ -274,8 +289,9 @@ module Source::Tests::Extractor
     context "A non-downloadable animated gif with id<=790677560" do
       strategy_should_work(
         "https://www.deviantart.com/heartgear/art/Silent-Night-579982816",
-        image_urls: [%r{\Ahttps://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/ea95be00-c5aa-4063-bd55-f5a9183912f7/d9lb1ls-7d625444-0003-4123-bf00-274737ca7fdd.gif\?token=}],
+        image_urls: [%r{\Ahttps://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/ea95be00-c5aa-4063-bd55-f5a9183912f7/d9lb1ls-7d625444-0003-4123-bf00-274737ca7fdd\.gif\?token=}],
         media_files: [{ file_size: 350_156, width: 746, height: 977 }],
+        published_at: Time.utc(2015, 12, 24, 18, 19, 4),
       )
     end
 
@@ -294,6 +310,7 @@ module Source::Tests::Extractor
           ["chakraguardians", "https://www.deviantart.com/tag/chakraguardians"],
           ["animation", "https://www.deviantart.com/tag/animation"],
         ],
+        published_at: Time.utc(2021, 12, 10, 17, 46, 49),
         dtext_artist_commentary_title: "Amelia",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           my baby 💙💙💙
@@ -314,6 +331,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://wixmp-ed30a86b8c4ca887773594c2.wixmp.com/v/mp4/d204f74b-728d-4a3e-9d85-217e5f4fffa3/dew0240-8051caf7-f08a-4727-a974-7f5396644c2a.VideoQualities.res_1080p.23d4baf83a244c979bc3378b2643dfb6.mp4],
         media_files: [{ file_size: 13_369_722, width: 1920, height: 1080 }],
         page_url: "https://www.deviantart.com/cutenikechan/art/Amelia-900276912",
+        published_at: Time.utc(2021, 12, 10, 17, 46, 49),
       )
     end
 
@@ -327,6 +345,7 @@ module Source::Tests::Extractor
         username: "noizave",
         profile_url: "https://www.deviantart.com/noizave",
         tags: %w[bar baz foo],
+        published_at: Time.utc(2017, 6, 9, 17, 8, 44),
         artist_commentary_title: "hidden work",
       )
     end
@@ -341,6 +360,7 @@ module Source::Tests::Extractor
         display_name: "BNJacob",
         username: "bnjacob",
         other_names: ["BNJacob"],
+        published_at: Time.utc(2024, 1, 2, 10, 59, 53),
         dtext_artist_commentary_title: "Celestial Muse #1",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           [i][b]*Purchase by points on DeviantArt could help reduce the fee on me*
@@ -360,6 +380,10 @@ module Source::Tests::Extractor
     end
 
     context "A watchers-only DeviantArt image" do
+      setup do
+        skip "Deleted post"
+      end
+
       strategy_should_work(
         "https://www.deviantart.com/theraceai/art/Realistic-Girl-14-1027403734",
         image_urls: [],
@@ -510,12 +534,13 @@ module Source::Tests::Extractor
     context "An artistname.deviantart.com page url" do
       strategy_should_work(
         "http://noizave.deviantart.com/art/test-post-please-ignore-685436408",
-        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dbc3a48-10b9e2e8-b176-4820-ab9e-23449c11e7c9.png\?token=}],
+        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dbc3a48-10b9e2e8-b176-4820-ab9e-23449c11e7c9\.png\?token=}],
         page_url: "https://www.deviantart.com/noizave/art/test-post-please-ignore-685436408",
         display_name: "noizave",
         username: "noizave",
         profile_url: "https://www.deviantart.com/noizave",
         tags: %w[bar baz foo],
+        published_at: Time.utc(2017, 6, 9, 14, 42, 34),
         artist_commentary_title: "test post please ignore",
       )
     end
@@ -523,12 +548,13 @@ module Source::Tests::Extractor
     context "A deviantart page for a Flash file" do
       strategy_should_work(
         "https://www.deviantart.com/midorynn/art/NieR-Automata-Anime-703917761",
-        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/e1d5122b-6fee-44df-8b8f-e6e8daa3396d/dbn3ef5-9e051a71-251d-4e0f-b5f1-3beb5e6a8667.swf\?token=}],
+        image_urls: [%r{https://wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/e1d5122b-6fee-44df-8b8f-e6e8daa3396d/dbn3ef5-9e051a71-251d-4e0f-b5f1-3beb5e6a8667\.swf\?token=}],
         media_files: [{ size: 4_243_457, width: 700, height: 300 }],
         display_name: "midorynn",
         username: "midorynn",
         profile_url: "https://www.deviantart.com/midorynn",
         tags: %w[animation fanart nier_automata nierautomata nier_automata_2b],
+        published_at: Time.utc(2017, 9, 12, 20, 22, 39),
         artist_commentary_title: "NieR: Automata Anime",
       )
     end
@@ -590,7 +616,7 @@ module Source::Tests::Extractor
     context "A DeviantPost with a commentary created using the WYSIWYG text editor" do
       strategy_should_work(
         "https://www.deviantart.com/noizave/art/1-Image-No-Contribution-1048220942",
-        image_urls: %w[https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dhc30ge-d2c07e30-3914-479d-8098-72ad01dc1209.jpg?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzgzZDNlYjRkLTEzZTUtNGFlYS1hMDhmLThkNDMzMWQwMzNjNFwvZGhjMzBnZS1kMmMwN2UzMC0zOTE0LTQ3OWQtODA5OC03MmFkMDFkYzEyMDkuanBnIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.zmr9cWpT_6WNXHCYvhbTDn9j1TXiSFWRWJEHV_MRi_c&filename=_1_image_no_contribution_by_noizave_dhc30ge.jpg],
+        image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dhc30ge-d2c07e30-3914-479d-8098-72ad01dc1209\.jpg\?token=.+&filename=_1_image_no_contribution_by_noizave_dhc30ge\.jpg}],
         media_files: [{ file_size: 213_868 }],
         page_url: "https://www.deviantart.com/noizave/art/1-Image-No-Contribution-1048220942",
         profile_url: "https://www.deviantart.com/noizave",
@@ -599,6 +625,7 @@ module Source::Tests::Extractor
         username: "noizave",
         other_names: ["noizave"],
         tags: [],
+        published_at: Time.utc(2024, 5, 3, 4, 52, 56),
         dtext_artist_commentary_title: "-1 Image No Contribution",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           h2. title
@@ -639,13 +666,14 @@ module Source::Tests::Extractor
       context "A https://sta.sh/:id url" do
         strategy_should_work(
           "https://sta.sh/0wxs31o7nn2",
-          image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dcmga0s-a345a815-2436-4ab5-8941-492011e1bff6.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzgzZDNlYjRkLTEzZTUtNGFlYS1hMDhmLThkNDMzMWQwMzNjNFwvZGNtZ2Ewcy1hMzQ1YTgxNS0yNDM2LTRhYjUtODk0MS00OTIwMTFlMWJmZjYucG5nIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.F2icb46nKwaaatyalqOVDO41BF3UrY3VFHvyJeHBGEk&filename=a_pepe_by_noizave_dcmga0s.png"],
+          image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dcmga0s-a345a815-2436-4ab5-8941-492011e1bff6\.png\?token=.+&filename=a_pepe_by_noizave_dcmga0s\.png}],
           media_files: [{ size: 106_741, width: 750, height: 730 }],
           page_url: "https://sta.sh/0wxs31o7nn2",
           display_name: "noizave",
           username: "noizave",
           profile_url: "https://www.deviantart.com/noizave",
           tags: [],
+          published_at: Time.utc(2018, 9, 9, 21, 4, 6),
           artist_commentary_title: "A pepe",
           artist_commentary_desc: "This is a test.",
         )
@@ -654,7 +682,7 @@ module Source::Tests::Extractor
       context "A https://orig00.deviantart.net/* image url with a https://sta.sh/:id referer" do
         strategy_should_work(
           "https://orig00.deviantart.net/0fd2/f/2018/252/9/c/a_pepe_by_noizave-dcmga0s.png",
-          image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dcmga0s-a345a815-2436-4ab5-8941-492011e1bff6.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzgzZDNlYjRkLTEzZTUtNGFlYS1hMDhmLThkNDMzMWQwMzNjNFwvZGNtZ2Ewcy1hMzQ1YTgxNS0yNDM2LTRhYjUtODk0MS00OTIwMTFlMWJmZjYucG5nIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.F2icb46nKwaaatyalqOVDO41BF3UrY3VFHvyJeHBGEk&filename=a_pepe_by_noizave_dcmga0s.png"],
+          image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dcmga0s-a345a815-2436-4ab5-8941-492011e1bff6\.png\?token=.+&filename=a_pepe_by_noizave_dcmga0s\.png}],
           media_files: [{ size: 106_741, width: 750, height: 730 }],
           referer: "https://sta.sh/0wxs31o7nn2",
           page_url: "https://sta.sh/0wxs31o7nn2",
@@ -662,6 +690,7 @@ module Source::Tests::Extractor
           username: "noizave",
           profile_url: "https://www.deviantart.com/noizave",
           tags: [],
+          published_at: Time.utc(2018, 9, 9, 21, 4, 6),
           artist_commentary_title: "A pepe",
           artist_commentary_desc: "This is a test.",
         )
@@ -670,7 +699,7 @@ module Source::Tests::Extractor
       context "A https://orig00.deviantart.net/* image url without the referer" do
         strategy_should_work(
           "https://orig00.deviantart.net/0fd2/f/2018/252/9/c/a_pepe_by_noizave-dcmga0s.png",
-          image_urls: ["https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dcmga0s-a345a815-2436-4ab5-8941-492011e1bff6.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwic3ViIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsImF1ZCI6WyJ1cm46c2VydmljZTpmaWxlLmRvd25sb2FkIl0sIm9iaiI6W1t7InBhdGgiOiIvZi84M2QzZWI0ZC0xM2U1LTRhZWEtYTA4Zi04ZDQzMzFkMDMzYzQvZGNtZ2Ewcy1hMzQ1YTgxNS0yNDM2LTRhYjUtODk0MS00OTIwMTFlMWJmZjYucG5nIn1dXX0.b29qVmG1on0SIwS0KhZjYM_LowH0A1NvO9cyvHde-mw"],
+          image_urls: [%r{https://images-wixmp-ed30a86b8c4ca887773594c2\.wixmp\.com/f/83d3eb4d-13e5-4aea-a08f-8d4331d033c4/dcmga0s-a345a815-2436-4ab5-8941-492011e1bff6\.png\?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9\.eyJpc3MiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwic3ViIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsImF1ZCI6WyJ1cm46c2VydmljZTpmaWxlLmRvd25sb2FkIl0sIm9iaiI6W1t7InBhdGgiOiIvZi84M2QzZWI0ZC0xM2U1LTRhZWEtYTA4Zi04ZDQzMzFkMDMzYzQvZGNtZ2Ewcy1hMzQ1YTgxNS0yNDM2LTRhYjUtODk0MS00OTIwMTFlMWJmZjYucG5nIn1dXX0\.b29qVmG1on0SIwS0KhZjYM_LowH0A1NvO9cyvHde-mw}],
           media_files: [{ size: 106_741, width: 750, height: 730 }],
           # if all we have is the image url, then we can't tell that this is really a sta.sh image.
           site_name: "Deviant Art",
@@ -680,6 +709,7 @@ module Source::Tests::Extractor
           username: "noizave",
           profile_url: "https://www.deviantart.com/noizave",
           tags: [],
+          published_at: nil,
           artist_commentary_title: nil,
           artist_commentary_desc: nil,
         )

--- a/test/unit/source/extractor/mastodon_extractor_test.rb
+++ b/test/unit/source/extractor/mastodon_extractor_test.rb
@@ -14,6 +14,7 @@ module Source::Tests::Extractor
           profile_url: "https://pawoo.net/@9ed00e924818",
           username: "9ed00e924818",
           display_name: nil,
+          published_at: Time.utc(2017, 4, 17, 20, 43, 37, 620_000),
           dtext_artist_commentary_desc: "a mind forever voyaging through strange seas of thought alone",
           media_files: [{ file_size: 7_680 }],
         )
@@ -42,6 +43,7 @@ module Source::Tests::Extractor
           username: "evazion",
           display_name: nil,
           tags: %w[foo bar baz],
+          published_at: Time.utc(2017, 6, 10, 23, 2, 48, 412_000),
           dtext_artist_commentary_desc: desc,
         )
       end
@@ -53,6 +55,7 @@ module Source::Tests::Extractor
           media_files: [{ file_size: 59_950 }],
           referer: "https://pawoo.net/@evazion/19451018",
           page_url: "https://pawoo.net/@evazion/19451018",
+          published_at: Time.utc(2017, 6, 10, 23, 2, 48, 412_000),
         )
       end
 
@@ -61,6 +64,7 @@ module Source::Tests::Extractor
           "https://pawoo.net/@nonamethankswashere/12345678901234567890",
           profile_url: "https://pawoo.net/@nonamethankswashere",
           username: "nonamethankswashere",
+          published_at: nil,
           deleted: true,
         )
       end
@@ -79,6 +83,7 @@ module Source::Tests::Extractor
           profile_url: "https://baraag.net/@bardbot",
           username: "bardbot",
           display_name: "SpicyBardo🔞",
+          published_at: Time.utc(2021, 2, 15, 2, 4, 53, 255_000),
           dtext_artist_commentary_desc: "🍌",
         )
       end
@@ -88,6 +93,7 @@ module Source::Tests::Extractor
           "https://baraag.net/system/media_attachments/files/105/803/948/862/719/091/original/54e1cb7ca33ec449.png",
           image_urls: ["https://media.baraag.net/media_attachments/files/105/803/948/862/719/091/original/54e1cb7ca33ec449.png"],
           media_files: [{ file_size: 363_261 }],
+          published_at: nil,
         )
       end
 
@@ -96,6 +102,7 @@ module Source::Tests::Extractor
           "https://media.baraag.net/media_attachments/files/105/803/948/862/719/091/original/54e1cb7ca33ec449.png",
           image_urls: ["https://media.baraag.net/media_attachments/files/105/803/948/862/719/091/original/54e1cb7ca33ec449.png"],
           media_files: [{ file_size: 363_261 }],
+          published_at: nil,
         )
       end
 
@@ -104,6 +111,7 @@ module Source::Tests::Extractor
           "https://baraag.net/@nonamethankswashere/12345678901234567890",
           profile_url: "https://baraag.net/@nonamethankswashere",
           username: "nonamethankswashere",
+          published_at: nil,
           deleted: true,
         )
       end

--- a/test/unit/source/extractor/mihuashi_extractor_test.rb
+++ b/test/unit/source/extractor/mihuashi_extractor_test.rb
@@ -11,6 +11,7 @@ module Source::Tests::Extractor
         profile_url: nil,
         display: nil,
         tags: [],
+        published_at: nil,
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -33,6 +34,7 @@ module Source::Tests::Extractor
           ["厚涂", "https://www.mihuashi.com/search?tab=artwork&q=厚涂"],
           ["插图", "https://www.mihuashi.com/search?tab=artwork&q=插图"],
         ],
+        published_at: Time.utc(2024, 5, 29, 8, 12, 57),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -54,6 +56,7 @@ module Source::Tests::Extractor
           ["meme", "https://www.mihuashi.com/search?tab=artwork&q=meme"],
           ["碧蓝档案", "https://www.mihuashi.com/search?tab=artwork&q=碧蓝档案"],
         ],
+        published_at: Time.utc(2024, 3, 10, 2, 54, 34),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -80,6 +83,7 @@ module Source::Tests::Extractor
         ],
         username: "黑石肆维",
         tags: [],
+        published_at: nil,
         dtext_artist_commentary_title: "印象QQ服",
         dtext_artist_commentary_desc: "封面这样的一身服设，拍下请提供设定图，会根据设定绘制印象服设，可以指定风格元素等！\n如想约两件及以上可以拍一个橱窗然后改价！\n流程：草稿-成图（修改意见请尽量在草稿提出，成图后就不能作大面积调整啦抱歉！（颜色成图后也可以随便改））\n\n备注：默认可以二转二改，商用需×3，有需要可以提供透明底线稿，草稿可以推翻重画两次（废稿会回收），小改次数不限，过程中如果觉得不满意到无法进行修改的程度随时可以沟通退稿，我真的很好说话，有意见尽管提出就好！！！\n\n感谢每位约稿的老板！！！",
       )
@@ -94,6 +98,7 @@ module Source::Tests::Extractor
         profile_urls: [],
         username: nil,
         tags: [],
+        published_at: Time.utc(2024, 12, 21, 13, 14, 17),
         dtext_artist_commentary_title: "💖五仁2025个人企划",
         dtext_artist_commentary_desc: "2025年五仁企划留档",
       )
@@ -108,6 +113,7 @@ module Source::Tests::Extractor
         profile_urls: [],
         username: nil,
         tags: [],
+        published_at: Time.utc(2025, 1, 24, 9, 43, 46),
         dtext_artist_commentary_title: "Amorolvido的2025年企💐🪦🕯️",
         dtext_artist_commentary_desc: "Amorolvido的2025年全年企划\n提供了5套设定（1原设+4服设）\n应征可以明确表示想画哪一个o(≧v≦)o\n感谢大家对Amor的喜欢🥺😚❤️\n祝大家25年心想事成万事如意喔",
       )
@@ -128,6 +134,7 @@ module Source::Tests::Extractor
         profile_urls: [],
         username: nil,
         tags: [],
+        published_at: Time.utc(2024, 6, 28, 13, 14, 51),
         dtext_artist_commentary_title: "墨殇离歌Project宣传图-多人互动",
         dtext_artist_commentary_desc: "OC企划宣传图-日系二次元多人宣传图。报价为单张商断报价相信价格根据具体细节沟通确定。详细需求会以文件形式发送给画师，欢迎应征",
       )
@@ -142,6 +149,7 @@ module Source::Tests::Extractor
         profile_urls: [],
         username: nil,
         tags: [],
+        published_at: nil,
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -157,6 +165,7 @@ module Source::Tests::Extractor
         profile_urls: [],
         username: nil,
         tags: [],
+        published_at: Time.utc(2025, 7, 12, 10, 34, 1),
         dtext_artist_commentary_title: "1",
         dtext_artist_commentary_desc: "还原，细致",
       )
@@ -181,6 +190,7 @@ module Source::Tests::Extractor
         profile_urls: [],
         username: nil,
         tags: [],
+        published_at: Time.utc(2024, 10, 29, 4, 43, 58),
         dtext_artist_commentary_title: "一些可以使用的元素",
         dtext_artist_commentary_desc: "生命之流是图1绿色的流动的线，菲拉是图二的黑色斗篷",
       )
@@ -199,6 +209,7 @@ module Source::Tests::Extractor
         ],
         username: "悪の箱",
         tags: [],
+        published_at: Time.utc(2019, 6, 16, 7, 28, 36),
         dtext_artist_commentary_title: "粉蓝夏日泳装",
         dtext_artist_commentary_desc: "成年人也想吹泡泡~(´-ω-`)【粉蓝萝莉的设计真的很棒！！",
       )
@@ -224,11 +235,12 @@ module Source::Tests::Extractor
         page_url: "https://www.mihuashi.com/activities/jw3-exterior-12/artworks/10515?type=zjjh",
         profile_url: "https://www.mihuashi.com/profiles/492",
         profile_urls: [
-          "https://www.mihuashi.com/users/CR",
+          "https://www.mihuashi.com/users/麻烦花少",
           "https://www.mihuashi.com/profiles/492",
         ],
-        username: "CR",
+        username: "麻烦花少",
         tags: [],
+        published_at: Time.utc(2021, 7, 3, 17, 58, 9),
         dtext_artist_commentary_title: "纸仙云鹤",
         dtext_artist_commentary_desc: "这套时装灵感来自于中国传统剪纸文化，结合了仙鹤和祥云的元素。\n红色的宣纸上剪裁出仙鹤在祥云中飞翔的图案，希望给大家带来温暖的感觉。",
       )
@@ -250,6 +262,7 @@ module Source::Tests::Extractor
           ["Q版", "https://www.mihuashi.com/search?tab=artwork&q=Q版"],
           ["插图", "https://www.mihuashi.com/search?tab=artwork&q=插图"],
         ],
+        published_at: Time.utc(2024, 3, 26, 8, 34, 14),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "蔚蓝档案小桃",
       )

--- a/test/unit/source/extractor/pixiv_extractor_test.rb
+++ b/test/unit/source/extractor/pixiv_extractor_test.rb
@@ -18,6 +18,7 @@ module Source::Tests::Extractor
         display_name: "Nardack",
         username: "nardack",
         tags: %w[神崎蘭子 双葉杏 アイドルマスターシンデレラガールズ Star!! アイマス10000users入り],
+        published_at: Time.find_zone("Tokyo").local(2015, 3, 14, 17, 53, 32),
         dtext_artist_commentary_title: "ツイログ",
         dtext_artist_commentary_desc: "",
       )
@@ -35,6 +36,7 @@ module Source::Tests::Extractor
         display_name: "uroobnad2",
         username: "user_myeg3558",
         tags: %w[Ugoira png blue],
+        published_at: Time.find_zone("Tokyo").local(2017, 4, 4, 8, 57, 38),
         dtext_artist_commentary_title: "ugoira",
         dtext_artist_commentary_desc: "",
       )
@@ -62,6 +64,7 @@ module Source::Tests::Extractor
         display_name: "uroobnad2",
         username: "user_myeg3558",
         tags: %w[Ugoira png blue],
+        published_at: Time.find_zone("Tokyo").local(2017, 4, 4, 8, 57, 38),
         dtext_artist_commentary_title: "ugoira",
         dtext_artist_commentary_desc: "",
       )
@@ -79,6 +82,7 @@ module Source::Tests::Extractor
         display_name: "uroobnad2",
         username: "user_myeg3558",
         tags: %w[Ugoira png blue],
+        published_at: Time.find_zone("Tokyo").local(2017, 4, 4, 8, 57, 38),
         dtext_artist_commentary_title: "ugoira",
         dtext_artist_commentary_desc: "",
       )
@@ -91,6 +95,7 @@ module Source::Tests::Extractor
         media_files: [{ file_size: 10_155 }],
         page_url: "https://www.pixiv.net/artworks/120834265",
         profile_urls: %w[https://www.pixiv.net/users/1802419 https://www.pixiv.net/stacc/thejunebug],
+        published_at: Time.find_zone("Tokyo").local(2024, 7, 24, 8, 46, 41),
       )
     end
 
@@ -105,6 +110,7 @@ module Source::Tests::Extractor
       strategy_should_work(
         "https://www.pixiv.net/artworks/113760314",
         image_urls: ["https://i.pximg.net/img-zip-ugoira/img/2023/11/27/19/51/28/113760314_ugoira1920x1080.zip?original"],
+        published_at: Time.find_zone("Tokyo").local(2023, 11, 27, 19, 51, 28),
         media_files: [
           {
             file_size: 5_320_292,
@@ -175,6 +181,7 @@ module Source::Tests::Extractor
       strategy_should_work(
         "https://i.pximg.net/img-zip-ugoira/img/2024/03/24/07/15/10/117197872_ugoira1920x1080.zip",
         image_urls: [],
+        published_at: nil,
       )
     end
 
@@ -187,6 +194,7 @@ module Source::Tests::Extractor
         display_name: "イチリ",
         username: "itiri",
         tags: %w[Fate/GrandOrder フランケンシュタイン(Fate) 水着 バーサーかわいい 新宿のアーチャー パパ製造機 Fate/GO5000users入り フランケンシュタイン(水着) セイバー(Fate)],
+        published_at: Time.find_zone("Tokyo").local(2017, 8, 18, 0, 9, 21),
         dtext_artist_commentary_title: "水着フランたそ",
         dtext_artist_commentary_desc: "ますたーもひかげですずむ？",
       )
@@ -201,6 +209,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: nil,
         tags: [],
+        published_at: Time.find_zone("Tokyo").local(2018, 12, 30, 1, 4, 55),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
         deleted: true,
@@ -217,6 +226,7 @@ module Source::Tests::Extractor
         profile_url: "https://www.pixiv.net/users/6570768",
         profile_urls: %w[https://www.pixiv.net/stacc/haku3490 https://www.pixiv.net/users/6570768],
         tags: %w[r-18 shylily シャイリリー バーチャルyoutuber バーチャルyoutuber30000users入り 両手に茎 乱交 輪姦],
+        published_at: Time.find_zone("Tokyo").local(2022, 8, 14, 19, 23, 6),
       )
     end
 
@@ -233,6 +243,7 @@ module Source::Tests::Extractor
         profile_url: "https://www.pixiv.net/users/6570768",
         profile_urls: %w[https://www.pixiv.net/stacc/haku3490 https://www.pixiv.net/users/6570768],
         tags: %w[r-18 shylily シャイリリー バーチャルyoutuber バーチャルyoutuber30000users入り 両手に茎 乱交 輪姦],
+        published_at: Time.find_zone("Tokyo").local(2022, 8, 14, 21, 21, 24),
       )
     end
 
@@ -244,6 +255,7 @@ module Source::Tests::Extractor
         display_name: "Anzatiridonia",
         profile_url: "https://www.pixiv.net/users/33589885",
         tags: %w[AI Re:ゼロから始める異世界生活 レム リゼロ レム(リゼロ) AIイラスト AnythingV3 Present sweater],
+        published_at: Time.find_zone("Tokyo").local(2022, 12, 3, 5, 6, 51),
       )
     end
 
@@ -372,6 +384,7 @@ module Source::Tests::Extractor
         display_name: "uroobnad2",
         username: "user_myeg3558",
         tags: %w[blue png],
+        published_at: Time.find_zone("Tokyo").local(2017, 4, 4, 8, 54, 15),
         dtext_artist_commentary_title: "single image",
         dtext_artist_commentary_desc: "description here",
       )
@@ -387,6 +400,7 @@ module Source::Tests::Extractor
         display_name: "uroobnad2",
         username: "user_myeg3558",
         tags: %w[blue png],
+        published_at: Time.find_zone("Tokyo").local(2017, 4, 4, 8, 54, 15),
         dtext_artist_commentary_title: "single image",
         dtext_artist_commentary_desc: "description here",
       )
@@ -402,6 +416,7 @@ module Source::Tests::Extractor
         display_name: "uroobnad2",
         username: "user_myeg3558",
         tags: %w[blue png],
+        published_at: Time.find_zone("Tokyo").local(2017, 4, 4, 8, 54, 15),
         dtext_artist_commentary_title: "single image",
         dtext_artist_commentary_desc: "description here",
       )
@@ -430,6 +445,7 @@ module Source::Tests::Extractor
           ["聖あげは", "https://www.pixiv.net/tags/聖あげは/artworks"],
           ["入れ替わり", "https://www.pixiv.net/tags/入れ替わり/artworks"],
         ],
+        published_at: Time.find_zone("Tokyo").local(2024, 4, 26, 13, 3, 41),
         dtext_artist_commentary_title: "ひプまとめ",
         dtext_artist_commentary_desc: "主にX(旧:Twitter)に載せた絵の寄せ集めです。",
       )
@@ -453,6 +469,7 @@ module Source::Tests::Extractor
           ["海琴烟", "https://www.pixiv.net/tags/海琴烟/artworks"],
           ["オリジナル10000users入り", "https://www.pixiv.net/tags/オリジナル10000users入り/artworks"],
         ],
+        published_at: Time.find_zone("Tokyo").local(2022, 3, 8, 0, 0, 56),
         dtext_artist_commentary_title: "Destination",
         dtext_artist_commentary_desc: "",
       )
@@ -468,6 +485,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: nil,
         tags: [],
+        published_at: Time.find_zone("Tokyo").local(2014, 12, 18, 10, 31, 23),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -483,6 +501,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: nil,
         tags: [],
+        published_at: Time.find_zone("Tokyo").local(2015, 10, 25, 8, 45, 27),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -494,6 +513,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://i.pximg.net/novel-cover-original/img/2017/07/27/23/14/17/8465454_80685d10e6df4d7d53ad347ddc18a36b.jpg],
         media_files: [{ file_size: 532_037 }],
         page_url: "https://www.pixiv.net/novel/show.php?id=8465454",
+        published_at: Time.find_zone("Tokyo").local(2017, 7, 27, 23, 14, 17),
       )
     end
 
@@ -518,6 +538,7 @@ module Source::Tests::Extractor
           ["百合", "https://www.pixiv.net/tags/百合/novels"],
           ["ガルパン小説100users入り", "https://www.pixiv.net/tags/ガルパン小説100users入り/novels"],
         ],
+        published_at: Time.find_zone("Tokyo").local(2017, 7, 27, 23, 14, 17),
         dtext_artist_commentary_title: "さよならのその先へ 後編",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           前回[b]"novel/8414084":[https://www.pixiv.net/novel/show.php?id=8414084][/b]の続きです。
@@ -563,6 +584,7 @@ module Source::Tests::Extractor
         username: nil,
         other_names: [],
         tags: [],
+        published_at: Time.find_zone("Tokyo").local(2022, 11, 2, 10, 4, 22),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -599,6 +621,7 @@ module Source::Tests::Extractor
           ["【SOZアロイスとユーゴ】", "https://www.pixiv.net/tags/【SOZアロイスとユーゴ】/novels"],
           ["アラディア院", "https://www.pixiv.net/tags/アラディア院/novels"],
         ],
+        published_at: Time.find_zone("Tokyo").local(2022, 10, 23, 21, 11, 17),
         dtext_artist_commentary_title: "【PFSOZ】身バレ【アラディア院】",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           リーリンの息子であることは隠していましたが、一部の人間に身バレしました。
@@ -636,6 +659,7 @@ module Source::Tests::Extractor
           ["【SOZアロイスとユーゴ】", "https://www.pixiv.net/tags/【SOZアロイスとユーゴ】/novels"],
           ["創作", "https://www.pixiv.net/tags/創作/novels"],
         ],
+        published_at: Time.find_zone("Tokyo").local(2022, 10, 23, 17, 31, 13),
         dtext_artist_commentary_title: "ユーゴとアロイス",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           PFSOZの自キャラのSS。傾向はブロマンス。友情と家族愛。魔術師リーリンの息子であるユーゴは正体を隠した父親に育てられるが、彼との関係に行き詰まり、外の世界を知ろうとアラディア院の門をたたくのだった。
@@ -671,6 +695,7 @@ module Source::Tests::Extractor
           ["【SOZアロイスとユーゴ】", "https://www.pixiv.net/tags/【SOZアロイスとユーゴ】/novels"],
           ["創作", "https://www.pixiv.net/tags/創作/novels"],
         ],
+        published_at: Time.find_zone("Tokyo").local(2022, 10, 23, 17, 31, 13),
         dtext_artist_commentary_title: "ユーゴとアロイス",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           PFSOZの自キャラのSS。傾向はブロマンス。友情と家族愛。魔術師リーリンの息子であるユーゴは正体を隠した父親に育てられるが、彼との関係に行き詰まり、外の世界を知ろうとアラディア院の門をたたくのだった。
@@ -690,6 +715,7 @@ module Source::Tests::Extractor
         media_files: [{ file_size: 1_770_646 }],
         page_url: "https://www.pixiv.net/novel/series/9593812",
         profile_url: "https://www.pixiv.net/users/66091066",
+        published_at: Time.find_zone("Tokyo").local(2022, 10, 23, 17, 31, 13),
       )
     end
 
@@ -699,6 +725,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://i.pximg.net/imgaz/upload/20240417/163474511.jpg],
         media_files: [{ file_size: 3_049_892 }],
         page_url: nil,
+        published_at: nil,
       )
     end
   end

--- a/test/unit/source/extractor/tumblr_extractor_test.rb
+++ b/test/unit/source/extractor/tumblr_extractor_test.rb
@@ -19,6 +19,7 @@ module Source::Tests::Extractor
           ["tag1", "https://tumblr.com/tagged/tag1"],
           ["tag2", "https://tumblr.com/tagged/tag2"],
         ],
+        published_at: Time.utc(2017, 6, 21, 19, 27, 29),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "description",
       )
@@ -34,6 +35,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: "nagian",
         tags: [],
+        published_at: Time.utc(2012, 12, 16, 14, 19, 29),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "ゆいあず",
       )
@@ -45,6 +47,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://media.tumblr.com/3bbfcbf075ddf969c996641b264086fd/tumblr_os2buiIOt51wsfqepo1_1280.png],
         media_files: [{ file_size: 3_655 }],
         page_url: "https://noizave.tumblr.com/post/162206271767",
+        published_at: Time.utc(2017, 6, 24, 17, 42, 18),
       )
     end
 
@@ -74,6 +77,7 @@ module Source::Tests::Extractor
           ["i'm a squid now", "https://tumblr.com/tagged/i'm a squid now"],
           ["squid", "https://tumblr.com/tagged/squid"],
         ],
+        published_at: Time.utc(2015, 6, 9, 19, 35, 3),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "[b]“SPLATOON SUPER NES VERSION (or more like GBA according to some XD)”[/b]",
       )
@@ -85,6 +89,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://media.tumblr.com/ee02048f5578595badc95905e17154b4/tumblr_inline_ofbr4452601sk4jd9_1280.gif],
         media_files: [{ file_size: 110_348 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -94,6 +99,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://media.tumblr.com/tumblr_lxbzel2H5y1r9yjhso1_1280.jpg],
         media_files: [{ file_size: 42_997 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -103,6 +109,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://media.tumblr.com/tumblr_m24kbxqKAX1rszquso1_1280.jpg],
         media_files: [{ file_size: 105_963 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -112,6 +119,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://media.tumblr.com/tumblr_m2dxb8aOJi1rop2v0o1_1280.png],
         media_files: [{ file_size: 62_658 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -121,6 +129,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://media.tumblr.com/701a535af224f89684d2cfcc097575ef/tumblr_pjsx70RakC1y0gqjko1_1280.png],
         media_files: [{ file_size: 296_595, file_ext: :jpg }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -137,6 +146,7 @@ module Source::Tests::Extractor
           ["original", "https://tumblr.com/tagged/original"],
           ["illustration", "https://tumblr.com/tagged/illustration"],
         ],
+        published_at: Time.utc(2020, 5, 31, 20, 39, 53),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -160,6 +170,7 @@ module Source::Tests::Extractor
           ["espclpse", "https://tumblr.com/tagged/espclpse"],
           ["i love rendering teru so much", "https://tumblr.com/tagged/i love rendering teru so much"],
         ],
+        published_at: Time.utc(2022, 6, 9, 10, 9, 30),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "Teru doddle",
       )
@@ -171,6 +182,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://va.media.tumblr.com/tumblr_pgohk0TjhS1u7mrsl.mp4],
         media_files: [{ file_size: 7_960_082 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -180,6 +192,7 @@ module Source::Tests::Extractor
         image_urls: %w[https://static.tumblr.com/923d3a1b85bdabcb6276ea921911497f/w3ze2u2/mdHpc3im5/tumblr_static_cd6gq50ia8oc8s04kcok44gkc.jpg],
         media_files: [{ file_size: 1_711_890 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -198,6 +211,7 @@ module Source::Tests::Extractor
           ["red-hair", "https://tumblr.com/tagged/red-hair"],
           ["red_hair", "https://tumblr.com/tagged/red_hair"],
         ],
+        published_at: Time.utc(2017, 6, 24, 17, 42, 18),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           h2. header
@@ -240,6 +254,7 @@ module Source::Tests::Extractor
         tags: [
           ["tag1 tag2", "https://tumblr.com/tagged/tag1 tag2"],
         ],
+        published_at: Time.utc(2017, 6, 25, 2, 14, 44),
         dtext_artist_commentary_title: "test post",
         dtext_artist_commentary_desc: "description",
       )
@@ -263,6 +278,7 @@ module Source::Tests::Extractor
         tags: [
           ["tag1", "https://tumblr.com/tagged/tag1"],
         ],
+        published_at: Time.utc(2017, 6, 25, 2, 53, 47),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "description",
       )
@@ -286,6 +302,7 @@ module Source::Tests::Extractor
           ["video", "https://tumblr.com/tagged/video"],
           ["my art", "https://tumblr.com/tagged/my art"],
         ],
+        published_at: Time.utc(2022, 10, 13, 6, 9, 41),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "direct quote from kaiba post battle city tournament",
       )
@@ -300,6 +317,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: "ebith1969",
         tags: [],
+        published_at: Time.utc(2013, 4, 17, 19, 0, 34),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "2009.03.05",
       )
@@ -324,6 +342,7 @@ module Source::Tests::Extractor
           ["today yra desperately tries to figure out procreate dreams. tomorrow?? who knows", "https://tumblr.com/tagged/today yra desperately tries to figure out procreate dreams. tomorrow%3F%3F who knows"],
           ["crawls back into cave", "https://tumblr.com/tagged/crawls back into cave"],
         ],
+        published_at: Time.utc(2023, 12, 10, 23, 47, 58),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           the divorce is going well
@@ -343,6 +362,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: "noizave",
         tags: [],
+        published_at: Time.utc(2018, 2, 24, 16, 27, 8),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           [quote]
@@ -382,6 +402,7 @@ module Source::Tests::Extractor
           ["venusaur", "https://tumblr.com/tagged/venusaur"],
           ["grass pokemon", "https://tumblr.com/tagged/grass pokemon"],
         ],
+        published_at: Time.utc(2022, 5, 7, 17, 28, 58),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "‘saur family 🌱",
       )
@@ -397,6 +418,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: "compllege",
         tags: [],
+        published_at: Time.utc(2018, 10, 25, 12, 34, 15),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           CODL-0001 “C-Experiment”
@@ -450,6 +472,7 @@ module Source::Tests::Extractor
           ["is anyone still even here", "https://tumblr.com/tagged/is anyone still even here"],
           ["crawls back into damp cave", "https://tumblr.com/tagged/crawls back into damp cave"],
         ],
+        published_at: Time.utc(2019, 10, 11, 4, 21, 14),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           "@phantom-miria":[https://www.tumblr.com/phantom-miria]
@@ -473,6 +496,7 @@ module Source::Tests::Extractor
           ["is anyone still even here", "https://tumblr.com/tagged/is anyone still even here"],
           ["crawls back into damp cave", "https://tumblr.com/tagged/crawls back into damp cave"],
         ],
+        published_at: Time.utc(2019, 10, 11, 4, 21, 14),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           "@phantom-miria":[https://www.tumblr.com/phantom-miria]
@@ -522,6 +546,7 @@ module Source::Tests::Extractor
           ["Binkan", "https://tumblr.com/tagged/Binkan"],
           ["shimoneta", "https://tumblr.com/tagged/shimoneta"],
         ],
+        published_at: Time.utc(2017, 7, 28, 2, 47, 55),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -538,6 +563,7 @@ module Source::Tests::Extractor
         tags: [
           ["adorable", "https://tumblr.com/tagged/adorable"],
         ],
+        published_at: Time.utc(2023, 10, 14, 6, 48, 35),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           [quote]
@@ -577,6 +603,7 @@ module Source::Tests::Extractor
           ["my art", "https://tumblr.com/tagged/my art"],
           ["fanart", "https://tumblr.com/tagged/fanart"],
         ],
+        published_at: Time.utc(2022, 10, 2, 22, 39, 57),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           [quote]
@@ -632,6 +659,7 @@ module Source::Tests::Extractor
           ["ok back 2 school", "https://tumblr.com/tagged/ok back 2 school"],
           ["tentatively... i still have to get to the hsy part of the reread so i can draw hsy💜", "https://tumblr.com/tagged/tentatively... i still have to get to the hsy part of the reread so i can draw hsy💜"],
         ],
+        published_at: Time.utc(2022, 1, 5, 0, 8, 7),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           [quote]
@@ -682,6 +710,7 @@ module Source::Tests::Extractor
           ["chilchuck", "https://tumblr.com/tagged/chilchuck"],
           ["fanart", "https://tumblr.com/tagged/fanart"],
         ],
+        published_at: Time.utc(2024, 3, 22, 3, 43, 10),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           [quote]
@@ -703,6 +732,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: "shortgremlinman",
         tags: [],
+        published_at: Time.utc(2023, 1, 30, 13, 20, 25),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           [quote]
@@ -796,6 +826,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: "shimetsukage",
         tags: [],
+        published_at: nil,
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )

--- a/test/unit/source/extractor/twitter_extractor_test.rb
+++ b/test/unit/source/extractor/twitter_extractor_test.rb
@@ -9,6 +9,7 @@ module Source::Tests::Extractor
         media_files: [{ file_size: 203_927, width: 1252, height: 1252 }],
         page_url: nil,
         profile_urls: %w[https://x.com/i/user/417182061145780225],
+        published_at: nil,
       )
     end
 
@@ -31,6 +32,7 @@ module Source::Tests::Extractor
         display_name: "丸茂",
         username: "motty08111213",
         tags: ["岩本町芸能社", "女優部"],
+        published_at: Time.utc(2017, 12, 20, 11, 41, 7, 961_000),
         dtext_artist_commentary_desc: <<~EOS.chomp,
           岩本町芸能社女優部のタレント3名がHPに公開されました。
           部署が違うので私の担当ではありませんが、みんなとても良い子たちです。
@@ -55,6 +57,7 @@ module Source::Tests::Extractor
         display_name: "丸茂",
         username: "motty08111213",
         tags: ["岩本町芸能社", "女優部"],
+        published_at: Time.utc(2017, 12, 20, 11, 41, 7, 961_000),
       )
     end
 
@@ -71,6 +74,7 @@ module Source::Tests::Extractor
         display_name: "丸茂",
         username: "motty08111213",
         tags: ["岩本町芸能社", "女優部"],
+        published_at: Time.utc(2017, 12, 20, 11, 41, 7, 961_000),
       )
     end
 
@@ -87,6 +91,7 @@ module Source::Tests::Extractor
         display_name: "丸茂",
         username: "motty08111213",
         tags: ["岩本町芸能社", "女優部"],
+        published_at: Time.utc(2017, 12, 20, 11, 41, 7, 961_000),
       )
     end
 
@@ -96,6 +101,7 @@ module Source::Tests::Extractor
         image_urls: ["https://video.twimg.com/ext_tw_video/859073467769126913/pu/vid/1280x720/cPGgVROXHy3yrK6u.mp4"],
         page_url: "https://x.com/CincinnatiZoo/status/859073537713328129",
         media_files: [{ file_size: 8_603_100 }],
+        published_at: Time.utc(2017, 5, 1, 15, 54, 26, 862_000),
         dtext_artist_commentary_desc: <<~EOS.chomp,
           Fiona loves playing in the hose water just like her parents! 💦 "#TeamFiona":[https://x.com/hashtag/TeamFiona] "#fionafix":[https://x.com/hashtag/fionafix]
         EOS
@@ -108,6 +114,7 @@ module Source::Tests::Extractor
         "https://pbs.twimg.com/tweet_video_thumb/ETkN_L3X0AMy1aT.jpg:small",
         image_urls: ["https://pbs.twimg.com/tweet_video_thumb/ETkN_L3X0AMy1aT.jpg:orig"],
         media_files: [{ file_size: 18_058 }],
+        published_at: nil,
       )
     end
 
@@ -116,6 +123,7 @@ module Source::Tests::Extractor
         "https://pbs.twimg.com/ext_tw_video_thumb/1578376127801761793/pu/img/oGcUqPnwRYYhk-gi.jpg:small",
         image_urls: ["https://pbs.twimg.com/ext_tw_video_thumb/1578376127801761793/pu/img/oGcUqPnwRYYhk-gi.jpg:orig"],
         media_files: [{ file_size: 243_227 }],
+        published_at: nil,
       )
     end
 
@@ -125,6 +133,7 @@ module Source::Tests::Extractor
         "https://pbs.twimg.com/amplify_video_thumb/1215590775364259840/img/lolCkEEioFZTb5dl.jpg:small",
         image_urls: ["https://pbs.twimg.com/amplify_video_thumb/1215590775364259840/img/lolCkEEioFZTb5dl.jpg:orig"],
         media_files: [{ file_size: 106_942 }],
+        published_at: nil,
       )
     end
 
@@ -134,6 +143,7 @@ module Source::Tests::Extractor
         image_urls: ["https://video.twimg.com/tweet_video/EWHWVrmVcAAp4Vw.mp4"],
         media_files: [{ file_size: 542_833 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -142,6 +152,7 @@ module Source::Tests::Extractor
         "https://twitter.com/i/web/status/1252517866059907073",
         image_urls: ["https://video.twimg.com/tweet_video/EWHWVrmVcAAp4Vw.mp4"],
         media_files: [{ file_size: 542_833 }],
+        published_at: Time.utc(2020, 4, 21, 8, 41, 44, 582_000),
         artist_commentary_desc: "https://t.co/gyTKOSBOQ7",
         dtext_artist_commentary_desc: "",
       )
@@ -158,6 +169,7 @@ module Source::Tests::Extractor
         display_name: "通天機",
         username: "twotenky",
         profile_url: "https://x.com/twotenky",
+        published_at: Time.utc(2022, 10, 6, 1, 22, 20, 937_000),
         artist_commentary_desc: "動画と静止画がセットでお得と聞いて https://t.co/hWvKoHLN7y",
         dtext_artist_commentary_desc: "動画と静止画がセットでお得と聞いて",
       )
@@ -173,6 +185,7 @@ module Source::Tests::Extractor
         profile_urls: ["https://x.com/Strangestone", "https://x.com/i/user/93332575"],
         display_name: "比村奇石",
         username: "Strangestone",
+        published_at: Time.utc(2015, 1, 17, 13, 17, 53, 653_000),
         dtext_artist_commentary_desc: "ブレザーが描きたかったのでJK鈴谷",
       )
     end
@@ -187,6 +200,7 @@ module Source::Tests::Extractor
         display_name: "ショカ",
         username: "shoka_bg",
         tags: %w[ブルアカ],
+        published_at: Time.utc(2023, 4, 7, 14, 21, 39, 702_000),
         dtext_artist_commentary_desc: <<~EOS.chomp,
           風紀委員の実態
           "#ブルアカ":[https://x.com/hashtag/ブルアカ]
@@ -204,6 +218,7 @@ module Source::Tests::Extractor
         display_name: "ラブレミ@うぉるやふぁんくらぶ",
         username: "loveremi_razoku",
         tags: [],
+        published_at: Time.utc(2023, 3, 20, 2, 48, 9, 805_000),
         dtext_artist_commentary_desc: <<~EOS.chomp,
           「ラリアッ党の野望チョコ」
           commission ラリアット さん"@rariatoo":[https://x.com/rariatoo]
@@ -243,6 +258,7 @@ module Source::Tests::Extractor
         display_name: "えむりん",
         username: "emurin",
         tags: %w[odaibako],
+        published_at: Time.utc(2017, 9, 27, 2, 8, 29, 946_000),
         dtext_artist_commentary_desc: <<~EOS.chomp,
           > ほわほわ系クーデレギロチンおねがいします <https://odaibako.net/detail/request/277bac5ea1b34b1abc7ac21dd1031690> "#odaibako":[https://x.com/hashtag/odaibako]
 
@@ -260,6 +276,7 @@ module Source::Tests::Extractor
         display_name: nil,
         username: "star_ukmgr",
         tags: [],
+        published_at: Time.utc(2025, 4, 30, 15, 8, 39, 806_000),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: "",
       )
@@ -277,6 +294,7 @@ module Source::Tests::Extractor
         display_name: "Noun Project",
         username: "nounproject",
         tags: [],
+        published_at: Time.utc(2014, 12, 5, 19, 2, 50, 61_000),
         dtext_artist_commentary_desc: <<~EOS.chomp,
           More is better. Unlimited is best. NounPro Members now get unlimited icon downloads <http://bit.ly/1yn2KWn>
         EOS
@@ -288,6 +306,7 @@ module Source::Tests::Extractor
         "https://twitter.com/teruyo/status/1058452066060853248",
         profile_url: "https://x.com/teruyo",
         image_urls: [],
+        published_at: Time.utc(2018, 11, 2, 20, 13, 32, 294_000),
         dtext_artist_commentary_desc: "all the women washizutan2 draws look like roast chicken",
       )
     end
@@ -298,6 +317,7 @@ module Source::Tests::Extractor
         image_urls: ["https://pbs.twimg.com/media/EBGp2YdUYAA19Uj.jpg:orig"],
         media_files: [{ file_size: 229_661 }],
         profile_url: nil,
+        published_at: nil,
       )
     end
 
@@ -307,6 +327,7 @@ module Source::Tests::Extractor
         image_urls: ["https://pbs.twimg.com/media/EAjc-OWVAAAxAgQ.jpg:orig"],
         media_files: [{ file_size: 842_373 }],
         profile_url: nil,
+        published_at: nil,
       )
     end
 
@@ -317,6 +338,7 @@ module Source::Tests::Extractor
         image_urls: ["https://pbs.twimg.com/media/EAjc-OWVAAAxAgQ.jpg:orig"],
         media_files: [{ file_size: 842_373 }],
         page_url: nil,
+        published_at: nil,
       )
     end
 
@@ -326,6 +348,7 @@ module Source::Tests::Extractor
         deleted: true,
         username: "masayasuf",
         profile_url: "https://x.com/masayasuf",
+        published_at: Time.utc(2017, 6, 2, 20, 12, 47, 18_000),
         dtext_artist_commentary_desc: "",
       )
     end
@@ -336,6 +359,7 @@ module Source::Tests::Extractor
         username: "tanso_panz",
         profile_url: "https://x.com/tanso_panz",
         image_urls: [],
+        published_at: Time.utc(2019, 11, 7, 13, 13, 13, 422_000),
         dtext_artist_commentary_desc: "",
       )
     end
@@ -350,6 +374,7 @@ module Source::Tests::Extractor
           "https://pbs.twimg.com/media/DRfKHgHU8AE7alV.jpg:orig",
         ],
         profile_url: "https://x.com/motty08111213",
+        published_at: Time.utc(2017, 12, 20, 11, 41, 7, 961_000),
       )
     end
 
@@ -363,6 +388,7 @@ module Source::Tests::Extractor
           "https://pbs.twimg.com/media/DRfKHgHU8AE7alV.jpg:orig",
         ],
         profile_url: "https://x.com/motty08111213",
+        published_at: Time.utc(2017, 12, 20, 11, 41, 7, 961_000),
       )
     end
 
@@ -374,6 +400,7 @@ module Source::Tests::Extractor
         profile_url: nil,
         # profile_url: "https://x.com/i/user/780804311529906176"
         # XXX we COULD fully support these by setting the page_url to https://x.com/Kekeflipnote/header_photo, but it's a lot of work for a niche case
+        published_at: nil,
       )
     end
 
@@ -384,6 +411,7 @@ module Source::Tests::Extractor
         media_files: [{ file_size: 108_605 }],
         page_url: nil,
         profile_url: nil,
+        published_at: nil,
       )
     end
 
@@ -394,6 +422,7 @@ module Source::Tests::Extractor
         media_files: [{ file_size: 159_186 }],
         page_url: nil,
         profile_url: nil,
+        published_at: nil,
       )
     end
 
@@ -506,6 +535,7 @@ module Source::Tests::Extractor
         tags: [
           ["スーパーカブ", "https://x.com/hashtag/スーパーカブ"],
         ],
+        published_at: Time.utc(2022, 5, 4, 13, 30, 0, 325_000),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           GWなので再放送です☺
@@ -550,6 +580,7 @@ module Source::Tests::Extractor
         tags: [
           ["山田999", "https://x.com/hashtag/山田999"],
         ],
+        published_at: Time.utc(2023, 4, 1, 16, 0, 2, 89_000),
         dtext_artist_commentary_title: "",
         dtext_artist_commentary_desc: <<~EOS.chomp,
           💕••┈┈┈┈┈┈┈┈•• 💕


### PR DESCRIPTION
Add a "published at" field for posts. This is the time that the artist first published the image at the source. Some examples:
* For web sources, this is the date that the post was created on the original website (which can usually be determined automatically by a source extractor).
* For game CGs, this is the date that the game was released.
* For magazine scans, this is the date that the issue was published (not when it was scanned).

Keeping track of this has several benefits:
* Knowing the surrounding context of when the artist posted an image. e.g. For art that references current world events or a new meme, not knowing the publication date makes it more difficult to determine what the image is referencing.
* Sorting posts by when the artist made them instead of when they got uploaded to Danbooru. This can fix images appearing out of order if they weren't uploaded to Danbooru in the right order. (Putting them in a series pool works to fix the order too, but publication date is a more general solution than pools.)
* Searching for art published within a certain time period, e.g. if you want to only look at art published in the 2010s.
* Archival purposes. The original source of an image can often be deleted (bad_id has almost 1.4 million posts), in which case the original metadata is often lost along with it. Danbooru already archives the artist's original commentary that accompanied the image, so archiving the original date it was posted as well makes sense.

Relevant forum discussion: https://danbooru.donmai.us/forum_topics/34323

---

It's important to note that the publication date is *not* the same as the time that the image was actually drawn, but is instead some amount of time later (because artists can wait a while before posting their work). Although Danbooru could theoretically keep track of the creation date that some artists date their work with, I think that idea causes too many issues in practice so this PR only deals with publication date. For more details about my thoughts on creation date click below.

<details>
<summary>Issues with creation date tracking</summary>

Let's say that image is posted to Twitter on 2026-03-15, but the artist commentary says "I drew this a couple years ago", and the image itself is dated as "03/09/24". If we only track publication date then we simply automatically extract that 2026-03-15 date and don't even need to think about anything else. But if Danbooru were to track creation date too, then a large number of problems appear:

* It cannot be automated at all, even for web sources. So it would need to be filled in manually for all posts, which would take an incredible amount of time.
* Danbooru users can misread dates. Is "03/09/24" March 9th or September 3rd? It probably depends what country the artist is from since date formats differ by country. Having to figure out what country every artist is from would create even more work.
* Artists can misremember or lie about when they drew something and put the wrong date. Unlike publication date, there's no way to verify creation date.
* The precision of creation date varies wildly, from the exact day, to the month, to just the year, to "I drew this a while ago".
* There's generally no way to get the creation time more specifically than just the date (no hour/minute/second or time zone) so sorting images drawn on the same day wouldn't work.
* Artists don't always date literally every single image they draw, so it wouldn't be very useful for sorting an individual artist tag as many posts would be missing the date.
* It wouldn't be useful for archival purposes either, as Danbooru already saves both the artist commentary and the image itself, so the original source being deleted already won't result in either of those being lost.

Rather than trying to deal with all of that, I think it's simpler to track only publication date, and creation date doesn't provide much search benefit over publication date anyway.

</details>

---

This PR has several parts:
* Add a published_at column for posts (and post versions) and display this date on the post show page if present. By default this publication date is null, which means it is currently unknown when the image was first published and this information needs to be filled in.
* Implement automatic date parsing for most source extractors so that the publication date for images from web sources can be filled in automatically without manual user intervention.
* Add a new `published:` edit metatag (as well as a separate text field in the post edit partial) to allow users to manually input publication dates (e.g. for non-web sources). Example: `published:2026-01-01` or `published:2026-01-01T12:34:56Z`
* Add new `published:` and `publishedage:` search metatags for searching for posts published within a certain range of dates/ages. (e.g. `published:2010-01-01..2020-01-01` to see images published in the 2010s.)
* Add a new `order:published` order metatag for sorting posts by their publication date. Posts with a null (unknown) publication date will be automatically excluded when using `order:published` (as if you had put `published:any` in the search).
* Add a fix script for existing Pixiv/Twitter posts to have DanbooruBot populate their publication dates. Because these two sites include publication date information within the URL itself, this does not require the script to make any external HTTP requests to sources.

Additional things that cannot be done on migration and instead will need to be done by users, after the update is live on Danbooru:
* Manually fill in the publication date for non-web sources. (Scans, game CGs, etc.)
    * To speed up setting many posts that were published together to the same publication date, it is possible to use the `published:` metatag in a tag script.
* For existing posts from websites other than Pixiv and Twitter, the publication date can be determined automatically by the source extractor, but this requires an HTTP request for every post, so users will need to fetch source data and click the "Fill" button to populate the publication date field for these posts.
    * It should be possible to speed up populating the backlog by writing an automated script that makes requests locally instead of through Danbooru, and then fills in the publication date via a bot account.