### PR TITLE
comment votes: search by body instead of id

### DIFF
--- a/app/views/comment_votes/_search.html.erb
+++ b/app/views/comment_votes/_search.html.erb
@@ -4,7 +4,7 @@
     <%= fc.input :creator_name, label: "Commenter", input_html: { value: params.dig(:search, :comment, :creator_name), "data-autocomplete": "user" } %>
     <%= fc.input :body_matches, label: "Text", input_html: { value: params.dig(:search, :comment, :body_matches ) } %>
     <%= fc.input :post_tags_match, label: "Tags", input_html: { value: params.dig(:search, :comment, :post_tags_match), "data-autocomplete": "tag-query" } %>
-    <%= fc.input :post_id, label: "Post", input_html: { value: params.dig(:search, :comment, :post_id) } %>
+    <%= fc.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :comment, :post_id) } %>
   <% end %>
   <%# <%= f.input :comment_id, label: "Comment", input_html: { value: params[:search][:comment_id] } %>
   <%= f.input :is_deleted, label: "Deleted?", as: :select, include_blank: true, selected: params[:search][:is_deleted] %>

--- a/app/views/comment_votes/_search.html.erb
+++ b/app/views/comment_votes/_search.html.erb
@@ -4,8 +4,8 @@
     <%= fc.input :creator_name, label: "Commenter", input_html: { value: params.dig(:search, :comment, :creator_name), "data-autocomplete": "user" } %>
     <%= fc.input :post_tags_match, label: "Tags", input_html: { value: params.dig(:search, :comment, :post_tags_match), "data-autocomplete": "tag-query" } %>
     <%= fc.input :post_id, label: "Post", input_html: { value: params.dig(:search, :comment, :post_id) } %>
+    <%= fc.input :body_matches, label: "Comment", input_html: { value: params.dig(:search, :comment, :body_matches ) } %>
   <% end %>
-  <%= f.input :comment_id, label: "Comment", input_html: { value: params[:search][:comment_id] } %>
   <%= f.input :is_deleted, label: "Deleted?", as: :select, include_blank: true, selected: params[:search][:is_deleted] %>
   <%= f.input :score, collection: [["+1", "1"], ["-1", "-1"]], include_blank: true, selected: params[:search][:score] %>
   <%= f.submit "Search" %>

--- a/app/views/comment_votes/_search.html.erb
+++ b/app/views/comment_votes/_search.html.erb
@@ -2,10 +2,11 @@
   <%= f.input :user_name, label: "Voter", input_html: { value: params[:search][:user_name], "data-autocomplete": "user" } %>
   <%= f.simple_fields_for :comment do |fc| %>
     <%= fc.input :creator_name, label: "Commenter", input_html: { value: params.dig(:search, :comment, :creator_name), "data-autocomplete": "user" } %>
+    <%= fc.input :body_matches, label: "Text", input_html: { value: params.dig(:search, :comment, :body_matches ) } %>
     <%= fc.input :post_tags_match, label: "Tags", input_html: { value: params.dig(:search, :comment, :post_tags_match), "data-autocomplete": "tag-query" } %>
     <%= fc.input :post_id, label: "Post", input_html: { value: params.dig(:search, :comment, :post_id) } %>
-    <%= fc.input :body_matches, label: "Comment", input_html: { value: params.dig(:search, :comment, :body_matches ) } %>
   <% end %>
+  <%# <%= f.input :comment_id, label: "Comment", input_html: { value: params[:search][:comment_id] } %>
   <%= f.input :is_deleted, label: "Deleted?", as: :select, include_blank: true, selected: params[:search][:is_deleted] %>
   <%= f.input :score, collection: [["+1", "1"], ["-1", "-1"]], include_blank: true, selected: params[:search][:score] %>
   <%= f.submit "Search" %>

--- a/app/views/comment_votes/_search.html.erb
+++ b/app/views/comment_votes/_search.html.erb
@@ -6,7 +6,6 @@
     <%= fc.input :post_tags_match, label: "Tags", input_html: { value: params.dig(:search, :comment, :post_tags_match), "data-autocomplete": "tag-query" } %>
     <%= fc.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :comment, :post_id) } %>
   <% end %>
-  <%# <%= f.input :comment_id, label: "Comment", input_html: { value: params[:search][:comment_id] } %>
   <%= f.input :is_deleted, label: "Deleted?", as: :select, include_blank: true, selected: params[:search][:is_deleted] %>
   <%= f.input :score, collection: [["+1", "1"], ["-1", "-1"]], include_blank: true, selected: params[:search][:score] %>
   <%= f.submit "Search" %>


### PR DESCRIPTION
Fixes #6369. Replaces the `comment_id` search field with a `body_matches` search field, form order remains the same. I picked `body_matches` to keep parity with normal comment searching which also uses `body_matches` in its form.