### PR TITLE
Uploads: Search source, referer, and source_url fields together.

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -122,8 +122,16 @@ class Upload < ApplicationRecord
     where(upload_media_assets.where("upload_media_assets.upload_id = uploads.id").arel.exists)
   end
 
+  def self.any_source_matches(source)
+    upload_media_assets = UploadMediaAsset.where_ilike(:source_url, source)
+    q = where_ilike(:source, source)
+    q = q.or(where_ilike(:referer_url, source))
+    q = q.or(where(upload_media_assets.where("upload_media_assets.upload_id = uploads.id").arel.exists))
+    q
+  end
+
   def self.search(params, current_user)
-    q = search_attributes(params, [:id, :created_at, :updated_at, :source, :referer_url, :status, :media_asset_count, :uploader, :upload_media_assets, :media_assets, :posts], current_user: current_user)
+    q = search_attributes(params, %i[id created_at updated_at source referer_url status media_asset_count uploader upload_media_assets media_assets posts], current_user: current_user)
 
     if params[:ai_tags_match].present?
       min_score = params.fetch(:min_score, 50).to_i
@@ -134,6 +142,10 @@ class Upload < ApplicationRecord
       q = q.where.not(id: Upload.where.missing(:posts))
     elsif params[:is_posted].to_s.falsy?
       q = q.where(id: Upload.where.missing(:posts))
+    end
+
+    if params[:any_source_matches].present?
+      q = q.any_source_matches(params[:any_source_matches])
     end
 
     case params[:order]

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -4,7 +4,7 @@
 
     <%= search_form_for(current_page_path) do |f| %>
       <%= f.input :ai_tags_match, label: "Tags", input_html: { value: params.dig(:search, :ai_tags_match), data: { autocomplete: "tag-query" } } %>
-      <%= f.input :source_ilike, label: "Source", input_html: { value: params.dig(:search, :source_ilike) } %>
+      <%= f.input :any_source_matches, label: "Source", input_html: { value: params.dig(:search, :any_source_matches) } %>
       <%= f.input :status, collection: %w[pending completed error], include_blank: true, selected: params.dig(:search, :status) %>
       <%= f.input :is_posted, as: :hidden, input_html: { value: params.dig(:search, :is_posted) } %>
       <%= f.input :min_score, as: :hidden, input_html: { value: params.dig(:search, :min_score) } %>

--- a/test/unit/upload_test.rb
+++ b/test/unit/upload_test.rb
@@ -11,10 +11,10 @@ class UploadTest < ActiveSupport::TestCase
         @asset1 = create(:media_asset, image_width: 720, image_height: 1280, file_size: 1.megabyte, file_ext: "jpg", media_metadata: build(:media_metadata, metadata: { "File:FileType" => "JPEG" }))
         @asset2 = create(:media_asset, image_width: 1920, image_height: 1080, file_size: 2.megabytes, file_ext: "png", duration: 3.0, media_metadata: build(:media_metadata, metadata: { "File:FileType" => "PNG" }))
 
-        @uma1 = build(:upload_media_asset, media_asset: @asset1, status: "active", created_at: Time.zone.now)
-        @uma2 = build(:upload_media_asset, media_asset: @asset2, status: "active", created_at: Time.zone.parse("2022-01-01"))
+        @uma1 = build(:upload_media_asset, media_asset: @asset1, status: "active", created_at: Time.zone.now, source_url: "https://example.com/image.jpg")
+        @uma2 = build(:upload_media_asset, media_asset: @asset2, status: "active", created_at: Time.zone.parse("2022-01-01"), source_url: "file://image.png")
 
-        @upload1 = create(:upload, created_at: Time.zone.now, upload_media_assets: [@uma1])
+        @upload1 = create(:upload, created_at: Time.zone.now, upload_media_assets: [@uma1], source: "https://example.com/posts/1")
         @upload2 = create(:upload, created_at: Time.zone.parse("2022-01-01"), upload_media_assets: [@uma2])
       end
 
@@ -74,6 +74,12 @@ class UploadTest < ActiveSupport::TestCase
       should "return assets for the exif: tag" do
         assert_tag_match([@upload2, @upload1], "exif:File:FileType")
         assert_tag_match([@upload1], "exif:File:FileType=JPEG")
+      end
+
+      should "return search for sources" do
+        assert_equal([@upload1], Upload.any_source_matches("https://example.com/image.jpg"))
+        assert_equal([@upload1], Upload.any_source_matches("https://example.com/posts/1"))
+        assert_equal([@upload2], Upload.any_source_matches("file://image.png"))
       end
     end
 


### PR DESCRIPTION
Fixes #6257 and fixes #5960.

Since `referer_url` can be anything, sometimes you can have false positives.