### PR TITLE
Fix DCinside extractor

### DIFF
--- a/app/logical/source/extractor/dc_inside.rb
+++ b/app/logical/source/extractor/dc_inside.rb
@@ -66,6 +66,6 @@ class Source::Extractor::DcInside < Source::Extractor
 
   def http_downloader
     # downloads are prone to being interrupted, especially for large files
-    super.use(retriable: { max_retries: 10 })
+    super.use(retriable: { max_retries: 10 }).headers(Referer: "https://gall.dcinside.com/")
   end
 end


### PR DESCRIPTION
Spoof the correct referer header for http downloader.

Note that there's another issue with the host not supporting resuming downloads and closing the connection too early before the whole file is downloaded, which seems to be solvable by using a proxy close to Korea, but that's on infra, not the code.