### PR TITLE
Notes: Replace Blackletter font with Manufacturing Consent.

### DIFF
--- a/app/javascript/src/styles/common/fonts.css
+++ b/app/javascript/src/styles/common/fonts.css
@@ -302,14 +302,14 @@
     url("@fontsource/petit-formal-script/files/petit-formal-script-latin-400-normal.woff") format("woff");
 }
 
-/* https://fonts.google.com/specimen/UnifrakturMaguntia */
+/* https://fonts.google.com/specimen/Manufacturing+Consent */
 @font-face {
   font-family: "Blackletter";
   font-display: swap;
   src:
-    local("UnifrakturMaguntia"),
-    url("@fontsource/unifrakturmaguntia/files/unifrakturmaguntia-latin-400-normal.woff2") format("woff2"),
-    url("@fontsource/unifrakturmaguntia/files/unifrakturmaguntia-latin-400-normal.woff") format("woff");
+    local("Manufacturing Consent"),
+    url("@fontsource/manufacturing-consent/files/manufacturing-consent-latin-400-normal.woff2") format("woff2"),
+    url("@fontsource/manufacturing-consent/files/manufacturing-consent-latin-400-normal.woff") format("woff");
 }
 
 /* https://www.dafont.com/anarchy2.font */

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
         "@fontsource/ibm-plex-mono": "^5.2.5",
         "@fontsource/indie-flower": "^5.2.5",
         "@fontsource/lora": "^5.2.5",
+        "@fontsource/manufacturing-consent": "^5.2.2",
         "@fontsource/petit-formal-script": "^5.2.5",
         "@fontsource/rokkitt": "^5.2.5",
-        "@fontsource/unifrakturmaguntia": "^5.2.5",
         "@rails/ujs": "^7.1.3-4",
         "@ruffle-rs/ruffle": "^0.1.0-nightly.2024.6.7",
         "@types/babel__core": "7",
@@ -3271,6 +3271,15 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@fontsource/manufacturing-consent": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@fontsource/manufacturing-consent/-/manufacturing-consent-5.2.2.tgz",
+      "integrity": "sha512-UHlkbNdvijvCBWyAovQAtVlSJ63JFuONua4aStZW3FHIgZy5qrJYu23MJuqqur9qD7wXGnSKC2lMIXhy2MO7nw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@fontsource/petit-formal-script": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/petit-formal-script/-/petit-formal-script-5.2.8.tgz",
@@ -3284,15 +3293,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/rokkitt/-/rokkitt-5.2.8.tgz",
       "integrity": "sha512-MpNFvyANvmcJOCQ+tE7bBxl2kwmUTQxf4RvlO8aALEACU+NeSTDNaKoU5qnWos0nhpSPzwOr2dz7FgLdrEHQTQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/unifrakturmaguntia": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/unifrakturmaguntia/-/unifrakturmaguntia-5.2.8.tgz",
-      "integrity": "sha512-FN6yt2BPasuXuwttsz31qlgcMMx6SZdY9HFv/GPAPonFfF5e4Y11j9mGRGGXY6V0iZzaZnQ4Yx6UPRCE/ECRqA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "@fontsource/ibm-plex-mono": "^5.2.5",
     "@fontsource/indie-flower": "^5.2.5",
     "@fontsource/lora": "^5.2.5",
+    "@fontsource/manufacturing-consent": "^5.2.2",
     "@fontsource/petit-formal-script": "^5.2.5",
     "@fontsource/rokkitt": "^5.2.5",
-    "@fontsource/unifrakturmaguntia": "^5.2.5",
     "@rails/ujs": "^7.1.3-4",
     "@ruffle-rs/ruffle": "^0.1.0-nightly.2024.6.7",
     "@types/babel__core": "7",
@@ -49,8 +49,8 @@
     "webpack-merge": "^6.0.1"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
     "@babel/cli": "^7.24.7",
+    "@eslint/js": "^10.0.1",
     "@webpack-cli/serve": "^3.0.1",
     "eslint": "^10.1.0",
     "eslint-plugin-ignore-erb": "^0.1.1",


### PR DESCRIPTION
Replace the existing UnifrakturMaguntia font with Manufacturing Consent for legibility. Some of the glyphs in Unifraktur look nothing like the letter they're meant to represent which makes it difficult to read notes using the font.

This replacement was suggested after discussion on Discord and [the forum](https://danbooru.donmai.us/forum_posts/430241).

Old:
<img width="249" height="111" alt="image" src="https://github.com/user-attachments/assets/90a1e4d1-6f4b-451e-b4da-68845dfb2f9a" />

New:
<img width="232" height="76" alt="image" src="https://github.com/user-attachments/assets/ebb9b763-cac7-4ce7-b863-9a358df53cc4" />

Fixes #5189.