### PR TITLE
Fix invalid BURs not showing validation errors.

### DIFF
--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -11,11 +11,7 @@ class BulkUpdateRequestsController < ApplicationController
   def create
     @bulk_update_request = authorize BulkUpdateRequest.new(user: CurrentUser.user, **permitted_attributes(BulkUpdateRequest))
     @bulk_update_request.save
-    if request.format.html?
-      respond_with(@bulk_update_request.forum_post || @bulk_update_request.forum_topic || @bulk_update_request)
-    else
-      respond_with(@bulk_update_request)
-    end
+    respond_with(@bulk_update_request, location: @bulk_update_request.forum_post || @bulk_update_request.forum_topic || @bulk_update_request)
   end
 
   def show


### PR DESCRIPTION
9bf202b7375df69b95858bae4fd447cb85af39d2 broke BUR validation. It currently redirects to the forum post even if the BUR validation fails (and thus the forum post never gets created).