### PR TITLE
Update default modqueue warning tags

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -634,8 +634,9 @@ module Danbooru
 
     # Posts with these tags will be highlighted in the modqueue.
     def modqueue_warning_tags
-      %w[ai-generated ai-assisted anime_screencap bad_source duplicate hard_translated image_sample md5_mismatch
-      nude_filter off-topic paid_reward resized third-party_edit]
+      %w[ai-generated ai-assisted anime_screenshot game_screenshot bad_source duplicate
+      hard-translated image_sample md5_mismatch nude_filter off-topic paid_reward resized
+      third-party_edit]
     end
 
     # Whether the Gold account upgrade page should be enabled.


### PR DESCRIPTION
Quick change to update default modqueue warning tags to match the current tag names on Danbooru proper as well as add one more prohibited type of content.

* Change anime_screencap -> anime_screenshot
* Change hard_translated -> hard-translated
* Add game_screenshot