### PR TITLE
Modqueue: Sort by least disapprovals first by default.

### DIFF
--- a/app/controllers/modqueue_controller.rb
+++ b/app/controllers/modqueue_controller.rb
@@ -8,10 +8,14 @@ class ModqueueController < ApplicationController
     authorize :modqueue
     @mode = params.fetch(:mode, "gallery")
     @limit = params.fetch(:limit, CurrentUser.user.per_page).to_i.clamp(0, PostSets::Post::MAX_PER_PAGE)
+    @order = params.dig(:search, :order) || "disapprovals_asc"
+    @tags = params.dig(:search, :tags)
 
     @posts = Post.includes(:appeals, :vote_by_current_user, :uploader, :media_asset, disapprovals: [:user], flags: [:creator])
     @posts = @posts.available_for_moderation(CurrentUser.user, search_params.fetch(:modqueue, :unseen))
-    @posts = @posts.paginated_search(params, limit: @limit, count_pages: true, defaults: { order: "modqueue" })
+    @posts = @posts.user_tag_match(@tags, CurrentUser.user) if @tags.present?
+    @posts = @posts.user_tag_match("order:#{@order}", CurrentUser.user)
+    @posts = @posts.paginate(params[:page], limit: @limit)
     @modqueue_posts = @posts.distinct.except(:select, :group, :order, :offset, :limit)
 
     @pending_post_count = @modqueue_posts.select(&:is_pending?).count

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -19,7 +19,7 @@ class PostQueryBuilder
     flag_count
     child_count deleted_child_count active_child_count
     pool_count deleted_pool_count active_pool_count series_pool_count collection_pool_count
-    appeal_count approval_count replacement_count
+    appeal_count approval_count replacement_count disapproval_count
   ]
 
   # allow e.g. `deleted_comments` as a synonym for `deleted_comment_count`

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1077,6 +1077,12 @@ class Post < ApplicationRecord
         relation
       end
 
+      def with_disapproval_stats
+        relation = left_outer_joins(:disapprovals).group(:id).select("posts.*")
+        relation = relation.select("COUNT(post_disapprovals.id) AS disapproval_count")
+        relation
+      end
+
       def with_replacement_stats
         relation = left_outer_joins(:replacements).group(:id).select("posts.*")
         relation = relation.select("COUNT(post_replacements.id) AS replacement_count")

--- a/app/views/modqueue/_sidebar.html.erb
+++ b/app/views/modqueue/_sidebar.html.erb
@@ -3,7 +3,7 @@
 
   <%= search_form_for(modqueue_index_path, classes: "one-line-form") do |f| %>
     <%= f.input :tags, label: false, input_html: { placeholder: "Tags", value: params.dig(:search, :tags), "data-autocomplete": "tag-query" } %>
-    <%= f.input :order, label: false, collection: [["Newest", "modqueue"], ["Oldest", "modqueue_asc"], ["Score (Highest)", "score"], ["Score (Lowest)", "score_asc"]], selected: params[:search][:order] %>
+    <%= f.input :order, label: false, collection: [["Disapprovals (Fewest)", "disapprovals_asc"], ["Disapprovals (Most)", "disapprovals"], ["Newest", "modqueue"], ["Oldest", "modqueue_asc"], ["Score (Highest)", "score"], ["Score (Lowest)", "score_asc"]], selected: params[:search][:order] %>
     <%= f.button :button, name: nil, id: "search-box-submit" do %>
       <%= search_icon %>
     <% end %>

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -628,6 +628,41 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([posts[2], posts[0]], "-flags:1")
     end
 
+    should "return posts for the approval_count:<N> metatag" do
+      posts = create_list(:post, 3, is_pending: true)
+      create(:post_approval, post: posts[0])
+      create(:post_flag, post: posts[0])
+      create(:post_approval, post: posts[0])
+      create(:post_approval, post: posts[1])
+
+      assert_tag_match([posts[0]], "approval_count:2")
+      assert_tag_match([posts[1]], "approval_count:1")
+      assert_tag_match([posts[1], posts[0]], "approval_count:>0")
+
+      assert_tag_match([posts[0]], "approvals:2")
+      assert_tag_match([posts[1]], "approvals:1")
+      assert_tag_match([posts[1], posts[0]], "approvals:>0")
+
+      assert_tag_match([posts[2]], "-approvals:>0")
+    end
+
+    should "return posts for the disapproval_count:<N> metatag" do
+      posts = create_list(:post, 3, is_pending: true)
+      create(:post_disapproval, post: posts[0])
+      create(:post_disapproval, post: posts[0])
+      create(:post_disapproval, post: posts[1])
+
+      assert_tag_match([posts[0]], "disapproval_count:2")
+      assert_tag_match([posts[1]], "disapproval_count:1")
+      assert_tag_match([posts[1], posts[0]], "disapproval_count:>0")
+
+      assert_tag_match([posts[0]], "disapprovals:2")
+      assert_tag_match([posts[1]], "disapprovals:1")
+      assert_tag_match([posts[1], posts[0]], "disapprovals:>0")
+
+      assert_tag_match([posts[2]], "-disapprovals:>0")
+    end
+
     should "return posts for the commentaryupdater:<name> metatag" do
       user1 = create(:user)
       user2 = create(:user)


### PR DESCRIPTION
Fixes #5862 and fixes #5863.

I switched from `paginated_search` to `user_tag_match` because `order_matches` has a bug where it doesn't apply joins (these are instead done in `PostQueryBuilder`), which makes `search` unusable for any of the association counts.