### PR TITLE
Support for Twitter intent/favorite and intent/retweet URLs

### DIFF
--- a/app/logical/source/url/twitter.rb
+++ b/app/logical/source/url/twitter.rb
@@ -141,6 +141,12 @@ class Source::URL::Twitter < Source::URL
     in _, _, "intent", "user" if params[:screen_name].present?
       @username = params[:screen_name]
 
+    # https://x.com/intent/favorite?tweet_id=2020838133525520807
+    # https://x.com/intent/retweet?tweet_id=2020838133525520807
+    in _, _, "intent", ("favorite" | "retweet") if params[:tweet_id].present?
+      @status_id = params[:tweet_id]
+      @base10_snowflake_id = @status_id
+
     # https://x.com/i/user/889592953
     in _, _, "i", "user", user_id
       @user_id = user_id

--- a/test/unit/source/extractor/twitter_extractor_test.rb
+++ b/test/unit/source/extractor/twitter_extractor_test.rb
@@ -100,6 +100,42 @@ module Source::Tests::Extractor
       )
     end
 
+    context "A https://x.com/intent/favorite?tweet_id=:id url" do
+      strategy_should_work(
+        "https://x.com/intent/favorite?tweet_id=2020838133525520807",
+        image_urls: %w[https://pbs.twimg.com/media/HAt1kgFbcAAD8xF.jpg:orig],
+        media_files: [{ file_size: 334_077 }],
+        page_url: "https://x.com/rousei13/status/2020838133525520807",
+        profile_url: "https://x.com/rousei13",
+        profile_urls: %w[https://x.com/rousei13 https://x.com/i/user/928581189442482178],
+        display_name: "ろうせい",
+        username: "rousei13",
+        published_at: Time.parse("2026-02-09T12:32:11.000000Z"),
+        updated_at: nil,
+        tags: [],
+        dtext_artist_commentary_title: "",
+        dtext_artist_commentary_desc: "誰もお前を愛さないパロ",
+      )
+    end
+
+    context "A https://x.com/intent/retweet?tweet_id=:id url" do
+      strategy_should_work(
+        "https://x.com/intent/retweet?tweet_id=2020838133525520807",
+        image_urls: %w[https://pbs.twimg.com/media/HAt1kgFbcAAD8xF.jpg:orig],
+        media_files: [{ file_size: 334_077 }],
+        page_url: "https://x.com/rousei13/status/2020838133525520807",
+        profile_url: "https://x.com/rousei13",
+        profile_urls: %w[https://x.com/rousei13 https://x.com/i/user/928581189442482178],
+        display_name: "ろうせい",
+        username: "rousei13",
+        published_at: Time.parse("2026-02-09T12:32:11.000000Z"),
+        updated_at: nil,
+        tags: [],
+        dtext_artist_commentary_title: "",
+        dtext_artist_commentary_desc: "誰もお前を愛さないパロ",
+      )
+    end
+
     context "A video tweet" do
       strategy_should_work(
         "https://twitter.com/CincinnatiZoo/status/859073537713328129",


### PR DESCRIPTION
A while back someone on Discord mentioned that these URL formats exist. Since they contain the Tweet ID, implementing them is pretty straightforward so I figured I might as well.

```
https://x.com/intent/favorite?tweet_id=2020838133525520807
https://x.com/intent/retweet?tweet_id=2020838133525520807
```