### PR TITLE
posts: add ability to hide posts

### DIFF
--- a/app/controllers/upload_media_assets_controller.rb
+++ b/app/controllers/upload_media_assets_controller.rb
@@ -27,4 +27,10 @@ class UploadMediaAssetsController < ApplicationController
       respond_with(@upload_media_asset)
     end
   end
+
+  def update
+    @upload_media_asset = authorize UploadMediaAsset.find(params[:id])
+    @upload_media_asset.update(permitted_attributes(@upload_media_asset))
+    respond_with(@upload_media_asset)
+  end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -145,6 +145,12 @@ class Upload < ApplicationRecord
       q = q.where(id: Upload.where.missing(:posts))
     end
 
+    if params[:is_hidden].to_s.truthy?
+      q = q.where(id: Upload.joins(:upload_media_assets).merge(UploadMediaAsset.hidden).select(:id))
+    elsif params[:is_hidden].to_s.falsy?
+      q = q.where.not(id: Upload.joins(:upload_media_assets).merge(UploadMediaAsset.hidden).select(:id))
+    end
+
     if params[:any_source_matches].present?
       q = q.any_source_matches(params[:any_source_matches])
     end

--- a/app/models/upload_media_asset.rb
+++ b/app/models/upload_media_asset.rb
@@ -26,6 +26,8 @@ class UploadMediaAsset < ApplicationRecord
   scope :unfinished, -> { where(status: %w[pending processing]) }
   scope :finished, -> { where(status: %w[active failed]) }
   scope :expired, -> { unfinished.where(created_at: ..4.hours.ago) }
+  scope :hidden, -> { where(is_hidden: true) }
+  scope :not_hidden, -> { where(is_hidden: false) }
 
   def self.visible(user)
     if user.is_admin?
@@ -57,7 +59,7 @@ class UploadMediaAsset < ApplicationRecord
   end
 
   def self.search(params, current_user)
-    q = search_attributes(params, %i[id created_at updated_at status source_url page_url error upload media_asset post], current_user: current_user)
+    q = search_attributes(params, %i[id created_at updated_at status is_hidden source_url page_url error upload media_asset post], current_user: current_user)
 
     if params[:is_posted].to_s.truthy?
       q = q.where.associated(:post)

--- a/app/policies/upload_media_asset_policy.rb
+++ b/app/policies/upload_media_asset_policy.rb
@@ -4,4 +4,12 @@ class UploadMediaAssetPolicy < ApplicationPolicy
   def show?
     user.is_admin? || record.upload.uploader_id == user.id
   end
+
+  def update?
+    user.is_admin? || record.upload.uploader_id == user.id
+  end
+
+  def permitted_attributes_for_update
+    [:is_hidden]
+  end
 end

--- a/app/views/upload_media_assets/_preview.html.erb
+++ b/app/views/upload_media_assets/_preview.html.erb
@@ -15,5 +15,12 @@
         <%= link_to "post ##{upload_media_asset.post.id}", upload_media_asset.post %>
       <% end %>
     </div>
+    <div class="text-center text-xs h-4">
+      <% if upload_media_asset.is_hidden? %>
+        <%= link_to "Unhide", upload_media_asset_path(upload_media_asset), method: :put, remote: true, "data-params": "upload_media_asset[is_hidden]=false" %>
+      <% else %>
+        <%= link_to "Hide", upload_media_asset_path(upload_media_asset), method: :put, remote: true, "data-params": "upload_media_asset[is_hidden]=true" %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/upload_media_assets/update.js.erb
+++ b/app/views/upload_media_assets/update.js.erb
@@ -1,0 +1,14 @@
+$(function() {
+  let $el = $(".upload-media-asset-preview[data-id=<%= @upload_media_asset.id %>]").get(0);
+
+  if ($el) {
+    let html = "<%= j render("upload_media_assets/preview", upload_media_asset: @upload_media_asset, size: params.fetch(:size, 180)) %>";
+    Alpine.morph($el, html);
+  } else {
+    $el = $(".upload-preview[data-id=<%= @upload_media_asset.upload_id %>]").get(0);
+    if ($el) {
+      let html = "<%= j render("uploads/preview", upload: @upload_media_asset.upload, size: params.fetch(:size, 180)) %>";
+      Alpine.morph($el, html);
+    }
+  }
+});

--- a/app/views/uploads/_preview.html.erb
+++ b/app/views/uploads/_preview.html.erb
@@ -28,5 +28,14 @@
         <%= link_to "#{upload.posts.length}/#{upload.media_asset_count} posted", posts_path(tags: "id:#{upload.posts.map(&:id).join(",")}") %>
       <% end %>
     </div>
+    <div class="text-center text-xs h-4">
+      <% if upload_media_asset.present? %>
+        <% if upload_media_asset.is_hidden? %>
+          <%= link_to "Unhide", upload_media_asset_path(upload_media_asset), method: :put, remote: true, "data-params": "upload_media_asset[is_hidden]=false" %>
+        <% else %>
+          <%= link_to "Hide", upload_media_asset_path(upload_media_asset), method: :put, remote: true, "data-params": "upload_media_asset[is_hidden]=true" %>
+        <% end %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -7,6 +7,7 @@
       <%= f.input :any_source_matches, label: "Source", input_html: { value: params.dig(:search, :any_source_matches) } %>
       <%= f.input :status, collection: %w[pending completed error], include_blank: true, selected: params.dig(:search, :status) %>
       <%= f.input :is_posted, as: :hidden, input_html: { value: params.dig(:search, :is_posted) } %>
+      <%= f.input :is_hidden, as: :hidden, input_html: { value: params.dig(:search, :is_hidden) } %>
       <%= f.input :min_score, as: :hidden, input_html: { value: params.dig(:search, :min_score) } %>
 
       <%= f.input :order, collection: [%w[Newest id], %w[Oldest id_asc], %w[Random random]], include_blank: true, selected: params[:search][:order] %>
@@ -15,9 +16,10 @@
 
     <div class="tab-panel-component horizontal-tab-panel">
       <div class="tab-list">
-        <%= link_to "All", current_page_path(search: search_params.to_h.without("is_posted")), class: [(search_params[:is_posted].nil? ? "tab active-tab" : "tab")] %>
-        <%= link_to "Posted", current_page_path(search: search_params.merge(is_posted: true)), class: [(search_params[:is_posted].to_s.truthy? ? "tab active-tab" : "tab")] %>
-        <%= link_to "Unposted", current_page_path(search: search_params.merge(is_posted: false)), class: [(search_params[:is_posted].to_s.falsy? ? "tab active-tab" : "tab")] %>
+        <%= link_to "All", current_page_path(search: search_params.to_h.without("is_posted", "is_hidden").merge(is_hidden: false)), class: [(search_params[:is_posted].nil? && search_params[:is_hidden].to_s != "true" ? "tab active-tab" : "tab")] %>
+        <%= link_to "Posted", current_page_path(search: search_params.to_h.without("is_hidden").merge(is_posted: true, is_hidden: false)), class: [(search_params[:is_posted].to_s.truthy? ? "tab active-tab" : "tab")] %>
+        <%= link_to "Unposted", current_page_path(search: search_params.to_h.without("is_hidden").merge(is_posted: false, is_hidden: false)), class: [(search_params[:is_posted].to_s.falsy? && search_params[:is_hidden].to_s != "true" ? "tab active-tab" : "tab")] %>
+        <%= link_to "Hidden", current_page_path(search: search_params.to_h.without("is_posted").merge(is_hidden: true)), class: [(search_params[:is_hidden].to_s.truthy? ? "tab active-tab" : "tab")] %>
 
         <span class="flex-1"></span>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,9 +256,9 @@ Rails.application.routes.draw do
     collection do
       get :batch, to: redirect(path: "/uploads/new")
     end
-    resources :upload_media_assets, only: [:show, :index], path: "assets"
+    resources :upload_media_assets, only: [:show, :index, :update], path: "assets"
   end
-  resources :upload_media_assets, only: [:show, :index]
+  resources :upload_media_assets, only: [:show, :index, :update]
   resources :user_actions, only: [:index, :show]
   resources :users do
     resources :actions, only: [:index], controller: "user_actions", as: "user_actions"

--- a/db/migrate/20260328173801_add_is_hidden_to_upload_media_assets.rb
+++ b/db/migrate/20260328173801_add_is_hidden_to_upload_media_assets.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIsHiddenToUploadMediaAssets < ActiveRecord::Migration[7.1]
+  def change
+    add_column :upload_media_assets, :is_hidden, :boolean, default: false, null: false
+    add_index :upload_media_assets, :is_hidden, where: "is_hidden = TRUE"
+  end
+end

--- a/test/functional/upload_media_assets_controller_test.rb
+++ b/test/functional/upload_media_assets_controller_test.rb
@@ -26,5 +26,31 @@ class UploadsMediaAssetsControllerTest < ActionDispatch::IntegrationTest
         assert_response 403
       end
     end
+
+    context "update action" do
+      should "allow the uploader to hide their own upload" do
+        @upload_media_asset = create(:upload_media_asset)
+        put_auth upload_media_asset_path(@upload_media_asset), @upload_media_asset.upload.uploader, params: { upload_media_asset: { is_hidden: true } }
+
+        assert_response :success
+        assert_equal(true, @upload_media_asset.reload.is_hidden)
+      end
+
+      should "allow the uploader to unhide their own upload" do
+        @upload_media_asset = create(:upload_media_asset, is_hidden: true)
+        put_auth upload_media_asset_path(@upload_media_asset), @upload_media_asset.upload.uploader, params: { upload_media_asset: { is_hidden: false } }
+
+        assert_response :success
+        assert_equal(false, @upload_media_asset.reload.is_hidden)
+      end
+
+      should "not allow other users to hide someone else's upload" do
+        @upload_media_asset = create(:upload_media_asset)
+        put_auth upload_media_asset_path(@upload_media_asset), create(:user), params: { upload_media_asset: { is_hidden: true } }
+
+        assert_response 403
+        assert_equal(false, @upload_media_asset.reload.is_hidden)
+      end
+    end
   end
 end

--- a/test/unit/upload_test.rb
+++ b/test/unit/upload_test.rb
@@ -81,6 +81,27 @@ class UploadTest < ActiveSupport::TestCase
         assert_equal([@upload1], Upload.any_source_matches("https://example.com/posts/1"))
         assert_equal([@upload2], Upload.any_source_matches("file://image.png"))
       end
+
+      should "exclude hidden uploads by default" do
+        @uma1.update!(is_hidden: true)
+
+        results = Upload.search({ is_hidden: "false" }, User.anonymous)
+        assert_equal([@upload2.id], results.pluck(:id))
+      end
+
+      should "return only hidden uploads when is_hidden is true" do
+        @uma1.update!(is_hidden: true)
+
+        results = Upload.search({ is_hidden: "true" }, User.anonymous)
+        assert_equal([@upload1.id], results.pluck(:id))
+      end
+
+      should "return all uploads when is_hidden is not specified" do
+        @uma1.update!(is_hidden: true)
+
+        results = Upload.search({}, User.anonymous)
+        assert_equal([@upload1.id, @upload2.id], results.pluck(:id).sort)
+      end
     end
 
     context "during validation" do


### PR DESCRIPTION
Puts hidden posts into a third tab where they are still available but removed from main view.

I'm not sure how the frontend should behave upon hiding/unhiding post - currently it stays on page and toggle switches state. I could make it disappear, but I think that would make handling misclicks more annoying.

<img width="412" height="276" alt="Screenshot from 2026-03-28 21-23-34" src="https://github.com/user-attachments/assets/96e0a55e-489a-4198-99f0-e3ca66e90b8d" />

Solves issue: #5827

