### PR TITLE
Lint: apply Rails/ActionOrder to all controllers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,9 +89,6 @@ Naming/MethodParameterName:
 Naming/PredicateName:
   Enabled: false
 
-Rails/ActionOrder:
-  Enabled: false
-
 Rails/Blank:
   UnlessPresent: false
 

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -4,8 +4,19 @@ class ApiKeysController < ApplicationController
   before_action :requires_reauthentication
   respond_to :html, :json, :xml
 
+  def index
+    params[:search][:user_id] = params[:user_id] if params[:user_id].present?
+    @api_keys = authorize ApiKey.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    respond_with(@api_keys)
+  end
+
   def new
     @api_key = authorize ApiKey.new(user: CurrentUser.user, **permitted_attributes(ApiKey))
+    respond_with(@api_key)
+  end
+
+  def edit
+    @api_key = authorize ApiKey.find(params[:id])
     respond_with(@api_key)
   end
 
@@ -16,22 +27,11 @@ class ApiKeysController < ApplicationController
     respond_with(@api_key, location: user_api_keys_path(CurrentUser.user.id))
   end
 
-  def edit
-    @api_key = authorize ApiKey.find(params[:id])
-    respond_with(@api_key)
-  end
-
   def update
     @api_key = authorize ApiKey.find(params[:id])
     @api_key.update(request: request, **permitted_attributes(@api_key))
 
     respond_with(@api_key, location: user_api_keys_path(CurrentUser.user.id))
-  end
-
-  def index
-    params[:search][:user_id] = params[:user_id] if params[:user_id].present?
-    @api_keys = authorize ApiKey.visible(CurrentUser.user).paginated_search(params, count_pages: true)
-    respond_with(@api_keys)
   end
 
   def destroy

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -3,16 +3,6 @@
 class BansController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @ban = authorize Ban.new(permitted_attributes(Ban))
-    respond_with(@ban)
-  end
-
-  def edit
-    @ban = authorize Ban.find(params[:id])
-    respond_with(@ban)
-  end
-
   def index
     @bans = authorize Ban.paginated_search(params, count_pages: true)
     @bans = @bans.includes(:user, :banner) if request.format.html?
@@ -25,6 +15,16 @@ class BansController < ApplicationController
     respond_with(@ban) do |format|
       format.html { redirect_to bans_path(search: { id: @ban.id }) }
     end
+  end
+
+  def new
+    @ban = authorize Ban.new(permitted_attributes(Ban))
+    respond_with(@ban)
+  end
+
+  def edit
+    @ban = authorize Ban.find(params[:id])
+    respond_with(@ban)
   end
 
   def create

--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -3,15 +3,10 @@
 class BulkUpdateRequestsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @bulk_update_request = authorize BulkUpdateRequest.new(permitted_attributes(BulkUpdateRequest))
-    respond_with(@bulk_update_request)
-  end
-
-  def create
-    @bulk_update_request = authorize BulkUpdateRequest.new(user: CurrentUser.user, **permitted_attributes(BulkUpdateRequest))
-    @bulk_update_request.save
-    respond_with(@bulk_update_request, location: @bulk_update_request.forum_post || @bulk_update_request.forum_topic || @bulk_update_request)
+  def index
+    @bulk_update_requests = authorize BulkUpdateRequest.paginated_search(params, count_pages: true)
+    @bulk_update_requests = @bulk_update_requests.includes(:user, :approver, :forum_topic, forum_post: [:votes]) if request.format.html?
+    respond_with(@bulk_update_requests)
   end
 
   def show
@@ -19,9 +14,20 @@ class BulkUpdateRequestsController < ApplicationController
     respond_with(@bulk_update_request)
   end
 
+  def new
+    @bulk_update_request = authorize BulkUpdateRequest.new(permitted_attributes(BulkUpdateRequest))
+    respond_with(@bulk_update_request)
+  end
+
   def edit
     @bulk_update_request = authorize BulkUpdateRequest.find(params[:id])
     respond_with(@bulk_update_request)
+  end
+
+  def create
+    @bulk_update_request = authorize BulkUpdateRequest.new(user: CurrentUser.user, **permitted_attributes(BulkUpdateRequest))
+    @bulk_update_request.save
+    respond_with(@bulk_update_request, location: @bulk_update_request.forum_post || @bulk_update_request.forum_topic || @bulk_update_request)
   end
 
   def update
@@ -40,11 +46,5 @@ class BulkUpdateRequestsController < ApplicationController
     @bulk_update_request = authorize BulkUpdateRequest.find(params[:id])
     @bulk_update_request.reject!(CurrentUser.user)
     respond_with(@bulk_update_request, notice: "BUR ##{@bulk_update_request.id} rejected")
-  end
-
-  def index
-    @bulk_update_requests = authorize BulkUpdateRequest.paginated_search(params, count_pages: true)
-    @bulk_update_requests = @bulk_update_requests.includes(:user, :approver, :forum_topic, forum_post: [:votes]) if request.format.html?
-    respond_with(@bulk_update_requests)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -20,6 +20,16 @@ class CommentsController < ApplicationController
     end
   end
 
+  def show
+    @comment = authorize Comment.find(params[:id])
+
+    respond_with(@comment) do |format|
+      format.html do
+        redirect_to post_path(@comment.post, anchor: "comment_#{@comment.id}")
+      end
+    end
+  end
+
   def new
     if params[:id]
       quoted_comment = authorize Comment.find(params[:id]), :reply?
@@ -31,11 +41,8 @@ class CommentsController < ApplicationController
     respond_with(@comment)
   end
 
-  def update
-    @comment = Comment.find(params[:id])
-    @comment.attributes = { updater: CurrentUser.user, **permitted_attributes(@comment) }
-    authorize(@comment).save
-
+  def edit
+    @comment = authorize Comment.find(params[:id])
     respond_with(@comment)
   end
 
@@ -45,24 +52,17 @@ class CommentsController < ApplicationController
 
     respond_with(@comment, notice: "Comment posted") do |format|
       format.html do
-        redirect_back fallback_location: (@comment.post || comments_path)
+        redirect_back fallback_location: @comment.post || comments_path
       end
     end
   end
 
-  def edit
-    @comment = authorize Comment.find(params[:id])
+  def update
+    @comment = Comment.find(params[:id])
+    @comment.attributes = { updater: CurrentUser.user, **permitted_attributes(@comment) }
+    authorize(@comment).save
+
     respond_with(@comment)
-  end
-
-  def show
-    @comment = authorize Comment.find(params[:id])
-
-    respond_with(@comment) do |format|
-      format.html do
-        redirect_to post_path(@comment.post, anchor: "comment_#{@comment.id}")
-      end
-    end
   end
 
   def destroy

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -3,17 +3,6 @@
 class DmailsController < ApplicationController
   respond_to :html, :xml, :js, :json
 
-  def new
-    if params[:respond_to_id]
-      parent = authorize Dmail.find(params[:respond_to_id]), :show?
-      @dmail = parent.build_response(:forward => params[:forward])
-    else
-      @dmail = authorize Dmail.new(permitted_attributes(Dmail))
-    end
-
-    respond_with(@dmail)
-  end
-
   def index
     @dmails = authorize Dmail.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @dmails = @dmails.includes(:owner, :to, :from) if request.format.html?
@@ -31,6 +20,17 @@ class DmailsController < ApplicationController
 
     if request.format.html? && @dmail.owner == CurrentUser.user
       @dmail.update!(is_read: true)
+    end
+
+    respond_with(@dmail)
+  end
+
+  def new
+    if params[:respond_to_id]
+      parent = authorize Dmail.find(params[:respond_to_id]), :show?
+      @dmail = parent.build_response(:forward => params[:forward])
+    else
+      @dmail = authorize Dmail.new(permitted_attributes(Dmail))
     end
 
     respond_with(@dmail)

--- a/app/controllers/dmcas_controller.rb
+++ b/app/controllers/dmcas_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class DmcasController < ApplicationController
+  def show
+    authorize nil, policy_class: DmcaPolicy
+  end
+
   def create
     @dmca = params[:dmca].slice(:name, :email, :address, :infringing_urls, :original_urls, :proof, :perjury_agree, :good_faith_agree, :signature)
     authorize @dmca, policy_class: DmcaPolicy
@@ -22,10 +26,6 @@ class DmcasController < ApplicationController
 
     UserMailer.with_request(request, dmca: @dmca).dmca_complaint(to: Danbooru.config.dmca_email).deliver_now
     UserMailer.with_request(request, dmca: @dmca).dmca_complaint(to: @dmca[:email]).deliver_now unless Danbooru::EmailAddress.new(@dmca[:email]).undeliverable?
-  end
-
-  def show
-    authorize nil, policy_class: DmcaPolicy
   end
 
   def template

--- a/app/controllers/favorite_groups_controller.rb
+++ b/app/controllers/favorite_groups_controller.rb
@@ -25,14 +25,14 @@ class FavoriteGroupsController < ApplicationController
     respond_with(@favorite_group)
   end
 
-  def create
-    @favorite_group = authorize FavoriteGroup.new(creator: CurrentUser.user, **permitted_attributes(FavoriteGroup))
-    @favorite_group.save
+  def edit
+    @favorite_group = authorize FavoriteGroup.find(params[:id])
     respond_with(@favorite_group)
   end
 
-  def edit
-    @favorite_group = authorize FavoriteGroup.find(params[:id])
+  def create
+    @favorite_group = authorize FavoriteGroup.new(creator: CurrentUser.user, **permitted_attributes(FavoriteGroup))
+    @favorite_group.save
     respond_with(@favorite_group)
   end
 

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -3,25 +3,11 @@
 class ForumPostsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @forum_post = authorize ForumPost.new_reply(params)
-    respond_with(@forum_post)
-  end
-
-  def edit
-    @forum_post = authorize ForumPost.find(params[:id])
-    respond_with(@forum_post)
-  end
-
   def index
     @forum_posts = authorize ForumPost.visible(CurrentUser.user).paginated_search(params)
     @forum_posts = @forum_posts.includes(:topic, :creator) if request.format.html?
 
     respond_with(@forum_posts)
-  end
-
-  def search
-    authorize ForumPost
   end
 
   def show
@@ -34,6 +20,20 @@ class ForumPostsController < ApplicationController
         redirect_to forum_topic_path(@forum_post.topic, page: page, anchor: "forum_post_#{@forum_post.id}")
       end
     end
+  end
+
+  def new
+    @forum_post = authorize ForumPost.new_reply(params)
+    respond_with(@forum_post)
+  end
+
+  def edit
+    @forum_post = authorize ForumPost.find(params[:id])
+    respond_with(@forum_post)
+  end
+
+  def search
+    authorize ForumPost
   end
 
   def create

--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -9,17 +9,6 @@ class ForumTopicsController < ApplicationController
     redirect_to root_path
   end
 
-  def new
-    @forum_topic = authorize ForumTopic.new
-    @forum_topic.original_post = ForumPost.new
-    respond_with(@forum_topic)
-  end
-
-  def edit
-    @forum_topic = authorize ForumTopic.find(params[:id])
-    respond_with(@forum_topic)
-  end
-
   def index
     if request.format.html?
       limit = params.fetch(:limit, 40)
@@ -50,6 +39,17 @@ class ForumTopicsController < ApplicationController
       @forum_posts = @forum_posts.reverse_order.load
     end
 
+    respond_with(@forum_topic)
+  end
+
+  def new
+    @forum_topic = authorize ForumTopic.new
+    @forum_topic.original_post = ForumPost.new
+    respond_with(@forum_topic)
+  end
+
+  def edit
+    @forum_topic = authorize ForumTopic.find(params[:id])
     respond_with(@forum_topic)
   end
 

--- a/app/controllers/ip_bans_controller.rb
+++ b/app/controllers/ip_bans_controller.rb
@@ -3,17 +3,6 @@
 class IpBansController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @ip_ban = authorize IpBan.new(permitted_attributes(IpBan))
-    respond_with(@ip_ban)
-  end
-
-  def create
-    @ip_ban = authorize IpBan.new(creator: CurrentUser.user, **permitted_attributes(IpBan))
-    @ip_ban.save
-    respond_with(@ip_ban, :location => ip_bans_path)
-  end
-
   def index
     @ip_bans = authorize IpBan.paginated_search(params, count_pages: true)
     @ip_bans = @ip_bans.includes(:creator) if request.format.html?
@@ -27,6 +16,17 @@ class IpBansController < ApplicationController
     respond_with(@ip_ban) do |format|
       format.html { redirect_to ip_bans_path(search: { id: @ip_ban.id }) }
     end
+  end
+
+  def new
+    @ip_ban = authorize IpBan.new(permitted_attributes(IpBan))
+    respond_with(@ip_ban)
+  end
+
+  def create
+    @ip_ban = authorize IpBan.new(creator: CurrentUser.user, **permitted_attributes(IpBan))
+    @ip_ban.save
+    respond_with(@ip_ban, :location => ip_bans_path)
   end
 
   def update

--- a/app/controllers/moderation_reports_controller.rb
+++ b/app/controllers/moderation_reports_controller.rb
@@ -3,11 +3,6 @@
 class ModerationReportsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @moderation_report = authorize ModerationReport.new(permitted_attributes(ModerationReport))
-    respond_with(@moderation_report)
-  end
-
   def index
     @moderation_reports = authorize ModerationReport.visible(CurrentUser.user).paginated_search(params, count_pages: true)
     @moderation_reports = @moderation_reports.includes(:creator, :model) if request.format.html?
@@ -18,6 +13,11 @@ class ModerationReportsController < ApplicationController
   def show
     authorize ModerationReport
     redirect_to moderation_reports_path(search: { id: params[:id] })
+  end
+
+  def new
+    @moderation_report = authorize ModerationReport.new(permitted_attributes(ModerationReport))
+    respond_with(@moderation_report)
   end
 
   def create

--- a/app/controllers/modqueue_controller.rb
+++ b/app/controllers/modqueue_controller.rb
@@ -20,8 +20,8 @@ class ModqueueController < ApplicationController
     @disapproval_reasons = PostDisapproval.where(post_id: @modqueue_posts.map(&:id)).where.not(reason: "disinterest").group(:reason).order(count: :desc).distinct.count(:post_id)
     @uploaders = @modqueue_posts.map(&:uploader).tally.sort_by(&:last).reverse.take(20).to_h
 
-    #@new_count = @modqueue_posts.available_for_moderation(CurrentUser.user, search_params.fetch(:modqueue, :unseen)).count
-    #@seen_count = @modqueue_posts.available_for_moderation(CurrentUser.user, search_params.fetch(:modqueue, :seen)).where(id: CurrentUser.user.post_disapprovals.select(:post_id)).count
+    # @new_count = @modqueue_posts.available_for_moderation(CurrentUser.user, search_params.fetch(:modqueue, :unseen)).count
+    # @seen_count = @modqueue_posts.available_for_moderation(CurrentUser.user, search_params.fetch(:modqueue, :seen)).where(id: CurrentUser.user.post_disapprovals.select(:post_id)).count
 
     @tags = RelatedTagCalculator.new.frequent_tags_for_post_relation(@modqueue_posts, @modqueue_posts.size).map(&:tag)
     @artist_tags = @tags.select(&:artist?).sort_by(&:overlap_count).reverse.take(10)

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -47,7 +47,7 @@ class PasswordResetsController < ApplicationController
       new_password: params.dig(:user, :password),
       password_confirmation: params.dig(:user, :password_confirmation),
       verification_code: params.dig(:user, :verification_code),
-      request: request
+      request: request,
     )
 
     if success

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -21,7 +21,7 @@ class PasswordsController < ApplicationController
       new_password: params.dig(:user, :password),
       password_confirmation: params.dig(:user, :password_confirmation),
       verification_code: params.dig(:user, :verification_code),
-      request: request
+      request: request,
     )
 
     notice = "Password updated" if success

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -3,16 +3,6 @@
 class PoolsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @pool = authorize Pool.new(permitted_attributes(Pool))
-    respond_with(@pool)
-  end
-
-  def edit
-    @pool = authorize Pool.find(params[:id])
-    respond_with(@pool)
-  end
-
   def index
     if request.format.html?
       @pools = authorize Pool.paginated_search(params, count_pages: true, defaults: { is_deleted: false })
@@ -23,20 +13,30 @@ class PoolsController < ApplicationController
     respond_with(@pools)
   end
 
-  def gallery
-    limit = params[:limit].presence || CurrentUser.user.per_page
-    search = search_params.presence || ActionController::Parameters.new(category: "series")
-
-    @pools = authorize Pool.search(search, CurrentUser.user).paginate(params[:page], limit: limit, search_count: params[:search])
-    respond_with(@pools)
-  end
-
   def show
     limit = params[:limit].presence || CurrentUser.user.per_page
 
     @pool = authorize Pool.find(params[:id])
     @posts = @pool.posts.paginate(params[:page], limit: limit, count: @pool.post_count)
     respond_with(@pool)
+  end
+
+  def new
+    @pool = authorize Pool.new(permitted_attributes(Pool))
+    respond_with(@pool)
+  end
+
+  def edit
+    @pool = authorize Pool.find(params[:id])
+    respond_with(@pool)
+  end
+
+  def gallery
+    limit = params[:limit].presence || CurrentUser.user.per_page
+    search = search_params.presence || ActionController::Parameters.new(category: "series")
+
+    @pools = authorize Pool.search(search, CurrentUser.user).paginate(params[:page], limit: limit, search_count: params[:search])
+    respond_with(@pools)
   end
 
   def create

--- a/app/controllers/post_appeals_controller.rb
+++ b/app/controllers/post_appeals_controller.rb
@@ -3,11 +3,6 @@
 class PostAppealsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @post_appeal = authorize PostAppeal.new(permitted_attributes(PostAppeal))
-    respond_with(@post_appeal)
-  end
-
   def index
     @post_appeals = authorize PostAppeal.paginated_search(params)
 
@@ -20,13 +15,6 @@ class PostAppealsController < ApplicationController
     respond_with(@post_appeals)
   end
 
-  def create
-    @post_appeal = authorize PostAppeal.new(creator: CurrentUser.user, **permitted_attributes(PostAppeal))
-    @post_appeal.save
-
-    respond_with(@post_appeal, notice: "Post appealed")
-  end
-
   def show
     @post_appeal = authorize PostAppeal.find(params[:id])
     respond_with(@post_appeal) do |fmt|
@@ -34,9 +22,21 @@ class PostAppealsController < ApplicationController
     end
   end
 
+  def new
+    @post_appeal = authorize PostAppeal.new(permitted_attributes(PostAppeal))
+    respond_with(@post_appeal)
+  end
+
   def edit
     @post_appeal = authorize PostAppeal.find(params[:id])
     respond_with(@post_appeal)
+  end
+
+  def create
+    @post_appeal = authorize PostAppeal.new(creator: CurrentUser.user, **permitted_attributes(PostAppeal))
+    @post_appeal.save
+
+    respond_with(@post_appeal, notice: "Post appealed")
   end
 
   def update

--- a/app/controllers/post_approvals_controller.rb
+++ b/app/controllers/post_approvals_controller.rb
@@ -3,12 +3,6 @@
 class PostApprovalsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def create
-    @approval = authorize PostApproval.new(user: CurrentUser.user, post_id: params[:post_id])
-    @approval.save
-    respond_with(@approval)
-  end
-
   def index
     @post_approvals = authorize PostApproval.paginated_search(params)
     @post_approvals = @post_approvals.includes(:user, post: [:uploader, :media_asset]) if request.format.html?
@@ -22,5 +16,11 @@ class PostApprovalsController < ApplicationController
     respond_with(@approval) do |format|
       format.html { redirect_to post_approvals_path(search: { id: @approval.id }) }
     end
+  end
+
+  def create
+    @approval = authorize PostApproval.new(user: CurrentUser.user, post_id: params[:post_id])
+    @approval.save
+    respond_with(@approval)
   end
 end

--- a/app/controllers/post_disapprovals_controller.rb
+++ b/app/controllers/post_disapprovals_controller.rb
@@ -3,12 +3,6 @@
 class PostDisapprovalsController < ApplicationController
   respond_to :js, :html, :json, :xml
 
-  def create
-    @post_disapproval = authorize PostDisapproval.new(user: CurrentUser.user, **permitted_attributes(PostDisapproval))
-    @post_disapproval.save
-    respond_with(@post_disapproval)
-  end
-
   def index
     @post_disapprovals = authorize PostDisapproval.paginated_search(params)
     @post_disapprovals = @post_disapprovals.includes(:user) if request.format.html?
@@ -26,6 +20,12 @@ class PostDisapprovalsController < ApplicationController
 
   def edit
     @post_disapproval = authorize PostDisapproval.find(params[:id])
+    respond_with(@post_disapproval)
+  end
+
+  def create
+    @post_disapproval = authorize PostDisapproval.new(user: CurrentUser.user, **permitted_attributes(PostDisapproval))
+    @post_disapproval.save
     respond_with(@post_disapproval)
   end
 

--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -3,11 +3,6 @@
 class PostFlagsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def new
-    @post_flag = authorize PostFlag.new(permitted_attributes(PostFlag))
-    respond_with(@post_flag)
-  end
-
   def index
     @post_flags = authorize PostFlag.paginated_search(params)
 
@@ -20,13 +15,6 @@ class PostFlagsController < ApplicationController
     respond_with(@post_flags)
   end
 
-  def create
-    @post_flag = authorize PostFlag.new(creator: CurrentUser.user, **permitted_attributes(PostFlag))
-    @post_flag.save
-
-    respond_with(@post_flag, notice: "Post flagged")
-  end
-
   def show
     @post_flag = authorize PostFlag.find(params[:id])
     respond_with(@post_flag) do |fmt|
@@ -34,9 +22,21 @@ class PostFlagsController < ApplicationController
     end
   end
 
+  def new
+    @post_flag = authorize PostFlag.new(permitted_attributes(PostFlag))
+    respond_with(@post_flag)
+  end
+
   def edit
     @post_flag = authorize PostFlag.find(params[:id])
     respond_with(@post_flag)
+  end
+
+  def create
+    @post_flag = authorize PostFlag.new(creator: CurrentUser.user, **permitted_attributes(PostFlag))
+    @post_flag.save
+
+    respond_with(@post_flag, notice: "Post flagged")
   end
 
   def update

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -3,6 +3,22 @@
 class PostReplacementsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
+  def index
+    params[:search][:post_id] = params.delete(:post_id) if params.key?(:post_id)
+    @post_replacements = authorize PostReplacement.paginated_search(params)
+    @post_replacements = @post_replacements.includes(:creator, :old_media_asset, :media_asset, post: [:uploader, :media_asset]) if request.format.html?
+
+    respond_with(@post_replacements)
+  end
+
+  def show
+    @post_replacement = authorize PostReplacement.find(params[:id])
+
+    respond_with(@post_replacement) do |format|
+      format.html { redirect_to post_replacements_path(search: { id: @post_replacement.id }) }
+    end
+  end
+
   def new
     @post_replacement = authorize PostReplacement.new(post_id: params[:post_id], **permitted_attributes(PostReplacement))
     respond_with(@post_replacement)
@@ -22,21 +38,5 @@ class PostReplacementsController < ApplicationController
     @post_replacement.update(permitted_attributes(@post_replacement))
 
     respond_with(@post_replacement)
-  end
-
-  def index
-    params[:search][:post_id] = params.delete(:post_id) if params.key?(:post_id)
-    @post_replacements = authorize PostReplacement.paginated_search(params)
-    @post_replacements = @post_replacements.includes(:creator, :old_media_asset, :media_asset, post: [:uploader, :media_asset]) if request.format.html?
-
-    respond_with(@post_replacements)
-  end
-
-  def show
-    @post_replacement = authorize PostReplacement.find(params[:id])
-
-    respond_with(@post_replacement) do |format|
-      format.html { redirect_to post_replacements_path(search: { id: @post_replacement.id }) }
-    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,14 +58,6 @@ class PostsController < ApplicationController
     end
   end
 
-  def update
-    @post = authorize Post.find(params[:id])
-    @post.update(permitted_attributes(@post))
-    @show_votes = (params[:show_votes].presence || cookies[:post_preview_show_votes].presence || "false").truthy?
-    @preview_size = params[:size].presence || cookies[:post_preview_size].presence || PostGalleryComponent::DEFAULT_SIZE
-    respond_with_post_after_update(@post)
-  end
-
   def create
     @upload_media_asset = UploadMediaAsset.find(params[:upload_media_asset_id])
     @post = authorize Post.new_from_upload(@upload_media_asset, **permitted_attributes(Post).to_h.symbolize_keys)
@@ -83,6 +75,14 @@ class PostsController < ApplicationController
       @post.tag_string = params.dig(:post, :tag_string) # Preserve original tag string on validation error
       respond_with(@post, render: { template: "upload_media_assets/show" })
     end
+  end
+
+  def update
+    @post = authorize Post.find(params[:id])
+    @post.update(permitted_attributes(@post))
+    @show_votes = (params[:show_votes].presence || cookies[:post_preview_show_votes].presence || "false").truthy?
+    @preview_size = params[:size].presence || cookies[:post_preview_size].presence || PostGalleryComponent::DEFAULT_SIZE
+    respond_with_post_after_update(@post)
   end
 
   def destroy

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -8,20 +8,14 @@ class SavedSearchesController < ApplicationController
     respond_with(@saved_searches)
   end
 
+  def edit
+    @saved_search = authorize SavedSearch.find(params[:id])
+    respond_with(@saved_search)
+  end
+
   def create
     @saved_search = authorize SavedSearch.new(user: CurrentUser.user, **permitted_attributes(SavedSearch))
     @saved_search.save
-    respond_with(@saved_search)
-  end
-
-  def destroy
-    @saved_search = authorize SavedSearch.find(params[:id])
-    @saved_search.destroy
-    respond_with(@saved_search)
-  end
-
-  def edit
-    @saved_search = authorize SavedSearch.find(params[:id])
     respond_with(@saved_search)
   end
 
@@ -29,5 +23,11 @@ class SavedSearchesController < ApplicationController
     @saved_search = authorize SavedSearch.find(params[:id])
     @saved_search.update(permitted_attributes(@saved_search))
     respond_with(@saved_search, :location => saved_searches_path)
+  end
+
+  def destroy
+    @saved_search = authorize SavedSearch.find(params[:id])
+    @saved_search.destroy
+    respond_with(@saved_search)
   end
 end

--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -3,16 +3,16 @@
 class TagAliasesController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def show
-    @tag_alias = authorize TagAlias.find(params[:id])
-    respond_with(@tag_alias)
-  end
-
   def index
     @tag_aliases = authorize TagAlias.paginated_search(params, count_pages: true)
     @tag_aliases = @tag_aliases.includes(:antecedent_tag, :consequent_tag, :approver) if request.format.html?
 
     respond_with(@tag_aliases)
+  end
+
+  def show
+    @tag_alias = authorize TagAlias.find(params[:id])
+    respond_with(@tag_alias)
   end
 
   def destroy

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -3,16 +3,16 @@
 class TagImplicationsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
-  def show
-    @tag_implication = authorize TagImplication.find(params[:id])
-    respond_with(@tag_implication)
-  end
-
   def index
     @tag_implications = authorize TagImplication.paginated_search(params, count_pages: true)
     @tag_implications = @tag_implications.includes(:antecedent_tag, :consequent_tag, :approver) if request.format.html?
 
     respond_with(@tag_implications)
+  end
+
+  def show
+    @tag_implication = authorize TagImplication.find(params[:id])
+    respond_with(@tag_implication)
   end
 
   def destroy

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -3,11 +3,6 @@
 class TagsController < ApplicationController
   respond_to :html, :xml, :json
 
-  def edit
-    @tag = authorize Tag.find(params[:id])
-    respond_with(@tag)
-  end
-
   def index
     if request.format.html?
       @tags = authorize Tag.paginated_search(params, defaults: { hide_empty: true })
@@ -20,6 +15,11 @@ class TagsController < ApplicationController
   end
 
   def show
+    @tag = authorize Tag.find(params[:id])
+    respond_with(@tag)
+  end
+
+  def edit
     @tag = authorize Tag.find(params[:id])
     respond_with(@tag)
   end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -4,16 +4,6 @@ class UploadsController < ApplicationController
   respond_to :html, :xml, :json, :js
   skip_before_action :verify_authenticity_token, only: [:create], if: -> { request.xhr? }
 
-  def new
-    @upload = authorize Upload.new(uploader: CurrentUser.user, source: params[:url], referer_url: params[:ref], **permitted_attributes(Upload))
-    respond_with(@upload)
-  end
-
-  def create
-    @upload = authorize Upload.new(uploader: CurrentUser.user, **permitted_attributes(Upload))
-    @upload.save
-    respond_with(@upload, include: { upload_media_assets: { include: { media_asset: { include: :post }}}})
-  end
 
   def index
     @mode = params.fetch(:mode, "gallery")
@@ -46,5 +36,16 @@ class UploadsController < ApplicationController
     else
       respond_with(@upload, include: { upload_media_assets: { include: { media_asset: { include: :post }}}})
     end
+  end
+
+  def new
+    @upload = authorize Upload.new(uploader: CurrentUser.user, source: params[:url], referer_url: params[:ref], **permitted_attributes(Upload))
+    respond_with(@upload)
+  end
+
+  def create
+    @upload = authorize Upload.new(uploader: CurrentUser.user, **permitted_attributes(Upload))
+    @upload.save
+    respond_with(@upload, include: { upload_media_assets: { include: { media_asset: { include: :post }}}})
   end
 end

--- a/app/controllers/user_feedbacks_controller.rb
+++ b/app/controllers/user_feedbacks_controller.rb
@@ -3,6 +3,18 @@
 class UserFeedbacksController < ApplicationController
   respond_to :html, :xml, :json, :js
 
+  def index
+    @user_feedbacks = authorize UserFeedback.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    @user_feedbacks = @user_feedbacks.includes(:user, :creator) if request.format.html?
+
+    respond_with(@user_feedbacks)
+  end
+
+  def show
+    @user_feedback = authorize UserFeedback.find(params[:id])
+    respond_with(@user_feedback)
+  end
+
   def new
     @user_feedback = authorize UserFeedback.new(permitted_attributes(UserFeedback))
     respond_with(@user_feedback)
@@ -11,18 +23,6 @@ class UserFeedbacksController < ApplicationController
   def edit
     @user_feedback = authorize UserFeedback.find(params[:id])
     respond_with(@user_feedback)
-  end
-
-  def show
-    @user_feedback = authorize UserFeedback.find(params[:id])
-    respond_with(@user_feedback)
-  end
-
-  def index
-    @user_feedbacks = authorize UserFeedback.visible(CurrentUser.user).paginated_search(params, count_pages: true)
-    @user_feedbacks = @user_feedbacks.includes(:user, :creator) if request.format.html?
-
-    respond_with(@user_feedbacks)
   end
 
   def create

--- a/app/controllers/user_name_change_requests_controller.rb
+++ b/app/controllers/user_name_change_requests_controller.rb
@@ -5,6 +5,16 @@ class UserNameChangeRequestsController < ApplicationController
 
   skip_before_action :redirect_if_name_invalid?
 
+  def index
+    @change_requests = authorize UserNameChangeRequest.visible(CurrentUser.user).paginated_search(params)
+    respond_with(@change_requests)
+  end
+
+  def show
+    @change_request = authorize UserNameChangeRequest.find(params[:id])
+    respond_with(@change_request)
+  end
+
   def new
     @user = params[:id].present? ? User.find(params[:id]) : CurrentUser.user
     @change_request = authorize UserNameChangeRequest.new(user: @user, **permitted_attributes(UserNameChangeRequest))
@@ -17,15 +27,5 @@ class UserNameChangeRequestsController < ApplicationController
     @change_request.save
 
     respond_with(@change_request, notice: "Name changed", location: @change_request.user)
-  end
-
-  def show
-    @change_request = authorize UserNameChangeRequest.find(params[:id])
-    respond_with(@change_request)
-  end
-
-  def index
-    @change_requests = authorize UserNameChangeRequest.visible(CurrentUser.user).paginated_search(params)
-    respond_with(@change_requests)
   end
 end

--- a/app/controllers/user_upgrades_controller.rb
+++ b/app/controllers/user_upgrades_controller.rb
@@ -3,12 +3,15 @@
 class UserUpgradesController < ApplicationController
   respond_to :js, :html, :json, :xml
 
-  def create
-    @user_upgrade = authorize UserUpgrade.create(recipient: recipient, purchaser: CurrentUser.user, status: "pending", upgrade_type: params[:upgrade_type], payment_processor: params[:payment_processor])
-    @country = params[:country] || "US"
-    @allow_promotion_codes = params[:promo].to_s.truthy?
-    @checkout = @user_upgrade.create_checkout!(country: @country, allow_promotion_codes: @allow_promotion_codes)
+  def index
+    @user_upgrades = authorize UserUpgrade.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+    @user_upgrades = @user_upgrades.includes(:recipient, :purchaser) if request.format.html?
 
+    respond_with(@user_upgrades)
+  end
+
+  def show
+    @user_upgrade = authorize UserUpgrade.find(params[:id])
     respond_with(@user_upgrade)
   end
 
@@ -19,15 +22,12 @@ class UserUpgradesController < ApplicationController
     respond_with(@user_upgrade)
   end
 
-  def index
-    @user_upgrades = authorize UserUpgrade.visible(CurrentUser.user).paginated_search(params, count_pages: true)
-    @user_upgrades = @user_upgrades.includes(:recipient, :purchaser) if request.format.html?
+  def create
+    @user_upgrade = authorize UserUpgrade.create(recipient: recipient, purchaser: CurrentUser.user, status: "pending", upgrade_type: params[:upgrade_type], payment_processor: params[:payment_processor])
+    @country = params[:country] || "US"
+    @allow_promotion_codes = params[:promo].to_s.truthy?
+    @checkout = @user_upgrade.create_checkout!(country: @country, allow_promotion_codes: @allow_promotion_codes)
 
-    respond_with(@user_upgrades)
-  end
-
-  def show
-    @user_upgrade = authorize UserUpgrade.find(params[:id])
     respond_with(@user_upgrade)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,28 +6,6 @@ class UsersController < ApplicationController
   around_action :set_timeout, only: [:profile, :show]
   verify_captcha only: :create
 
-  def new
-    @user = authorize User.new
-    @url = params.dig(:user, :url).presence || params[:url].presence || root_path
-    respond_with(@user)
-  end
-
-  def edit
-    @user = authorize User.find(params[:id])
-    respond_with(@user)
-  end
-
-  def settings
-    @user = authorize CurrentUser.user
-
-    if @user.is_anonymous?
-      redirect_to login_path(url: settings_path)
-    else
-      params[:action] = "edit"
-      respond_with(@user, template: "users/edit")
-    end
-  end
-
   def index
     if params[:name].present?
       params[:search] ||= {}
@@ -49,6 +27,28 @@ class UsersController < ApplicationController
     @user = authorize User.find(params[:id])
     respond_with(@user, methods: @user.full_attributes) do |format|
       format.html.tooltip { render layout: false }
+    end
+  end
+
+  def new
+    @user = authorize User.new
+    @url = params.dig(:user, :url).presence || params[:url].presence || root_path
+    respond_with(@user)
+  end
+
+  def edit
+    @user = authorize User.find(params[:id])
+    respond_with(@user)
+  end
+
+  def settings
+    @user = authorize CurrentUser.user
+
+    if @user.is_anonymous?
+      redirect_to login_path(url: settings_path)
+    else
+      params[:action] = "edit"
+      respond_with(@user, template: "users/edit")
     end
   end
 

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -4,17 +4,6 @@ class WikiPagesController < ApplicationController
   respond_to :html, :xml, :json, :js
   layout "sidebar"
 
-  def new
-    @wiki_page = authorize WikiPage.new(permitted_attributes(WikiPage))
-    respond_with(@wiki_page)
-  end
-
-  def edit
-    @wiki_page, _found_by = WikiPage.find_by_id_or_title(params[:id])
-    authorize @wiki_page
-    respond_with(@wiki_page)
-  end
-
   def index
     if params[:title].present?
       authorize WikiPage
@@ -40,6 +29,17 @@ class WikiPagesController < ApplicationController
     else
       respond_with(@wiki_page)
     end
+  end
+
+  def new
+    @wiki_page = authorize WikiPage.new(permitted_attributes(WikiPage))
+    respond_with(@wiki_page)
+  end
+
+  def edit
+    @wiki_page, _found_by = WikiPage.find_by_id_or_title(params[:id])
+    authorize @wiki_page
+    respond_with(@wiki_page)
   end
 
   def create


### PR DESCRIPTION
Also reenables the rubocop rule.
This rule always shifts stuff whenever we're doing edits in controllers, so might as well do it all in one go if we want to keep it.