### PR TITLE
Auto scroll the current post in post relationship previews into view 

### DIFF
--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -215,7 +215,9 @@ Post.initialize_links = function() {
 
 Post.initialize_post_relationship_previews = function() {
   var current_post_id = $("meta[name=post-id]").attr("content");
-  $("[id=post_" + current_post_id + "]").addClass("current-post");
+  var $current_post = $(`[id=post_${current_post_id}]`);
+  $current_post.addClass("current-post");
+  Post.scroll_relationship_preview($current_post);
 
   if (Cookie.get("show-relationship-previews") === "0") {
     this.toggle_relationship_preview($("#has-children-relationship-preview"), $("#has-children-relationship-preview-link"));
@@ -238,10 +240,31 @@ Post.toggle_relationship_preview = function(preview, preview_link) {
   if (preview.is(":visible")) {
     preview_link.html("&laquo; hide");
     Cookie.put("show-relationship-previews", "1");
+    Post.scroll_relationship_preview(preview.find(".current-post"));
   } else {
     preview_link.html("show &raquo;");
     Cookie.put("show-relationship-previews", "0");
   }
+}
+
+Post.scroll_relationship_preview = function($post) {
+  let $post_container = $post.parent('.posts-container');
+  let $previous_post = $post.prev();
+
+  if ($post.length === 0 || $post_container.length === 0 || $previous_post.length === 0) {
+    return;
+  }
+
+  let post = $post.get(0);
+  let post_container = $post_container.get(0);
+  let previous_post = $previous_post.get(0);
+  let post_rect = post.getBoundingClientRect();
+  let post_container_rect = post_container.getBoundingClientRect();
+  let previous_post_rect = previous_post.getBoundingClientRect();
+  let target_scroll_left = post_container.scrollLeft + (post_rect.left - post_container_rect.left) - (previous_post_rect.width / 2);
+  let max_scroll_left = Math.max(0, post_container.scrollWidth - post_container.clientWidth);
+
+  post_container.scrollLeft = Math.max(0, Math.min(target_scroll_left, max_scroll_left));
 }
 
 Post.initialize_post_preview_size_menu = function() {


### PR DESCRIPTION
On especially large variant sets (10+ posts) the current post's preview may appear out of initially visible part of the scrollable preview area. I find it quite inconvenient.
This will scroll the current post to the left side of the previews container, leaving some extra space before (equal to half of the previous sibling's width) - to make it apparent that there are older siblings present. To my experimentation, it feels like the best position to scroll it to.