### PR TITLE
Fix #6250: "none" in commentary controls doesn't remove tags

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -656,12 +656,12 @@ class Post < ApplicationRecord
       tag_array.include?(tag)
     end
 
-    def add_tag(tag)
-      self.tag_string = "#{tag_string} #{tag}"
+    def add_tag(*tags)
+      self.tag_string = [tag_string, *tags].join(" ").strip
     end
 
-    def remove_tag(tag)
-      self.tag_string = (tag_array - Array(tag)).join(" ")
+    def remove_tag(*tags)
+      self.tag_string = (tag_array - tags).join(" ")
     end
 
     def tag_categories

--- a/test/unit/artist_commentary_test.rb
+++ b/test/unit/artist_commentary_test.rb
@@ -65,6 +65,13 @@ class ArtistCommentaryTest < ActiveSupport::TestCase
         assert(@artcomm.post.has_tag?("partial_commentary"))
       end
 
+      should "remove tags if requested" do
+        @artcomm.post.update!(tag_string: "partial_commentary commentary")
+        @artcomm.update!(commentary_tags: "none")
+        assert_not(@artcomm.post.reload.has_tag?("commentary"))
+        assert_not(@artcomm.post.has_tag?("partial_commentary"))
+      end
+
       should "not add unrelated tags" do
         @artcomm.update(commentary_tags: "foo")
         assert_not(@artcomm.post.reload.has_tag?("foo"))


### PR DESCRIPTION
Also changes `Post#add_tag` and `Post#remove_tag` to accept multiple arguments, to avoid having to call remove_tag repeatedly.

Fixes #6250.