### PR TITLE
Fix #6275: File upload progress bar clips through rounded corners

### DIFF
--- a/app/components/file_upload_component/file_upload_component.html.erb
+++ b/app/components/file_upload_component/file_upload_component.html.erb
@@ -1,10 +1,10 @@
-<div class="file-upload-component relative card w-md max-w-full" data-drop-target="<%= j drop_target %>" data-max-file-size="<%= j max_file_size %>" data-max-files-per-upload="<%= j max_files_per_upload %>">
+<div class="file-upload-component relative card w-md max-w-full border-0" data-drop-target="<%= j drop_target %>" data-max-file-size="<%= j max_file_size %>" data-max-files-per-upload="<%= j max_files_per_upload %>">
   <%= simple_form_for(Upload.new, url: uploads_path(format: :json), html: { class: "flex flex-col !m-0", autocomplete: "off" }, remote: true) do |f| %>
     <%= f.input :files, as: :file, wrapper_html: { class: "hidden" }, input_html: { "multiple": max_files_per_upload > 1 }  %>
 
-    <div class="rounded-t-lg p-4 pb-8 max-h-360px thin-scrollbar source">
+    <div class="rounded-t-lg p-4 pb-8 max-h-360px thin-scrollbar bg-dropzone">
       <label id="source-label" class="w-full text-center mb-1 block !font-normal">Paste URL here</label>
-      <%= f.input :source, label: false, as: :string, placeholder: "Paste a pixiv link, Tweet, etc", input_html: { value: url, class: "text-center bg:card" }, wrapper_html: { class: "px-4 text-center !m-0" } %>
+      <%= f.input :source, label: false, as: :string, placeholder: "Paste a pixiv link, tweet, etc", input_html: { value: url, class: "text-center bg:card" }, wrapper_html: { class: "px-4 text-center !m-0" } %>
       <span class="hint text-muted text-xs text-center w-full block mt-1">
         <%= link_to_wiki "See here", "help:bookmarklet_notice" %> for a list of supported sites.
       </span>
@@ -13,7 +13,7 @@
     </div>
 
 
-    <div class="dropzone-container relative input text-center rounded-t-lg cursor-pointer p-4 pt-2 max-h-360px thin-scrollbar !m-0">
+    <div class="dropzone-container relative input text-center rounded-b-lg cursor-pointer p-4 pt-2 max-h-360px thin-scrollbar !m-0">
       <p class="text-center mb-2">&mdash; or &mdash;</p>
 
       <div class="dropzone-hint">
@@ -32,7 +32,7 @@
         <span class="dz-size" data-dz-size></span>
       </div>
 
-      <div class="dz-progress absolute bottom-0 left-0 w-full h-1">
+      <div class="dz-progress absolute bottom-0 left-0 w-full h-1 rounded-b-lg overflow-hidden">
         <div class="dz-upload h-1" data-dz-uploadprogress></div>
       </div>
 

--- a/app/components/file_upload_component/file_upload_component.scss
+++ b/app/components/file_upload_component/file_upload_component.scss
@@ -1,5 +1,5 @@
 .file-upload-component {
-  div.source {
+  div.bg-dropzone {
     background: var(--uploads-dropzone-background);
   }
 

--- a/app/javascript/src/styles/common/utilities.scss
+++ b/app/javascript/src/styles/common/utilities.scss
@@ -130,6 +130,10 @@ $spacer: 0.25rem; /* 4px */
 .rounded-t,    %rounded-t    { border-top-left-radius: 1   * $spacer; border-top-right-radius: 1   * $spacer; }
 .rounded-t-lg, %rounded-t-lg { border-top-left-radius: 2   * $spacer; border-top-right-radius: 2   * $spacer; }
 
+.rounded-b-sm, %rounded-b-sm { border-bottom-left-radius: 0.5 * $spacer; border-bottom-right-radius: 0.5 * $spacer; }
+.rounded-b,    %rounded-b    { border-bottom-left-radius: 1   * $spacer; border-bottom-right-radius: 1   * $spacer; }
+.rounded-b-lg, %rounded-b-lg { border-bottom-left-radius: 2   * $spacer; border-bottom-right-radius: 2   * $spacer; }
+
 .rounded-full { border-radius: 9999px; }
 
 .shadow-md, %shadow-md { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 10%), 0 2px 4px -2px rgb(0 0 0 / 10%); }


### PR DESCRIPTION
I renamed .source to .bg-dropzone because of [this comment](https://github.com/danbooru/danbooru/pull/6226#discussion_r2766800083).

<img width="729" height="125" alt="image" src="https://github.com/user-attachments/assets/41642231-2506-4d8f-99fe-1c8033de41d4" />

Fixes #6275.