### PR TITLE
Comments: show new comment button for anon users

### DIFF
--- a/app/components/comment_section_component/comment_section_component.html.erb
+++ b/app/components/comment_section_component/comment_section_component.html.erb
@@ -11,10 +11,12 @@
     <% end %>
   </div>
 
-  <% if policy(Comment).create? %>
-    <div class="new-comment">
-      <p><%= link_to "Post comment", new_comment_path(comment: { post_id: post.id }), class: "expand-comment-response" %></p>
+  <div class="new-comment">
+    <% if policy(Comment).create? %>
+      <p><%= link_to "Leave a comment", new_comment_path(comment: { post_id: post.id }), class: "expand-comment-response" %></p>
       <%= render "comments/form", comment: post.comments.new, hidden: true %>
-    </div>
-  <% end %>
+    <% elsif current_user.is_anonymous? %>
+      <p><%= link_to "Leave a comment", login_path(url: request.fullpath) %></p>
+    <% end %>
+  </div>
 </div>

--- a/test/functional/comments_controller_test.rb
+++ b/test/functional/comments_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   context "A comments controller" do
@@ -26,6 +26,8 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
           assert_select "div#post_#{@post.id}", 1
           assert_select "div#post_#{@post.id} .comment", 1
           assert_select "div#post_#{@post.id} .show-all-comments-link", 0
+
+          assert_select ".new-comment a", count: 1, text: "Leave a comment"
         end
 
         should "not bump posts with nonbumping comments" do


### PR DESCRIPTION
Also change the prompt from "Post comment" to "Leave a comment".

Fixes #6238.