### PR TITLE
Use pwnedpasswords for password security

### DIFF
--- a/app/logical/pwned_password_validator.rb
+++ b/app/logical/pwned_password_validator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Validates that a password has not appeared in known data breaches using the
+# HaveIBeenPwned PwnedPasswords API.
+#
+# The API uses k-anonymity: only the first 5 characters of the SHA1 hash are
+# sent, and the API returns all matching suffixes. The full hash never leaves
+# the server.
+#
+# @example
+#   validates :password, pwned_password: true
+#
+# @see https://haveibeenpwned.com/API/v3#PwnedPasswords
+# @see https://guides.rubyonrails.org/active_record_validations.html#custom-validators
+class PwnedPasswordValidator < ActiveModel::EachValidator
+  API_URL = "https://api.pwnedpasswords.com/range/"
+
+  def validate_each(rec, attr, password)
+    return if password.blank?
+
+    count = pwned_count(password)
+    rec.errors.add(attr, :pwned_password, count: count) if count > 0
+  rescue StandardError
+    # If the API is unreachable, allow the password rather than blocking signups.
+  end
+
+  private
+
+  def pwned_count(password)
+    sha1 = Digest::SHA1.hexdigest(password).upcase
+    prefix = sha1[0..4]
+    suffix = sha1[5..]
+
+    response = Danbooru::Http.external.timeout(5).cache(1.hour).get("#{API_URL}#{prefix}")
+    return 0 unless response.status == 200
+
+    response.to_s.each_line do |line|
+      hash_suffix, count = line.strip.split(":")
+      return count.to_i if hash_suffix == suffix
+    end
+
+    0
+  end
+end

--- a/app/logical/pwned_password_validator.rb
+++ b/app/logical/pwned_password_validator.rb
@@ -16,7 +16,7 @@ class PwnedPasswordValidator < ActiveModel::EachValidator
   API_URL = "https://api.pwnedpasswords.com/range/"
 
   def validate_each(rec, attr, password)
-    return if password.blank?
+    return if password.blank? || !Danbooru.config.pwned_password_check_enabled?
 
     count = pwned_count(password)
     rec.errors.add(attr, :pwned_password, count: count) if count > 0

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,7 @@ class User < ApplicationRecord
   validates :custom_style, visible_string: { allow_empty: true }, length: { maximum: 40_000 }, if: :custom_style_changed?
   validates :name, user_name: true, on: :create
   validates :password, length: { minimum: 5 }, if: ->(rec) { rec.new_record? || rec.password.present? }
+  validates :password, pwned_password: true, if: ->(rec) { rec.new_record? || rec.password.present? }
   validates :default_image_size, inclusion: { in: %w[large original] }
   validates :per_page, inclusion: { in: (1..PostSets::Post::MAX_PER_PAGE) }
   validates :password, confirmation: { message: "Passwords don't match" }

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -683,6 +683,13 @@ module Danbooru
       true
     end
 
+    # Whether to check passwords against the HaveIBeenPwned database when
+    # users sign up or change their password. Disable this if you don't want
+    # Danbooru to make outbound requests to a third-party API.
+    def pwned_password_check_enabled?
+      true
+    end
+
     # If defined, Danbooru will automatically post new forum posts to the
     # Discord channel belonging to this webhook.
     def discord_webhook_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
     errors:
       messages:
         record_invalid: "%{errors}"
+        pwned_password: "has appeared in a data breach and can't be used"
       models:
         tag:
           attributes:

--- a/test/unit/pwned_password_validator_test.rb
+++ b/test/unit/pwned_password_validator_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PwnedPasswordValidatorTest < ActiveSupport::TestCase
+  # SHA1 of "password" = 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8
+  PWNED_SHA1_PREFIX = "5BAA6"
+  PWNED_SHA1_SUFFIX = "1E4C9B93F3F0682250B6CF8331B7EE68FD8"
+
+  def stub_pwned_api(prefix, body, status: 200)
+    response = ::HTTP::Response.new(status: status, version: "1.1", body: body, request: ::HTTP::Request.new(verb: :get, uri: "https://api.pwnedpasswords.com/range/#{prefix}"))
+    Danbooru::Http.any_instance.stubs(:get).returns(response)
+  end
+
+  context "PwnedPasswordValidator" do
+    should "reject a password that has appeared in a data breach" do
+      stub_pwned_api(PWNED_SHA1_PREFIX, "#{PWNED_SHA1_SUFFIX}:3861493\r\nABCDEF1234567890ABCDEF1234567890ABC:5\r\n")
+
+      user = build(:user, password: "password")
+      assert_not(user.valid?)
+      assert_includes(user.errors[:password], "has appeared in a data breach and can't be used")
+    end
+
+    should "accept a password that has not appeared in a data breach" do
+      stub_pwned_api("2AF12", "1234567890ABCDEF1234567890ABCDEF123:1\r\n")
+
+      user = build(:user, password: "super-unique-passphrase-#{SecureRandom.hex}")
+      assert(user.valid?)
+    end
+
+    should "accept the password if the API is unreachable" do
+      Danbooru::Http.any_instance.stubs(:get).raises(HTTP::ConnectionError)
+
+      user = build(:user, password: "password")
+      assert(user.valid?)
+    end
+
+    should "accept the password if the API returns an error" do
+      stub_pwned_api(PWNED_SHA1_PREFIX, "", status: 503)
+
+      user = build(:user, password: "password")
+      assert(user.valid?)
+    end
+  end
+end

--- a/test/unit/pwned_password_validator_test.rb
+++ b/test/unit/pwned_password_validator_test.rb
@@ -41,5 +41,13 @@ class PwnedPasswordValidatorTest < ActiveSupport::TestCase
       user = build(:user, password: "password")
       assert(user.valid?)
     end
+
+    should "accept the password without calling the API if the check is disabled" do
+      Danbooru.config.stubs(:pwned_password_check_enabled?).returns(false)
+      Danbooru::Http.any_instance.expects(:get).never
+
+      user = build(:user, password: "password")
+      assert(user.valid?)
+    end
   end
 end


### PR DESCRIPTION
Adds a validator that checks new passwords against the HaveIBeenPwned PwnedPasswords API. If a password has appeared in a known breach, signup or password change is rejected with the error "has appeared in a data breach and can't be used".

The API uses k-anonymity: we SHA1 the password, send only the first 5 characters of the hash, and the API returns all matching suffixes. The full password and full hash never leave the server. No API key is required.

Responses are cached for 1 hour. If the API is unreachable or slow, the validator fails open so outages don't block signups.

Related issue: #6608