### PR TITLE
Fix NoMethodError on e621 posts with non-url sources.

### DIFF
--- a/app/logical/source/extractor/e621.rb
+++ b/app/logical/source/extractor/e621.rb
@@ -88,7 +88,7 @@ class Source::Extractor::E621 < Source::Extractor
 
     url = api_response[:sources].filter_map do |url|
       url = Source::URL.parse(url)
-      url if url.page_url.present?
+      url if url&.page_url.present?
     end.first
 
     @sub_extractor ||= Source::Extractor.find(url, default_extractor: nil, parent_extractor: self)

--- a/test/unit/source/extractor/e621_extractor_test.rb
+++ b/test/unit/source/extractor/e621_extractor_test.rb
@@ -145,5 +145,23 @@ module Source::Tests::Extractor
         dtext_artist_commentary_desc: "Spent the last couple days modelin some of the designs from \"@JeremeyChinshue\":[https://x.com/JeremeyChinshue]'s \"#somethingseries\":[https://x.com/hashtag/somethingseries]. It's one of the funniest video game parodies I've seen and I had a lotta fun making these guys.",
       )
     end
+
+    context "A post with a deleted source" do
+      strategy_should_work(
+        "https://e621.net/posts/6305694",
+        image_urls: %w[https://static1.e621.net/data/bf/d5/bfd52ec727810f04fa8c897f9c026f5a.jpg],
+        media_files: [{ file_size: 165_929 }],
+        page_url: "https://e621.net/posts/6305694",
+      )
+    end
+
+    context "A post with a non-web source" do
+      strategy_should_work(
+        "https://e621.net/posts/5473882",
+        image_urls: %w[https://static1.e621.net/data/b7/ff/b7ff8c1b1024125f993dae40ed7efa85.png],
+        media_files: [{ file_size: 21_211 }],
+        page_url: "https://e621.net/posts/5473882",
+      )
+    end
   end
 end


### PR DESCRIPTION
Minor fixup for posts on e621 that have a non-url or deleted source (the latter they do by prepending `-` like for artists).