### PR TITLE
Users: remember redirection on login error and registration

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < ApplicationController
 
   def new
     @session = authorize SessionLoader.new(request)
+    @url = params.dig(:session, :url).presence || params[:url].presence || root_path
 
     if params[:signed_login_event].present? && @session.authorize_login_event!(params[:signed_login_event])
       notice = "New location verified. Login again to continue"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
 
   def new
     @user = authorize User.new
+    @url = params.dig(:user, :url).presence || params[:url].presence || root_path
     respond_with(@user)
   end
 
@@ -65,12 +66,13 @@ class UsersController < ApplicationController
   def create
     user_signup = UserSignup.new(request)
     @user = authorize(user_signup.user)
+    @url = params.dig(:user, :url).presence || params[:url].presence || root_path
 
     if @user.save(context: [:create, :deliverable])
       set_current_user
     end
 
-    respond_with(@user)
+    respond_with(@user, location: @url)
   end
 
   def update

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -10,7 +10,7 @@
       <h1 class="pb-4">Login</h1>
 
       <%= edit_form_for(@session, as: :session, url: session_path, html: { class: "w-full stacked-form stacked-hints", "data-validate-form": "true" }) do |f| %>
-        <%= f.input :url, as: :hidden, input_html: { value: params[:url] } %>
+        <%= f.input :url, as: :hidden, input_html: { value: @url } %>
         <%= f.input :name, label: "Name or Email", input_html: { autofocus: true, autocapitalize: "none", value: params.dig(:session, :name) } %>
         <%= f.input :password, hint: link_to("Forgot password?", password_reset_path), input_html: { autocomplete: "current-password" } %>
         <%= captcha_tag class: "mb-4", action: :login %>
@@ -18,7 +18,7 @@
       <% end %>
 
       <p class="fineprint">
-        Don't have an account? <%= link_to "Create a new account", new_user_path %>.
+        Don't have an account? <%= link_to "Create a new account", new_user_path(url: @url) %>.
       </p>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -9,6 +9,7 @@
       <h1 class="pb-4">Sign Up</h1>
 
       <%= edit_form_for(@user, validate: true, formatted_errors: true, html: { id: "signup-form", class: "w-full stacked-form stacked-hints", "data-validate-form": "true" }) do |f| %>
+        <%= f.input :url, as: :hidden, input_html: { value: @url } %>
         <%= f.input :name, as: :string, label: "Username", input_html: { autocapitalize: "none", minlength: UserNameValidator::MIN_LENGTH, maxlength: UserNameValidator::MAX_LENGTH }, required: true %>
         <%= f.simple_fields_for(@user.email_address || @user.build_email_address) do |fa| %>
           <%= fa.input :address, label: "Email", required: false, as: :email, input_html: { value: fa.object.address, pattern: Danbooru::EmailAddress::EMAIL_REGEX, placeholder: "your.name@example.com" }, hint: "Optional" %>
@@ -21,7 +22,7 @@
       <% end %>
 
       <p class="fineprint">
-        Already have an account? <%= link_to "Login here", login_path %>.
+        Already have an account? <%= link_to "Login here", login_path(url: @url) %>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Fixes the following:
* a user redirected to login who then registered would not be redirected to the  original page after success
* login/registration errors would not redirect the user back after success

Fixes #6239