### PR TITLE
Prevent changing artist tags' category.

### DIFF
--- a/app/logical/bulk_update_request_processor.rb
+++ b/app/logical/bulk_update_request_processor.rb
@@ -47,7 +47,7 @@ class BulkUpdateRequestProcessor
         [:rename, Tag.normalize_name($1), Tag.normalize_name($2)]
       when /\A(?:mass update|update) (.+?) -> (.*)\z/i
         [:mass_update, $1, $2]
-      when /\Acategory (\S+) -> (#{Tag.categories.regexp})\z/i
+      when /\Acategory (\S+) -> (.*)\z/i
         [:change_category, Tag.normalize_name($1), $2.downcase]
       when /\Aconvert (.+?) -> (.*)\z/i
         [:convert, $1, $2]
@@ -159,8 +159,17 @@ class BulkUpdateRequestProcessor
 
   def validate_change_category(tag_name, category)
     tag = Tag.find_by_name(tag_name)
+
     if tag.nil?
-      errors.add(:base, "Can't change category of [[#{tag_name}]] to #{category} ([[#{tag_name}]] doesn't exist)")
+      errors.add(:base, "Can't change the category of [[#{tag_name}]] to #{category} ([[#{tag_name}]] doesn't exist)")
+    elsif Tag.categories.value_for(category).nil?
+      errors.add(:base, "Can't change the category of [[#{tag_name}]] to #{category} (#{category} is not a valid category)")
+    elsif validation_context == :approval
+      # do nothing
+    elsif Tag.categories.value_for(category) == tag.category
+      errors.add(:base, "Can't change the category of [[#{tag_name}]] to #{category} ([[#{tag_name}]] is already in that category)")
+    elsif Tag.categories.value_for(category) != Tag.categories.artist && tag.artist.present?
+      errors.add(:base, "Can't change the category of [[#{tag_name}]] to #{category} ([[#{tag_name}]] must be an Artist tag)")
     end
   end
 

--- a/app/logical/related_tag_query.rb
+++ b/app/logical/related_tag_query.rb
@@ -16,7 +16,7 @@ class RelatedTagQuery
     @media_asset = media_asset
     @categories = categories
     @categories = @categories.to_s.split(/[[:space:],]/) unless categories.is_a?(Array)
-    @categories = @categories.map { |c| Tag.categories.value_for(c) }
+    @categories = @categories.map { |c| Tag.categories.value_for(c) }.compact
     @order = order
     @search_sample_size = search_sample_size.to_i.clamp(0, 100_000)
     @search_sample_size = 5000 if @search_sample_size == 0

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -65,10 +65,8 @@ class Tag < ApplicationRecord
       norm_string = string.to_s.downcase
       if norm_string =~ /\A#{TagCategory.category_ids_regex}\z/
         norm_string.to_i
-      elsif TagCategory.mapping[string.to_s.downcase]
-        TagCategory.mapping[string.to_s.downcase]
       else
-        0
+        TagCategory.mapping[string.to_s.downcase]
       end
     end
   end
@@ -197,6 +195,10 @@ class Tag < ApplicationRecord
     end
 
     def validate_category
+      if category != Tag.categories.artist && artist.present?
+        errors.add(:base, "Artist tags must be in the Artist category")
+      end
+
       if is_aliased? && category != aliased_tag.category
         errors.add(:base, "Can't change the category of an aliased tag")
       end
@@ -236,7 +238,7 @@ class Tag < ApplicationRecord
       end
 
       def find_or_create_by_name(name, category: nil, current_user: nil, **options)
-        cat_id = categories.value_for(category)
+        cat_id = categories.value_for(category) || 0
         tag = Tag.find_by(name: normalize_name(name))
 
         if tag.nil?

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -2,9 +2,10 @@
 
 class TagPolicy < ApplicationPolicy
   def can_change_category?
-    user.is_admin? ||
-      (user.is_builder? && record.post_count < 1_000) ||
-      (user.is_member? && record.post_count < 50)
+    return false if record.artist.present? && record.category == Tag.categories.artist
+    return true if user.is_admin?
+    return true if user.is_builder? && record.post_count < 1_000
+    record.post_count < 50
   end
 
   def can_change_deprecated_status?

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -5,6 +5,8 @@
     <%= edit_form_for(@tag) do |f| %>
       <% if policy(@tag).can_change_category? %>
         <%= f.input :category, collection: TagCategory.canonical_mapping.to_a, include_blank: false %>
+      <% elsif @tag.artist.present? %>
+        <p>Cannot change the category of an artist tag. Rename the artist first.</p>
       <% else %>
         <p>Create a <%= link_to "bulk update request", new_bulk_update_request_path(bulk_update_request: { script: "category #{@tag.name} -> general" }) %> to change this tag's category.</p>
       <% end %>

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -7,13 +7,6 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
       @tag = create(:tag, name: "touhou", category: Tag.categories.copyright, post_count: 1)
     end
 
-    context "edit action" do
-      should "render" do
-        get_auth edit_tag_path(@tag), @user
-        assert_response :success
-      end
-    end
-
     context "index action" do
       should "render" do
         get tags_path
@@ -100,6 +93,29 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "edit action" do
+      should "render" do
+        get_auth edit_tag_path(@tag), @user
+        assert_response :success
+        assert_select("#tag_category")
+      end
+
+      should "not give the option to change the category for a large tag" do
+        @tag.update!(post_count: 1000)
+        get_auth edit_tag_path(@tag), @user
+        assert_response :success
+        assert_not_select("#tag_category")
+      end
+
+      should "not give the option to change the category for artist tags" do
+        @tag = create(:tag, category: Tag.categories.artist)
+        @artist = create(:artist, name: @tag.name)
+        get_auth edit_tag_path(@tag), @user
+        assert_response :success
+        assert_not_select("#tag_category")
+      end
+    end
+
     context "update action" do
       setup do
         @mod = create(:moderator_user)
@@ -151,6 +167,25 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
           assert_equal(Tag.categories.copyright, @tag.first_version.category)
           assert_equal(Tag.categories.general, @tag.last_version.category)
         end
+      end
+
+      should "not change category when the tag is too large to be changed by a builder" do
+        @tag = create(:tag, category: Tag.categories.general, post_count: 1001)
+        put_auth tag_path(@tag), @user, params: {:tag => {:category => Tag.categories.artist}}
+
+        assert_response 403
+        assert_equal(Tag.categories.general, @tag.reload.category)
+        assert_equal(0, @tag.versions.count)
+      end
+
+      should "not change the category of an artist tag" do
+        @tag = create(:tag, category: Tag.categories.artist)
+        @artist = create(:artist, name: @tag.name)
+
+        put_auth tag_path(@tag), @user, params: { tag: { category: Tag.categories.character }}
+        assert_response 403
+        assert(@tag.reload.artist?)
+        assert_equal(0, @tag.versions.count)
       end
 
       context "for deprecation" do
@@ -240,15 +275,6 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
           assert_equal(false, @tag_with_deleted_wiki.reload.is_deprecated?)
           assert_equal(0, @tag_with_deleted_wiki.versions.count)
         end
-      end
-
-      should "not change category when the tag is too large to be changed by a builder" do
-        @tag = create(:tag, category: Tag.categories.general, post_count: 1001)
-        put_auth tag_path(@tag), @user, params: {:tag => {:category => Tag.categories.artist}}
-
-        assert_response 403
-        assert_equal(Tag.categories.general, @tag.reload.category)
-        assert_equal(0, @tag.versions.count)
       end
     end
   end

--- a/test/unit/bulk_update_request_test.rb
+++ b/test/unit/bulk_update_request_test.rb
@@ -57,7 +57,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
           @bur = build(:bulk_update_request, script: "category hello -> artist")
 
           assert_equal(false, @bur.valid?)
-          assert_equal(["Can't change category of [[hello]] to artist ([[hello]] doesn't exist)"], @bur.errors[:base])
+          assert_equal(["Can't change the category of [[hello]] to artist ([[hello]] doesn't exist)"], @bur.errors[:base])
         end
       end
 
@@ -945,6 +945,33 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
 
           assert_equal(false, @bur.valid?)
           assert_equal(["Duplicate line found: create implication [[a]] -> [[b]]", "Duplicate line found: create implication [[b]] -> [[a]]"], @bur.errors.full_messages)
+        end
+      end
+
+      context "a bulk update request to change a tag's category" do
+        should "not allow changing a tag to an invalid category" do
+          @tag = create(:tag, name: "foo")
+          @bur = build(:bulk_update_request, script: "category foo -> bar")
+
+          assert_not(@bur.valid?)
+          assert_equal(["Can't change the category of [[foo]] to bar (bar is not a valid category)"], @bur.errors.full_messages)
+        end
+
+        should "not allow changing a tag to its own category" do
+          @tag = create(:tag, name: "touhou", category: Tag.categories.copyright)
+          @bur = build(:bulk_update_request, script: "category touhou -> copyright")
+
+          assert_not(@bur.valid?)
+          assert_equal(["Can't change the category of [[touhou]] to copyright ([[touhou]] is already in that category)"], @bur.errors.full_messages)
+        end
+
+        should "not allow changing an artist tag's category" do
+          @tag = create(:tag, name: "noizave", category: Tag.categories.artist)
+          @artist = create(:artist, name: @tag.name)
+          @bur = build(:bulk_update_request, script: "category noizave -> general")
+
+          assert_not(@bur.valid?)
+          assert_equal(["Can't change the category of [[noizave]] to general ([[noizave]] must be an Artist tag)"], @bur.errors.full_messages)
         end
       end
     end

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class TagTest < ActiveSupport::TestCase
   setup do
@@ -56,7 +56,7 @@ class TagTest < ActiveSupport::TestCase
       assert_equal(1, Tag.categories.value_for("artist"))
       assert_equal(1, Tag.categories.value_for("art"))
       assert_equal(5, Tag.categories.value_for("meta"))
-      assert_equal(0, Tag.categories.value_for("unknown"))
+      assert_equal(nil, Tag.categories.value_for("unknown"))
     end
   end
 
@@ -184,6 +184,13 @@ class TagTest < ActiveSupport::TestCase
 
       assert_equal(false, t1.valid?)
       assert_equal(["Can't change the category of an aliased tag"], t1.errors[:base])
+    end
+
+    should "not change category of an artist tag" do
+      tag = create(:tag, category: Tag.categories.artist)
+      create(:artist, name: tag.name)
+      Tag.find_or_create_by_name(tag.name, category: "character", current_user: create(:admin_user))
+      assert(tag.reload.artist?)
     end
 
     should "update post tag counts when the category is changed" do


### PR DESCRIPTION
Fixes #5326. It doesn't give you an error if the category change fails (also currently does not happen if the tag is too large to change the category), but I wasn't sure how to add that.