### PR TITLE
Fix duplicate post merging bugs.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -68,7 +68,7 @@ class PostsController < ApplicationController
       respond_with(@post, notice: notice)
     elsif @post.errors.of_kind?(:md5, :taken)
       @original_post = Post.find_by!(md5: @post.md5)
-      @original_post.update(rating: @post.rating, parent_id: @post.parent_id, tag_string: "#{@original_post.tag_string} #{@post.tag_string}")
+      @original_post.update(rating: @post.rating.presence || @original_post.rating, parent_id: @post.parent_id || @original_post.parent_id, tag_string: "#{@original_post.tag_string} #{params.dig(:post, :tag_string)}")
       flash[:notice] = "Duplicate of post ##{@original_post.id}; merging tags"
       redirect_to @original_post
     else

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -764,6 +764,34 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
         assert_equal("e", post1.rating)
       end
 
+      should "not clobber the parent_id of a duplicate" do
+        parent_post = create_post!(rating: "s", media_asset: create(:media_asset))
+        media_asset = create(:media_asset)
+        post1 = create_post!(rating: "s", parent_id: parent_post.id, media_asset: media_asset)
+        create_post!(rating: "s", parent_id: nil, media_asset: media_asset)
+
+        assert_redirected_to post1
+        assert_equal(parent_post.id, post1.reload.parent_id)
+      end
+
+      should "apply metatags to a duplicate" do
+        media_asset = create(:media_asset)
+        post1 = create_post!(rating: "s", media_asset: media_asset)
+        create_post!(rating: "s", tag_string: "fav:me", media_asset: media_asset)
+
+        assert_redirected_to post1
+        assert_equal(1, post1.reload.favorites.count)
+      end
+
+      should "merge tags if rating was forgotten" do
+        media_asset = create(:media_asset)
+        post1 = create_post!(rating: "s", tag_string: "post1", media_asset: media_asset)
+        create_post!(rating: "", tag_string: "post2", media_asset: media_asset)
+
+        assert_redirected_to post1
+        assert_equal("post1 post2", post1.reload.tag_string)
+      end
+
       should "apply the rating from the tags" do
         @post = create_post!(rating: nil, tag_string: "rating:s")
 


### PR DESCRIPTION
* Fix parent being clobbered if the later post didn't specify one.
* Fix missing rating preventing tags from being merged.
* Fix metatags not being applied because they were eaten by the first post.

Fixes #5500 and fixes #6122.