### PR TITLE
Fix #6270: duration metatag should support minutes

### DIFF
--- a/app/logical/duration_parser.rb
+++ b/app/logical/duration_parser.rb
@@ -6,9 +6,13 @@ module DurationParser
   def self.parse(string)
     abbrevs = Abbrev.abbrev(%w[seconds minutes hours days weeks months years])
 
-    raise unless string =~ /(.*?)([a-z]+)\z/i
-    size = Float($1)
-    unit = abbrevs.fetch($2.downcase)
+    if string =~ /(.*?)([a-z]+)\z/i
+      size = Float($1)
+      unit = abbrevs.fetch($2.downcase)
+    else
+      size = Float(string)
+      unit = "seconds"
+    end
 
     case unit
     when "seconds"

--- a/app/logical/range_parser.rb
+++ b/app/logical/range_parser.rb
@@ -63,9 +63,9 @@ class RangeParser
       [:not_eq, nil]
     in "none"
       [:eq, nil]
-    in _ if type == :float
+    in _ if type in :float | :duration
       value = parse_value(string)
-      [:between, (value * 0.95..value * 1.05)] # add a 5% tolerance for float values
+      [:between, (value * 0.95..value * 1.05)] # add a 5% tolerance for float/duration values
     in /[km]b?\z/i if type == :filesize
       value = parse_value(string)
       [:between, (value * 0.95..value * 1.05)] # add a 5% tolerance for filesize values
@@ -109,6 +109,9 @@ class RangeParser
 
     when :float
       Float(string) # raises ArgumentError if string is invalid
+
+    when :duration
+      DurationParser.parse(string).to_f
 
     when :md5
       raise ParseError, "#{string} is not a valid MD5" unless string.match?(/\A[0-9a-fA-F]{32}\z/)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1172,7 +1172,7 @@ class Post < ApplicationRecord
         when "tagcount"
           attribute_matches(value, :tag_count)
         when "duration"
-          attribute_matches(value, "media_assets.duration", :float).joins(:media_asset)
+          attribute_matches(value, "media_assets.duration", :duration).joins(:media_asset)
         when "is"
           is_matches(value, current_user)
         when "has"

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -763,7 +763,7 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([post], "-age:>1y")
       assert_tag_match([], "-age:<1y")
 
-      assert_tag_match([], "age:<60")
+      assert_tag_match([post], "age:<60")
     end
 
     should "return posts for the ratio:<x:y> metatag" do
@@ -794,7 +794,7 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
     end
 
     should "return posts for the duration:<x> metatag" do
-      post = create(:post, media_asset: create(:media_asset, file: "test/files/webm/test-512x512.webm"))
+      post = create(:post, media_asset: create(:media_asset, duration: 0.48, file: "test/files/webm/test-512x512.webm"))
 
       assert_tag_match([post], "duration:0.48")
       assert_tag_match([post], "duration:>0.4")
@@ -805,6 +805,52 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([post], "-duration:<0.4")
       assert_tag_match([], "-duration:<0.5")
       assert_tag_match([], "-duration:>0.4")
+
+      assert_tag_match([post], "duration:<1s")
+      assert_tag_match([post], "duration:<1sec")
+      assert_tag_match([post], "duration:<1second")
+      assert_tag_match([post], "duration:<1seconds")
+      assert_tag_match([post], "duration:>0.4s")
+      assert_tag_match([], "duration:>1s")
+
+      assert_tag_match([post], "duration:<1min")
+      assert_tag_match([post], "duration:<1minute")
+      assert_tag_match([post], "duration:<1minutes")
+      assert_tag_match([], "duration:>1min")
+
+      assert_tag_match([post], "duration:<1h")
+      assert_tag_match([post], "duration:<1hour")
+      assert_tag_match([post], "duration:<1hours")
+      assert_tag_match([], "duration:>1h")
+
+      assert_tag_match([post], "duration:<1d")
+      assert_tag_match([post], "duration:<1day")
+      assert_tag_match([post], "duration:<1days")
+      assert_tag_match([], "duration:>1d")
+
+      assert_tag_match([post], "duration:<1w")
+      assert_tag_match([post], "duration:<1week")
+      assert_tag_match([post], "duration:<1weeks")
+      assert_tag_match([], "duration:>1w")
+
+      assert_tag_match([post], "duration:<1mo")
+      assert_tag_match([post], "duration:<1month")
+      assert_tag_match([post], "duration:<1months")
+      assert_tag_match([], "duration:>1mo")
+
+      assert_tag_match([post], "duration:<1y")
+      assert_tag_match([post], "duration:<1year")
+      assert_tag_match([post], "duration:<1years")
+      assert_tag_match([], "duration:>1y")
+
+      long_post = create(:post, media_asset: create(:media_asset, duration: 90.0))
+      assert_tag_match([long_post], "duration:90")
+      assert_tag_match([long_post], "duration:90s")
+      assert_tag_match([long_post], "duration:1.5min")
+      assert_tag_match([long_post], "duration:>1min")
+      assert_tag_match([long_post], "duration:1min..2min")
+      assert_tag_match([], "duration:>2min")
+      assert_tag_match([], "duration:1s..1min")
     end
 
     should "return posts for the is:<status> metatag" do


### PR DESCRIPTION
Fixes #6270.

The `duration` metatag now accepts time unit suffixes, matching how the `age` metatag works.

**`duration` now supports unit suffixes:**

```
duration:>1min        # longer than 1 minute
duration:<1h          # shorter than 1 hour
duration:<1s          # shorter than 1 second
duration:0.4s..2min   # between 0.4 seconds and 2 minutes
```

Supported units: `s` / `sec` / `second` / `seconds`, `min` / `minute` / `minutes`, `h` / `hour` / `hours`, `d` / `day` / `days`, `w` / `week` / `weeks`. Without a unit, values are interpreted as seconds.

**`age` behavior change:**

`age:` now defaults to seconds when no unit is given, so `age:30` is equivalent to `age:30s` (posts created within the last 30 seconds). Previously, `age:30` was rejected as invalid.
