### PR TITLE
Add indices for any_source_matches

### DIFF
--- a/app/models/upload_media_asset.rb
+++ b/app/models/upload_media_asset.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 class UploadMediaAsset < ApplicationRecord
-  self.ignored_columns += [:user_id]
-
   extend Memoist
 
   attr_accessor :file
 
   belongs_to :upload
   belongs_to :media_asset, optional: true
+  belongs_to :user, optional: true, default: -> { upload.uploader }
   has_one :post, through: :media_asset
 
   after_create :async_process_upload!

--- a/app/models/upload_media_asset.rb
+++ b/app/models/upload_media_asset.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UploadMediaAsset < ApplicationRecord
+  self.ignored_columns += [:user_id]
+
   extend Memoist
 
   attr_accessor :file

--- a/app/models/upload_media_asset.rb
+++ b/app/models/upload_media_asset.rb
@@ -7,7 +7,7 @@ class UploadMediaAsset < ApplicationRecord
 
   belongs_to :upload
   belongs_to :media_asset, optional: true
-  belongs_to :user, optional: true, default: -> { upload.uploader }
+  belongs_to :user, default: -> { upload.uploader }
   has_one :post, through: :media_asset
 
   after_create :async_process_upload!
@@ -34,7 +34,7 @@ class UploadMediaAsset < ApplicationRecord
     elsif user.is_anonymous?
       none
     else
-      where(upload: user.uploads)
+      where(user: user)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,7 +171,7 @@ class User < ApplicationRecord
   has_many :tag_aliases, foreign_key: :creator_id
   has_many :tag_implications, foreign_key: :creator_id
   has_many :uploads, foreign_key: :uploader_id, dependent: :destroy
-  has_many :upload_media_assets, through: :uploads, dependent: :destroy
+  has_many :upload_media_assets, dependent: :destroy
   has_many :mod_actions, as: :subject, dependent: :destroy
   has_many :reactions, as: :model, dependent: :destroy
   has_many :site_credentials, foreign_key: :creator_id, dependent: :destroy

--- a/db/migrate/20260309171518_add_user_to_upload_media_assets.rb
+++ b/db/migrate/20260309171518_add_user_to_upload_media_assets.rb
@@ -1,0 +1,5 @@
+class AddUserToUploadMediaAssets < ActiveRecord::Migration[8.0]
+  def change
+    add_column :upload_media_assets, :user_id, :integer, null: true
+  end
+end

--- a/db/migrate/20260309181625_add_source_indices_to_upload_media_assets.rb
+++ b/db/migrate/20260309181625_add_source_indices_to_upload_media_assets.rb
@@ -1,0 +1,29 @@
+class AddSourceIndicesToUploadMediaAssets < ActiveRecord::Migration[8.0]
+  include MigrationHelpers
+  disable_ddl_transaction!
+
+  def change
+    add_not_null_constraint :upload_media_assets, :user_id
+    add_foreign_key :upload_media_assets, :users, deferrable: :deferred
+    add_index :upload_media_assets, :user_id, algorithm: :concurrently
+
+    remove_index :uploads, :source, algorithm: :concurrently
+    remove_index :uploads, :referer_url, algorithm: :concurrently
+
+    enable_extension "btree_gin"
+
+    reversible do |dir|
+      dir.up do
+        execute "CREATE INDEX CONCURRENTLY index_uploads_on_uploader_id_and_source ON uploads USING gin (uploader_id, source gin_trgm_ops)"
+        execute "CREATE INDEX CONCURRENTLY index_uploads_on_uploader_id_and_referer_url ON uploads USING gin (uploader_id, referer_url gin_trgm_ops)"
+        execute "CREATE INDEX CONCURRENTLY index_upload_media_assets_on_user_id_and_source_url ON upload_media_assets USING gin (user_id, source_url gin_trgm_ops)"
+      end
+
+      dir.down do
+        execute "DROP INDEX index_uploads_on_uploader_id_and_source"
+        execute "DROP INDEX index_uploads_on_uploader_id_and_referer_url"
+        execute "DROP INDEX index_upload_media_assets_on_user_id_and_source_url"
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2112,7 +2112,8 @@ CREATE TABLE public.upload_media_assets (
     status integer DEFAULT 0 NOT NULL,
     source_url character varying DEFAULT ''::character varying NOT NULL,
     error character varying,
-    page_url character varying
+    page_url character varying,
+    user_id integer
 );
 
 
@@ -3342,7 +3343,6 @@ ALTER TABLE ONLY public.ip_bans
 
 ALTER TABLE ONLY public.ip_geolocations
     ADD CONSTRAINT ip_geolocations_pkey PRIMARY KEY (id);
-
 
 
 --
@@ -7113,6 +7113,7 @@ ALTER TABLE ONLY public.user_upgrades
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260309171518'),
 ('20250720155738'),
 ('20250718142035'),
 ('20250716202530'),
@@ -7457,4 +7458,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20100205162521'),
 ('20100204214746'),
 ('20100204211522');
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: btree_gin; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS btree_gin WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION btree_gin; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION btree_gin IS 'support for indexing common datatypes in GIN';
+
+
+--
 -- Name: fuzzystrmatch; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -2113,7 +2127,7 @@ CREATE TABLE public.upload_media_assets (
     source_url character varying DEFAULT ''::character varying NOT NULL,
     error character varying,
     page_url character varying,
-    user_id integer
+    user_id integer NOT NULL
 );
 
 
@@ -5947,6 +5961,20 @@ CREATE INDEX index_upload_media_assets_on_upload_id ON public.upload_media_asset
 
 
 --
+-- Name: index_upload_media_assets_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_upload_media_assets_on_user_id ON public.upload_media_assets USING btree (user_id);
+
+
+--
+-- Name: index_upload_media_assets_on_user_id_and_source_url; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_upload_media_assets_on_user_id_and_source_url ON public.upload_media_assets USING gin (user_id, source_url public.gin_trgm_ops);
+
+
+--
 -- Name: index_uploads_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5968,20 +5996,6 @@ CREATE INDEX index_uploads_on_media_asset_count ON public.uploads USING btree (m
 
 
 --
--- Name: index_uploads_on_referer_url; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_uploads_on_referer_url ON public.uploads USING btree (referer_url);
-
-
---
--- Name: index_uploads_on_source; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_uploads_on_source ON public.uploads USING btree (source);
-
-
---
 -- Name: index_uploads_on_uploader_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5993,6 +6007,20 @@ CREATE INDEX index_uploads_on_uploader_id ON public.uploads USING btree (uploade
 --
 
 CREATE INDEX index_uploads_on_uploader_id_and_created_at_and_id ON public.uploads USING btree (uploader_id, created_at, id);
+
+
+--
+-- Name: index_uploads_on_uploader_id_and_referer_url; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_uploads_on_uploader_id_and_referer_url ON public.uploads USING gin (uploader_id, referer_url public.gin_trgm_ops);
+
+
+--
+-- Name: index_uploads_on_uploader_id_and_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_uploads_on_uploader_id_and_source ON public.uploads USING gin (uploader_id, source public.gin_trgm_ops);
 
 
 --
@@ -7003,6 +7031,14 @@ ALTER TABLE ONLY public.upgrade_codes
 
 
 --
+-- Name: upload_media_assets fk_rails_d61d4a2ba9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.upload_media_assets
+    ADD CONSTRAINT fk_rails_d61d4a2ba9 FOREIGN KEY (user_id) REFERENCES public.users(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
 -- Name: tag_implications fk_rails_dba2c19f93; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7113,6 +7149,7 @@ ALTER TABLE ONLY public.user_upgrades
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260309181625'),
 ('20260309171518'),
 ('20250720155738'),
 ('20250718142035'),

--- a/script/fixes/141_populate_upload_media_assets_user.sql
+++ b/script/fixes/141_populate_upload_media_assets_user.sql
@@ -1,0 +1,4 @@
+UPDATE upload_media_assets
+SET user_id = uploads.uploader_id
+FROM uploads
+WHERE uploads.id = upload_media_assets.upload_id AND upload_media_assets.user_id IS NULL;


### PR DESCRIPTION
Replaces the btree indices on uploads and upload_media_assets with compound gin indices, which requires the btree_gin extension. Adding a user_id column on upload_media_assets, so it must be deployed in parts (first migration, run fix script, then second migration).