### PR TITLE
Use zxcvbn for password security#6398

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "bcrypt_pbkdf"
 gem "connection_pool"
 gem "rotp"
 gem "rqrcode"
+gem "zxcvbn-ruby", require: "zxcvbn"
 gem "kramdown"
 gem "abbrev"
 gem "rubyzip", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,6 @@ GEM
     method_source (1.1.0)
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (6.0.3)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -346,9 +345,6 @@ GEM
       net-protocol
     net-ssh (7.3.2)
     nio4r (2.7.5)
-    nokogiri (1.19.2)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     numo-narray (0.9.2.1)
@@ -574,9 +570,9 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.5)
+    zxcvbn-ruby (1.4.0)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -668,6 +664,7 @@ DEPENDENCIES
   view_component
   webrick
   x25519
+  zxcvbn-ruby
 
 CHECKSUMS
   abbrev (0.1.2) sha256=ad1b4eaaaed4cb722d5684d63949e4bde1d34f2a95e20db93aecfe7cbac74242
@@ -781,7 +778,6 @@ CHECKSUMS
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mini_histogram (0.3.1) sha256=6a114b504e4618b0e076cc672996036870f7cc6f16b8e5c25c0c637726d2dd94
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.3) sha256=88ac8a1de36c00692420e7cb3cc11a0773bbcb126aee1c249f320160a7d11411
   minitest-reporters (1.8.0) sha256=8ce5280fb73ad3178ae525454df169b6f28c1b38b1d088ea91815d3a370ba384
   mocha (3.1.0) sha256=75f42d69ebfb1f10b32489dff8f8431d37a418120ecdfc07afe3bc183d4e1d56
@@ -797,7 +793,6 @@ CHECKSUMS
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   net-ssh (7.3.2) sha256=65029e213c380e20e5fd92ece663934ab0a0fe888e0cd7cc6a5b664074362dd4
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.2) sha256=38fdd8b59db3d5ea9e7dfb14702e882b9bf819198d5bf976f17ebce12c481756
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   numo-narray (0.9.2.1) sha256=eed76b47eebe1288ffd878b387f1882f4863d8e6ab5dd61453768139e14adceb
   optimist (3.2.1) sha256=8cf8a0fd69f3aa24ab48885d3a666717c27bc3d9edd6e976e18b9d771e72e34e
@@ -899,6 +894,7 @@ CHECKSUMS
   x25519 (1.0.11) sha256=24168680ded91fdd06a4b3c2b0800c71dc149c71265ba57d91df5832a7002b6d
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
+  zxcvbn-ruby (1.4.0) sha256=655253a68ce12b9a8991c7a885e43eb516fecd3334f91ca97f57f9679653259f
 
 RUBY VERSION
   ruby 4.0.2p0

--- a/app/logical/zxcvbn_password_validator.rb
+++ b/app/logical/zxcvbn_password_validator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Validates password strength using zxcvbn, a password strength estimator that
+# recognizes dictionary words, keyboard patterns, dates, and other common
+# weaknesses that simple length/complexity rules miss.
+#
+# @example
+#   validates :password, zxcvbn_password: true
+#   validates :password, zxcvbn_password: { min_score: 3 }
+#
+# @see https://github.com/envato/zxcvbn-ruby
+# @see https://guides.rubyonrails.org/active_record_validations.html#custom-validators
+class ZxcvbnPasswordValidator < ActiveModel::EachValidator
+  DEFAULT_MIN_SCORE = 2
+
+  def validate_each(rec, attr, password)
+    return if password.blank?
+
+    result = Zxcvbn.test(password)
+    min_score = options[:min_score] || DEFAULT_MIN_SCORE
+    return if result.score >= min_score
+
+    rec.errors.add(attr, :weak_password, warning: result.feedback.warning.presence || "is too weak")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,7 @@ class User < ApplicationRecord
   validates :custom_style, visible_string: { allow_empty: true }, length: { maximum: 40_000 }, if: :custom_style_changed?
   validates :name, user_name: true, on: :create
   validates :password, length: { minimum: 5 }, if: ->(rec) { rec.new_record? || rec.password.present? }
+  validates :password, zxcvbn_password: true, if: ->(rec) { rec.new_record? || rec.password.present? }
   validates :default_image_size, inclusion: { in: %w[large original] }
   validates :per_page, inclusion: { in: (1..PostSets::Post::MAX_PER_PAGE) }
   validates :password, confirmation: { message: "Passwords don't match" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
     errors:
       messages:
         record_invalid: "%{errors}"
+        weak_password: "is too weak: %{warning}"
       models:
         tag:
           attributes:

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user, aliases: [:creator, :updater] do
     name { SecureRandom.uuid.first(20) }
-    password { "password" }
+    password { "correct horse battery staple" }
     level { 20 }
     last_logged_in_at { Time.zone.now }
 

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -124,7 +124,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
 
     context "on api authentication" do
       setup do
-        @user = create(:user, password: "password")
+        @user = create(:user, password: "correct horse battery staple")
         @api_key = create(:api_key, user: @user)
 
         ActionController::Base.allow_forgery_protection = true
@@ -292,7 +292,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
           token = css_select("form input[name=authenticity_token]").first["value"]
 
           # login
-          post session_path, params: { authenticity_token: token, session: { name: @user.name, password: "password" }}
+          post session_path, params: { authenticity_token: token, session: { name: @user.name, password: "correct horse battery staple" }}
           assert_redirected_to root_path
 
           # try to submit a form with cookies but without the csrf token
@@ -306,7 +306,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
 
     context "on session cookie authentication" do
       setup do
-        @user = create(:user, password: "password")
+        @user = create(:user, password: "correct horse battery staple")
         login_as(@user)
       end
 

--- a/test/functional/password_resets_controller_test.rb
+++ b/test/functional/password_resets_controller_test.rb
@@ -145,16 +145,16 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     context "update action" do
       context "for a user without 2FA enabled" do
         setup do
-          @user = create(:user, password: "old_password")
+          @user = create(:user, password: "strong-old-passphrase")
         end
 
         should "change the user's password when given a valid new password" do
           freeze_time
-          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "password" })
+          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "correct horse battery staple" })
 
           assert_redirected_to @user
           assert_equal(@user.id, session[:user_id])
-          assert_equal(true, @user.reload.authenticate_password("password").present?)
+          assert_equal(true, @user.reload.authenticate_password("correct horse battery staple").present?)
           assert_equal(true, @user.user_events.login.exists?(login_session_id: @user.login_sessions.last.login_id))
           assert_equal(true, @user.user_events.password_reset.exists?(login_session_id: nil))
           assert_equal(true, @user.login_sessions.exists?)
@@ -165,11 +165,11 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
         end
 
         should "not change the user's password when the passwords don't match" do
-          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "wrong" })
+          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "wrong" })
 
           assert_response :success
           assert_nil(session[:user_id])
-          assert_equal(false, @user.authenticate_password("password").present?)
+          assert_equal(false, @user.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)
@@ -180,11 +180,11 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
         end
 
         should "not change the user's password when not given a signed_id" do
-          put password_reset_path(user: { password: "password", password_confirmation: "password" })
+          put password_reset_path(user: { password: "correct horse battery staple", password_confirmation: "correct horse battery staple" })
 
           assert_redirected_to password_reset_path
           assert_nil(session[:user_id])
-          assert_equal(false, @user.authenticate_password("password").present?)
+          assert_equal(false, @user.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)
@@ -195,11 +195,11 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
         end
 
         should "not change the user's password when given an expired signed_id" do
-          put password_reset_path(user: { signed_id: @user.signed_id(expires_at: 1.minute.ago, purpose: :password_reset), password: "password", password_confirmation: "password" })
+          put password_reset_path(user: { signed_id: @user.signed_id(expires_at: 1.minute.ago, purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "correct horse battery staple" })
 
           assert_redirected_to password_reset_path
           assert_nil(session[:user_id])
-          assert_equal(false, @user.authenticate_password("password").present?)
+          assert_equal(false, @user.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)
@@ -210,11 +210,11 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
         end
 
         should "not change the user's password when given an invalid signed_id" do
-          put password_reset_path(user: { signed_id: "invalid", password: "password", password_confirmation: "password" })
+          put password_reset_path(user: { signed_id: "invalid", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" })
 
           assert_redirected_to password_reset_path
           assert_nil(session[:user_id])
-          assert_equal(false, @user.authenticate_password("password").present?)
+          assert_equal(false, @user.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)
@@ -226,11 +226,11 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
         should "not change the user's password when the user is already logged in as another user" do
           @user2 = create(:user)
-          put_auth password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "password" }), @user2
+          put_auth password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }), @user2
 
           assert_redirected_to profile_path
           assert_equal(@user2.id, session[:user_id])
-          assert_equal(false, @user.authenticate_password("password").present?)
+          assert_equal(false, @user.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)
@@ -242,15 +242,15 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
       context "for a user with 2FA enabled" do
         setup do
-          @user = create(:user_with_2fa, password: "old_password")
+          @user = create(:user_with_2fa, password: "strong-old-passphrase")
         end
 
         should "change the user's password when the verification code is correct" do
           freeze_time
-          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "password", verification_code: @user.totp.code })
+          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "correct horse battery staple", verification_code: @user.totp.code })
 
           assert_redirected_to @user
-          assert_equal(true, @user.reload.authenticate_password("password").present?)
+          assert_equal(true, @user.reload.authenticate_password("correct horse battery staple").present?)
           assert_equal(true, @user.user_events.login.exists?(login_session_id: @user.login_sessions.last.login_id))
           assert_equal(true, @user.user_events.password_reset.exists?(login_session_id: nil))
           assert_equal(true, @user.login_sessions.exists?)
@@ -264,10 +264,10 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
           backup_code = @user.backup_codes.first
 
           freeze_time
-          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "password", verification_code: backup_code })
+          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "correct horse battery staple", verification_code: backup_code })
 
           assert_redirected_to @user
-          assert_equal(true, @user.reload.authenticate_password("password").present?)
+          assert_equal(true, @user.reload.authenticate_password("correct horse battery staple").present?)
           assert_equal(true, @user.user_events.login.exists?(login_session_id: @user.login_sessions.last.login_id))
           assert_equal(true, @user.user_events.password_reset.exists?(login_session_id: nil))
           assert_equal(true, @user.login_sessions.exists?)
@@ -279,10 +279,10 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
         end
 
         should "not change the user's password when the verification code is incorrect" do
-          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "password", verification_code: "wrong" })
+          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "correct horse battery staple", verification_code: "wrong" })
 
           assert_response :success
-          assert_equal(false, @user.reload.authenticate_password("password").present?)
+          assert_equal(false, @user.reload.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)
@@ -295,10 +295,10 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
         should "not spend a backup code when the new password is invalid" do
           backup_code = @user.backup_codes.first
-          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "12345", verification_code: backup_code })
+          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "secure-current-pass-123", verification_code: backup_code })
 
           assert_response :success
-          assert_equal(false, @user.reload.authenticate_password("password").present?)
+          assert_equal(false, @user.reload.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)
@@ -312,12 +312,12 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
       context "for a deleted user" do
         should "not change the user's password" do
-          @user = create(:user, is_deleted: true, password: "old_password")
-          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "password", password_confirmation: "password" })
+          @user = create(:user, is_deleted: true, password: "strong-old-passphrase")
+          put password_reset_path(user: { signed_id: @user.signed_id(purpose: :password_reset), password: "correct horse battery staple", password_confirmation: "correct horse battery staple" })
 
           assert_response :success
           assert_nil(session[:user_id])
-          assert_equal(false, @user.reload.authenticate_password("password").present?)
+          assert_equal(false, @user.reload.authenticate_password("correct horse battery staple").present?)
           assert_equal(false, @user.user_events.login.exists?)
           assert_equal(false, @user.user_events.password_reset.exists?)
           assert_equal(false, @user.login_sessions.exists?)

--- a/test/functional/passwords_controller_test.rb
+++ b/test/functional/passwords_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class PasswordsControllerTest < ActionDispatch::IntegrationTest
   context "The passwords controller" do
     setup do
-      @user = create(:user, password: "12345")
+      @user = create(:user, password: "secure-current-pass-123")
     end
 
     context "edit action" do
@@ -32,72 +32,72 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
     context "update action" do
       should "update the password when given a valid old password" do
-        put_auth user_password_path(@user), @user, params: { user: { current_password: "12345", password: "abcde", password_confirmation: "abcde" }}
+        put_auth user_password_path(@user), @user, params: { user: { current_password: "secure-current-pass-123", password: "secure-new-pass-456", password_confirmation: "secure-new-pass-456" }}
 
         assert_redirected_to @user
-        assert_equal(false, @user.reload.authenticate_password("12345"))
-        assert_equal(@user, @user.authenticate_password("abcde"))
+        assert_equal(false, @user.reload.authenticate_password("secure-current-pass-123"))
+        assert_equal(@user, @user.authenticate_password("secure-new-pass-456"))
         assert_equal(true, @user.user_events.password_change.exists?(login_session_id: @user.login_sessions.last.login_id))
       end
 
       should "not allow users to change the password of other users" do
         @owner = create(:owner_user)
-        put_auth user_password_path(@user), @owner, params: { user: { current_password: "12345", password: "abcde", password_confirmation: "abcde" }}
+        put_auth user_password_path(@user), @owner, params: { user: { current_password: "secure-current-pass-123", password: "secure-new-pass-456", password_confirmation: "secure-new-pass-456" }}
 
         assert_response 403
-        assert_equal(@user, @user.reload.authenticate_password("12345"))
-        assert_equal(false, @user.authenticate_password("abcde"))
+        assert_equal(@user, @user.reload.authenticate_password("secure-current-pass-123"))
+        assert_equal(false, @user.authenticate_password("secure-new-pass-456"))
         assert_equal(false, @user.user_events.password_change.exists?)
       end
 
       should "not update the password when given an invalid old password" do
-        put_auth user_password_path(@user), @user, params: { user: { current_password: "3qoirjqe", password: "abcde", password_confirmation: "abcde" }}
+        put_auth user_password_path(@user), @user, params: { user: { current_password: "3qoirjqe", password: "secure-new-pass-456", password_confirmation: "secure-new-pass-456" }}
 
         assert_response :success
-        assert_equal(@user, @user.reload.authenticate_password("12345"))
-        assert_equal(false, @user.authenticate_password("abcde"))
+        assert_equal(@user, @user.reload.authenticate_password("secure-current-pass-123"))
+        assert_equal(false, @user.authenticate_password("secure-new-pass-456"))
         assert_equal(false, @user.user_events.password_change.exists?)
         assert_equal(true, @user.user_events.failed_reauthenticate.exists?(login_session_id: @user.login_sessions.last.login_id))
       end
 
       should "not update the password when password confirmation fails for the new password" do
-        put_auth user_password_path(@user), @user, params: { user: { current_password: "12345", password: "abcde", password_confirmation: "qerogijqe" }}
+        put_auth user_password_path(@user), @user, params: { user: { current_password: "secure-current-pass-123", password: "secure-new-pass-456", password_confirmation: "qerogijqe" }}
 
         assert_response :success
-        assert_equal(@user, @user.reload.authenticate_password("12345"))
-        assert_equal(false, @user.authenticate_password("abcde"))
+        assert_equal(@user, @user.reload.authenticate_password("secure-current-pass-123"))
+        assert_equal(false, @user.authenticate_password("secure-new-pass-456"))
         assert_equal(false, @user.user_events.password_change.exists?)
       end
 
       context "for a user with 2FA enabled" do
         setup do
-          @user = create(:user_with_2fa, password: "12345")
+          @user = create(:user_with_2fa, password: "secure-current-pass-123")
         end
 
         should "change the user's password when the verification code is correct" do
-          put_auth user_password_path(@user), @user, params: { user: { current_password: "12345", password: "abcde", password_confirmation: "abcde", verification_code: @user.totp.code }}
+          put_auth user_password_path(@user), @user, params: { user: { current_password: "secure-current-pass-123", password: "secure-new-pass-456", password_confirmation: "secure-new-pass-456", verification_code: @user.totp.code }}
 
           assert_redirected_to @user
-          assert_equal(true, @user.reload.authenticate_password("abcde").present?)
+          assert_equal(true, @user.reload.authenticate_password("secure-new-pass-456").present?)
           assert_equal(true, @user.user_events.password_change.exists?(login_session_id: @user.login_sessions.last.login_id))
         end
 
         should "not change the user's password when given a backup code" do
           backup_code = @user.backup_codes.first
-          put_auth user_password_path(@user), @user, params: { user: { current_password: "12345", password: "abcde", password_confirmation: "abcde", verification_code: backup_code }}
+          put_auth user_password_path(@user), @user, params: { user: { current_password: "secure-current-pass-123", password: "secure-new-pass-456", password_confirmation: "secure-new-pass-456", verification_code: backup_code }}
 
           assert_response :success
-          assert_equal(true, @user.reload.authenticate_password("12345").present?)
+          assert_equal(true, @user.reload.authenticate_password("secure-current-pass-123").present?)
           assert_equal(false, @user.user_events.password_change.exists?)
           assert_equal(true, @user.backup_codes.include?(backup_code))
           assert_equal(true, @user.user_events.totp_failed_reauthenticate.exists?(login_session_id: @user.login_sessions.last.login_id))
         end
 
         should "not change the user's password when the verification code is incorrect" do
-          put_auth user_password_path(@user), @user, params: { user: { current_password: "12345", password: "abcde", password_confirmation: "abcde", verification_code: "wrong" }}
+          put_auth user_password_path(@user), @user, params: { user: { current_password: "secure-current-pass-123", password: "secure-new-pass-456", password_confirmation: "secure-new-pass-456", verification_code: "wrong" }}
 
           assert_response :success
-          assert_equal(true, @user.reload.authenticate_password("12345").present?)
+          assert_equal(true, @user.reload.authenticate_password("secure-current-pass-123").present?)
           assert_equal(false, @user.user_events.password_change.exists?)
           assert_equal(true, @user.user_events.totp_failed_reauthenticate.exists?(login_session_id: @user.login_sessions.last.login_id))
         end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class SessionsControllerTest < ActionDispatch::IntegrationTest
   context "the sessions controller" do
     setup do
-      @user = create(:user, password: "password", email_address_attributes: { address: "Foo.Bar+nospam@Googlemail.com" })
+      @user = create(:user, password: "correct horse battery staple", email_address_attributes: { address: "Foo.Bar+nospam@Googlemail.com" })
     end
 
     context "new action" do
@@ -59,14 +59,14 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     context "create action" do
       should "fail if the user is already logged in" do
-        post_auth session_path, @user, params: { session: { name: @user.name, password: "password" }}
+        post_auth session_path, @user, params: { session: { name: @user.name, password: "correct horse battery staple" }}
 
         assert_response 403
       end
 
       should "log the user in when given the correct password" do
         freeze_time
-        post session_path, params: { session: { name: @user.name, password: "password" }}
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}
 
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
@@ -79,7 +79,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "log the user in when given their email address" do
         freeze_time
-        post session_path, params: { session: { name: "Foo.Bar+nospam@Googlemail.com", password: "password" }}
+        post session_path, params: { session: { name: "Foo.Bar+nospam@Googlemail.com", password: "correct horse battery staple" }}
 
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
@@ -92,7 +92,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "normalize the user's email address when logging in" do
         freeze_time
-        post session_path, params: { session: { name: "foobar@gmail.com", password: "password" }}
+        post session_path, params: { session: { name: "foobar@gmail.com", password: "correct horse battery staple" }}
 
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
@@ -105,7 +105,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "be case-insensitive towards the user's name when logging in" do
         freeze_time
-        post session_path, params: { session: { name: @user.name.upcase, password: "password" }}
+        post session_path, params: { session: { name: @user.name.upcase, password: "correct horse battery staple" }}
 
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
@@ -127,7 +127,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not log the user in when given an incorrect email" do
-        post session_path, params: { session: { name: "foo@gmail.com", password: "password" }}
+        post session_path, params: { session: { name: "foo@gmail.com", password: "correct horse battery staple" }}
 
         assert_response 401
         assert_nil(session[:user_id])
@@ -136,7 +136,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not log the user in when given an incorrect username" do
-        post session_path, params: { session: { name: "dne", password: "password" }}
+        post session_path, params: { session: { name: "dne", password: "correct horse battery staple" }}
 
         assert_response 401
         assert_nil(session[:user_id])
@@ -145,10 +145,10 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not allow approvers without 2FA to login from a proxy" do
-        user = create(:approver_user, password: "password")
+        user = create(:approver_user, password: "correct horse battery staple")
         Danbooru::IpAddress.any_instance.stubs(:is_proxy?).returns(true)
 
-        post session_path, params: { session: { name: user.name, password: "password" }}
+        post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}
 
         assert_response 401
         assert_nil(session[:user_id])
@@ -157,10 +157,10 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not allow inactive accounts without 2FA to login from a proxy" do
-        user = create(:user, password: "password", last_logged_in_at: 1.year.ago)
+        user = create(:user, password: "correct horse battery staple", last_logged_in_at: 1.year.ago)
         Danbooru::IpAddress.any_instance.stubs(:is_proxy?).returns(true)
 
-        post session_path, params: { session: { name: user.name, password: "password" }}
+        post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}
 
         assert_response 401
         assert_nil(session[:user_id])
@@ -169,10 +169,10 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "allow approvers with 2FA enabled to login from a proxy" do
-        user = create(:user_with_2fa, password: "password", level: User::Levels::APPROVER)
+        user = create(:user_with_2fa, password: "correct horse battery staple", level: User::Levels::APPROVER)
         Danbooru::IpAddress.any_instance.stubs(:is_proxy?).returns(true)
 
-        post session_path, params: { session: { name: user.name, password: "password" }}
+        post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}
 
         assert_response :success
         assert_nil(session[:user_id])
@@ -183,9 +183,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not log the user in yet if they have 2FA enabled" do
-        user = create(:user_with_2fa, password: "password")
+        user = create(:user_with_2fa, password: "correct horse battery staple")
 
-        post session_path, params: { session: { name: user.name, password: "password" }}
+        post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}
 
         assert_response :success
         assert_nil(session[:user_id])
@@ -200,7 +200,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         Danbooru.config.stubs(:captcha_site_key).returns("3x00000000000000000000FF") # forces an interactive challenge
         Danbooru.config.stubs(:captcha_secret_key).returns("2x0000000000000000000000000000000AA") # always fails
 
-        post session_path, params: { "session": { name: @user.name, password: "password" }, "cf-turnstile-response": "blah" }
+        post session_path, params: { "session": { name: @user.name, password: "correct horse battery staple" }, "cf-turnstile-response": "blah" }
 
         assert_response 401
         assert_nil(session[:user_id])
@@ -215,7 +215,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         Danbooru.config.stubs(:captcha_secret_key).returns("1x0000000000000000000000000000000AA") # always passes
 
         freeze_time
-        post session_path, params: { "session": { name: @user.name, password: "password", url: users_path }, "cf-turnstile-response": "blah" }
+        post session_path, params: { "session": { name: @user.name, password: "correct horse battery staple", url: users_path }, "cf-turnstile-response": "blah" }
 
         assert_redirected_to users_path
         assert_equal(@user.id, session[:user_id])
@@ -227,18 +227,18 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "redirect the user when given an url param" do
-        post session_path, params: { session: { name: @user.name, password: "password" }, url: tags_path }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }, url: tags_path }
         assert_redirected_to tags_path
       end
 
       should "not allow redirects to protocol-relative URLs" do
-        post session_path, params: { session: { name: @user.name, password: "password" }, url: "//example.com" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }, url: "//example.com" }
         assert_response 403
       end
 
       should "not allow deleted users to login" do
         @user.update!(is_deleted: true)
-        post session_path, params: { session: { name: @user.name, password: "password" }}
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}
 
         assert_response 401
         assert_nil(session[:user_id])
@@ -250,7 +250,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "not allow IP banned users to login" do
         @ip_ban = create(:ip_ban, category: :full, ip_addr: "1.2.3.4")
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
         assert_response 403
         assert_nil(session[:user_id])
@@ -265,7 +265,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "allow partial IP banned users to login" do
         @ip_ban = create(:ip_ban, category: :partial, ip_addr: "1.2.3.4")
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
@@ -276,7 +276,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       should "ignore deleted IP bans when logging in" do
         @ip_ban = create(:ip_ban, is_deleted: true, category: :full, ip_addr: "1.2.3.4")
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
@@ -288,9 +288,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       context "for a builder" do
         context "with 2FA and with an email address" do
           should "not send a login verification email when logging in from a new IP address" do
-            user = create(:user_with_2fa, level: User::Levels::BUILDER, password: "password", email_address_attributes: { address: "user@example.com" })
+            user = create(:user_with_2fa, level: User::Levels::BUILDER, password: "correct horse battery staple", email_address_attributes: { address: "user@example.com" })
 
-            post session_path, params: { session: { name: user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+            post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
             assert_response :success
             assert_nil(session[:user_id])
@@ -304,9 +304,9 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
         context "without 2FA but with an email address" do
           should "send a login verification email when logging in from a new IP address" do
-            user = create(:builder_user, password: "password", email_address_attributes: { address: "user@example.com" })
+            user = create(:builder_user, password: "correct horse battery staple", email_address_attributes: { address: "user@example.com" })
 
-            post session_path, params: { session: { name: user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+            post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
             assert_response 401
             assert_nil(session[:user_id])
@@ -321,11 +321,11 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           end
 
           should "not send a login verification email when logging in from an authorized IP address" do
-            user = create(:builder_user, password: "password", email_address_attributes: { address: "user@example.com" })
+            user = create(:builder_user, password: "correct horse battery staple", email_address_attributes: { address: "user@example.com" })
             create(:user_event, user: user, category: :login_verification, ip_addr: "1.2.3.4")
 
             freeze_time
-            post session_path, params: { session: { name: user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+            post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
             assert_redirected_to root_path
             assert_equal(user.id, session[:user_id])
@@ -338,10 +338,10 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           end
 
           should "not count failed login attempts as authorized IPs" do
-            user = create(:builder_user, password: "password", email_address_attributes: { address: "user@example.com" })
+            user = create(:builder_user, password: "correct horse battery staple", email_address_attributes: { address: "user@example.com" })
             create(:user_event, user: user, category: :failed_login, ip_addr: "1.2.3.4")
 
-            post session_path, params: { session: { name: user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+            post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
             assert_response 401
             assert_nil(session[:user_id])
@@ -357,10 +357,10 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
         context "without 2FA or an email address" do
           should "not send a login verification email when logging in from a new IP address" do
-            user = create(:builder_user, password: "password")
+            user = create(:builder_user, password: "correct horse battery staple")
 
             freeze_time
-            post session_path, params: { session: { name: user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+            post session_path, params: { session: { name: user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
             assert_redirected_to root_path
             assert_equal(user.id, session[:user_id])
@@ -379,7 +379,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         freeze_time
 
         5.times do
-          post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+          post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
 
           assert_redirected_to root_path
           assert_equal(@user.id, session[:user_id])
@@ -387,17 +387,17 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           reset! # clear session id
         end
 
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
         assert_response 429
         assert_not_equal(@user.id, session[:user_id])
 
         travel 4.minutes
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
         assert_response 429
         assert_not_equal(@user.id, session[:user_id])
 
         travel 9.minutes
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.4" }
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
       end
@@ -407,7 +407,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         freeze_time
 
         5.times do |n|
-          post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.#{n}" }
+          post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.#{n}" }
 
           assert_redirected_to root_path
           assert_equal(@user.id, session[:user_id])
@@ -415,17 +415,17 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           reset! # clear session id
         end
 
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.21" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.21" }
         assert_response 429
         assert_not_equal(@user.id, session[:user_id])
 
         travel 4.minutes
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.22" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.22" }
         assert_response 429
         assert_not_equal(@user.id, session[:user_id])
 
         travel 9.minutes
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1.2.3.23" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1.2.3.23" }
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
       end
@@ -435,7 +435,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         freeze_time
 
         5.times do |n|
-          post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1:2:3:4:#{n}::1" }
+          post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1:2:3:4:#{n}::1" }
 
           assert_redirected_to root_path
           assert_equal(@user.id, session[:user_id])
@@ -443,17 +443,17 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           reset! # clear session id
         end
 
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1:2:3:4:21::1" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1:2:3:4:21::1" }
         assert_response 429
         assert_not_equal(@user.id, session[:user_id])
 
         travel 4.minutes
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1:2:3:4:22::1" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1:2:3:4:22::1" }
         assert_response 429
         assert_not_equal(@user.id, session[:user_id])
 
         travel 9.minutes
-        post session_path, params: { session: { name: @user.name, password: "password" }}, headers: { REMOTE_ADDR: "1:2:3:4:23::1" }
+        post session_path, params: { session: { name: @user.name, password: "correct horse battery staple" }}, headers: { REMOTE_ADDR: "1:2:3:4:23::1" }
         assert_redirected_to root_path
         assert_equal(@user.id, session[:user_id])
       end
@@ -461,7 +461,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     context "verify_totp action" do
       should "log the user in if they enter the correct 2FA code" do
-        @user = create(:user_with_2fa, password: "password")
+        @user = create(:user_with_2fa, password: "correct horse battery staple")
 
         freeze_time
         post verify_totp_session_path, params: { totp: { user_id: @user.signed_id(purpose: :verify_totp), code: @user.totp.code, url: users_path }}
@@ -476,7 +476,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "log the user in if they enter a 2FA code that was generated less than 30 seconds ago" do
-        @user = create(:user_with_2fa, password: "password")
+        @user = create(:user_with_2fa, password: "correct horse battery staple")
         code = travel_to(25.seconds.ago) { @user.totp.code }
 
         post verify_totp_session_path, params: { totp: { user_id: @user.signed_id(purpose: :verify_totp), code: code, url: users_path }}
@@ -489,7 +489,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "log the user in if they enter a 2FA code that was generated less than 30 seconds in the future" do
-        @user = create(:user_with_2fa, password: "password")
+        @user = create(:user_with_2fa, password: "correct horse battery staple")
         code = travel_to(25.seconds.from_now) { @user.totp.code }
 
         post verify_totp_session_path, params: { totp: { user_id: @user.signed_id(purpose: :verify_totp), code: code, url: users_path }}
@@ -502,7 +502,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not log the user in if they enter an incorrect 2FA code" do
-        @user = create(:user_with_2fa, password: "password")
+        @user = create(:user_with_2fa, password: "correct horse battery staple")
 
         post verify_totp_session_path, params: { totp: { user_id: @user.signed_id(purpose: :verify_totp), code: "invalid", url: users_path }}
 
@@ -515,7 +515,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not log the user in if they enter a 2FA code that was generated more than a minute ago" do
-        @user = create(:user_with_2fa, password: "password")
+        @user = create(:user_with_2fa, password: "correct horse battery staple")
         code = travel_to(65.seconds.ago) { @user.totp.code }
 
         post verify_totp_session_path, params: { totp: { user_id: @user.signed_id(purpose: :verify_totp), code: code, url: users_path }}
@@ -529,7 +529,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not log the user in if they enter a 2FA code that was generated more than a minute in the future" do
-        @user = create(:user_with_2fa, password: "password")
+        @user = create(:user_with_2fa, password: "correct horse battery staple")
         code = travel_to(65.seconds.from_now) { @user.totp.code }
 
         post verify_totp_session_path, params: { totp: { user_id: @user.signed_id(purpose: :verify_totp), code: code, url: users_path }}
@@ -613,12 +613,12 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     context "reauthenticate action" do
       context "for a user with 2FA enabled" do
         setup do
-          @user = create(:user_with_2fa, password: "password")
+          @user = create(:user_with_2fa, password: "correct horse battery staple")
         end
 
         should "succeed if the user enters the right password and 2FA code" do
           travel_to(1.day.ago) { login_as(@user) }
-          post reauthenticate_session_path, params: { session: { password: "password", verification_code: @user.totp.code, url: users_path }}
+          post reauthenticate_session_path, params: { session: { password: "correct horse battery staple", verification_code: @user.totp.code, url: users_path }}
 
           assert_redirected_to users_path
           assert_equal(true, Time.zone.parse(session[:last_authenticated_at]) > 1.second.ago)
@@ -629,7 +629,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           backup_code = @user.backup_codes.first
 
           travel_to(1.day.ago) { login_as(@user) }
-          post reauthenticate_session_path, params: { session: { password: "password", verification_code: backup_code, url: users_path }}
+          post reauthenticate_session_path, params: { session: { password: "correct horse battery staple", verification_code: backup_code, url: users_path }}
 
           assert_redirected_to users_path
           assert_equal(true, Time.zone.parse(session[:last_authenticated_at]) > 1.second.ago)
@@ -639,7 +639,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
         should "fail if the user enters the right password but the wrong 2FA code" do
           travel_to(1.day.ago) { login_as(@user) }
-          post reauthenticate_session_path, params: { session: { password: "password", verification_code: "wrong", url: users_path }}
+          post reauthenticate_session_path, params: { session: { password: "correct horse battery staple", verification_code: "wrong", url: users_path }}
 
           assert_response :success
           assert_equal(true, Time.zone.parse(session[:last_authenticated_at]) < 1.second.ago)
@@ -659,7 +659,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           backup_code = "99999999"
 
           travel_to(1.day.ago) { login_as(@user) }
-          post reauthenticate_session_path, params: { session: { password: "password", verification_code: backup_code, url: users_path }}
+          post reauthenticate_session_path, params: { session: { password: "correct horse battery staple", verification_code: backup_code, url: users_path }}
 
           assert_response :success
           assert_equal(true, Time.zone.parse(session[:last_authenticated_at]) < 1.second.ago)
@@ -681,7 +681,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       context "for a user without 2FA enabled" do
         should "succeed if the user enters the right password" do
           travel_to(1.day.ago) { login_as(@user) }
-          post reauthenticate_session_path, params: { session: { password: "password", url: users_path }}
+          post reauthenticate_session_path, params: { session: { password: "correct horse battery staple", url: users_path }}
 
           assert_redirected_to users_path
           assert_equal(true, Time.zone.parse(session[:last_authenticated_at]) > 1.second.ago)
@@ -701,7 +701,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
       context "for a user who is not logged in" do
         should "fail" do
-          post reauthenticate_session_path, params: { session: { password: "password", url: users_path }}
+          post reauthenticate_session_path, params: { session: { password: "correct horse battery staple", url: users_path }}
 
           assert_response 403
           assert_nil(session[:user_id])

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -196,7 +196,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     context "#destroy action" do
       should "delete the user when given the correct password" do
-        delete_auth user_path(@user), @user, params: { user: { password: "password" }}
+        delete_auth user_path(@user), @user, params: { user: { password: "correct horse battery staple" }}
 
         assert_redirected_to posts_path
         assert_equal(true, @user.reload.is_deleted?)
@@ -209,7 +209,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not delete the user when given an incorrect password" do
-        delete_auth user_path(@user), @user, params: { user: { password: "hunter2" }}
+        delete_auth user_path(@user), @user, params: { user: { password: "secure-delete-pass-789" }}
 
         assert_redirected_to deactivate_user_path(@user)
         assert_equal(false, @user.reload.is_deleted?)
@@ -233,13 +233,13 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not allow users to delete other users" do
-        delete_auth user_path(@user), create(:user), params: { user: { password: "password" }}
+        delete_auth user_path(@user), create(:user), params: { user: { password: "correct horse battery staple" }}
 
         assert_response 403
       end
 
       should "not allow logged-out users to delete other users" do
-        delete user_path(@user), params: { user: { password: "password" }}
+        delete user_path(@user), params: { user: { password: "correct horse battery staple" }}
 
         assert_response 403
       end
@@ -451,12 +451,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     context "create action" do
       should "create a user" do
         freeze_time
-        post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+        post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
         assert_redirected_to User.last
         assert_equal("xxx", User.last.name)
         assert_equal(User::Levels::MEMBER, User.last.level)
-        assert_equal(User.last, User.last.authenticate_password("xxxxx1"))
+        assert_equal(User.last, User.last.authenticate_password("correct horse battery staple"))
         assert_nil(User.last.email_address)
         assert_equal(true, User.last.user_events.user_creation.exists?(login_session_id: User.last.login_sessions.last.login_id))
         assert_no_enqueued_jobs
@@ -470,11 +470,11 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       should "create a user with a valid email" do
         freeze_time
-        post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1", email_address: { address: "webmaster@danbooru.donmai.us" }}}
+        post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple", email_address: { address: "webmaster@danbooru.donmai.us" }}}
 
         assert_redirected_to User.last
         assert_equal("xxx", User.last.name)
-        assert_equal(User.last, User.last.authenticate_password("xxxxx1"))
+        assert_equal(User.last, User.last.authenticate_password("correct horse battery staple"))
         assert_equal("webmaster@danbooru.donmai.us", User.last.email_address.address)
         assert_equal(false, User.last.email_address.is_verified?)
         assert_equal(true, User.last.user_events.user_creation.exists?(login_session_id: User.last.login_sessions.last.login_id))
@@ -493,18 +493,18 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "redirect to the given URL after creating a user" do
-        post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }, url: comments_path }
+        post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }, url: comments_path }
         assert_redirected_to comments_url
       end
 
       should "not redirect to an offsite URL after creating a user" do
-        post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }, url: "https://evil.com" }
+        post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }, url: "https://evil.com" }
         assert_response 403
       end
 
       should "not create a user with an invalid name" do
         assert_no_difference("User.count") do
-          post users_path, params: { user: { name: "x" * 100, password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "x" * 100, password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_response :success
           assert_nil(session[:user_id])
@@ -528,7 +528,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       should "not create a user with a mismatched password" do
         assert_no_difference("User.count") do
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx2" }}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "different horse battery staple" }}
 
           assert_response :success
           assert_nil(session[:user_id])
@@ -540,7 +540,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       should "not create a user with an invalid email" do
         assert_no_difference(["User.count", "EmailAddress.count"]) do
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1", email_address: { address: "test" }}}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple", email_address: { address: "test" }}}
 
           assert_response :success
           assert_nil(session[:user_id])
@@ -552,7 +552,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       should "not create a user with an undeliverable email address" do
         assert_no_difference(["User.count", "EmailAddress.count"]) do
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1", email_address: { address: "nobody@nothing.donmai.us" }}}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple", email_address: { address: "nobody@nothing.donmai.us" }}}
 
           assert_response :success
           assert_nil(session[:user_id])
@@ -564,7 +564,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
       should "not allow logged-in users to create new accounts" do
         assert_no_difference("User.count") do
-          post_auth users_path, @user, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post_auth users_path, @user, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_response 403
         end
@@ -577,7 +577,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           Danbooru.config.stubs(:captcha_secret_key).returns("2x0000000000000000000000000000000AA") # always fails
 
           assert_no_difference(["User.count"]) do
-            post users_path, params: { "user": { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }, "cf-turnstile-response": "blah" }
+            post users_path, params: { "user": { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }, "cf-turnstile-response": "blah" }
 
             assert_response 401
           end
@@ -587,7 +587,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           Danbooru.config.stubs(:captcha_site_key).returns("3x00000000000000000000FF") # forces an interactive challenge
           Danbooru.config.stubs(:captcha_secret_key).returns("1x0000000000000000000000000000000AA") # always passes
 
-          post users_path, params: { "user": { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }, "cf-turnstile-response": "blah" }
+          post users_path, params: { "user": { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }, "cf-turnstile-response": "blah" }
 
           assert_redirected_to User.last
           assert_equal("xxx", User.last.name)
@@ -604,7 +604,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
         should "not create a user if the captcha response is missing" do
           assert_no_difference(["User.count"]) do
-            post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+            post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
             assert_response 401
           end
@@ -612,7 +612,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
         should "not create a user if the captcha response is invalid" do
           assert_no_difference(["User.count"]) do
-            post users_path, params: { "user": { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }, "cf-turnstile-response": "blah" }
+            post users_path, params: { "user": { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }, "cf-turnstile-response": "blah" }
 
             assert_response 401
           end
@@ -630,7 +630,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         should "work for a public IPv6 address" do
           self.remote_addr = @valid_ipv6
 
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(true, User.last.is_member?)
@@ -643,7 +643,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           skip unless IpLookup.enabled?
           self.remote_addr = @proxy_ip
 
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(false, User.last.is_member?)
@@ -656,7 +656,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           self.remote_addr = @valid_ip
 
           @ip_ban = create(:ip_ban, ip_addr: remote_addr, category: :partial)
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(false, User.last.is_member?)
@@ -671,7 +671,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           skip unless IpLookup.enabled?
           self.remote_addr = @valid_ip
 
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(true, User.last.is_member?)
@@ -684,7 +684,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           self.remote_addr = @valid_ip
 
           create(:user_event, created_at: 1.hour.ago, category: :login, ip_addr: @valid_ip)
-          post users_path, params: { user: { name: "dupe", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "dupe", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(false, User.last.is_member?)
@@ -697,7 +697,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           self.remote_addr = @valid_ip
 
           create(:user, last_logged_in_at: 1.hour.ago, last_ip_addr: @valid_ip)
-          post users_path, params: { user: { name: "dupe", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "dupe", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(false, User.last.is_member?)
@@ -712,7 +712,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           get new_user_path # create a session
           create(:user_event, category: :login, session_id: session[:session_id])
 
-          post users_path, params: { user: { name: "dupe", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "dupe", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(false, User.last.is_member?)
@@ -724,7 +724,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         should "not mark users signing up from localhost as restricted" do
           self.remote_addr = "127.0.0.1"
 
-          post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+          post users_path, params: { user: { name: "xxx", password: "correct horse battery staple", password_confirmation: "correct horse battery staple" }}
 
           assert_redirected_to User.last
           assert_equal(true, User.last.is_member?)

--- a/test/test_helpers/system_test_helper.rb
+++ b/test/test_helpers/system_test_helper.rb
@@ -1,5 +1,5 @@
 module SystemTestHelper
-  def signup(name, password: "password")
+  def signup(name, password: "correct horse battery staple")
     visit new_user_path
     fill_in "Name", with: name
     fill_in "Password", with: password

--- a/test/unit/user_deletion_test.rb
+++ b/test/unit/user_deletion_test.rb
@@ -25,7 +25,7 @@ class UserDeletionTest < ActiveSupport::TestCase
     context "for a moderator" do
       should "fail" do
         @user = create(:moderator_user)
-        @deletion = UserDeletion.new(user: @user, password: "password", request: @request)
+        @deletion = UserDeletion.new(user: @user, password: "correct horse battery staple", request: @request)
         @deletion.delete!
         assert_includes(@deletion.errors[:base], "Moderators cannot delete their account")
         assert_equal(false, @user.reload.is_deleted)
@@ -35,7 +35,7 @@ class UserDeletionTest < ActiveSupport::TestCase
     context "for an admin" do
       should "fail" do
         @user = create(:admin_user)
-        @deletion = UserDeletion.new(user: @user, password: "password", request: @request)
+        @deletion = UserDeletion.new(user: @user, password: "correct horse battery staple", request: @request)
         @deletion.delete!
         assert_includes(@deletion.errors[:base], "Admins cannot delete their account")
         assert_equal(false, @user.reload.is_deleted)
@@ -45,7 +45,7 @@ class UserDeletionTest < ActiveSupport::TestCase
     context "for a banned user" do
       should "fail" do
         @user = create(:banned_user)
-        @deletion = UserDeletion.new(user: @user, password: "password", request: @request)
+        @deletion = UserDeletion.new(user: @user, password: "correct horse battery staple", request: @request)
         @deletion.delete!
         assert_includes(@deletion.errors[:base], "You cannot delete your account if you are banned")
         assert_equal(false, @user.reload.is_deleted)
@@ -68,7 +68,7 @@ class UserDeletionTest < ActiveSupport::TestCase
       @active_login_session = create(:login_session, user: @user, status: :active)
       @inactive_login_session = create(:login_session, user: @user, status: :logged_out)
       @request.session[:login_id] = @login_session.login_id
-      @deletion = UserDeletion.new(user: @user, password: "password", request: @request)
+      @deletion = UserDeletion.new(user: @user, password: "correct horse battery staple", request: @request)
     end
 
     should "blank out the email" do
@@ -96,7 +96,7 @@ class UserDeletionTest < ActiveSupport::TestCase
 
     should "reset the password" do
       @deletion.delete!
-      assert_equal(false, @user.authenticate_password("password"))
+      assert_equal(false, @user.authenticate_password("correct horse battery staple"))
     end
 
     should "destroy the 2FA secret and backup codes" do
@@ -219,13 +219,13 @@ class UserDeletionTest < ActiveSupport::TestCase
 
   context "undeleting a user's account" do
     should "restore the user's name and reset their password" do
-      @user = create(:user, name: "fumimi", password: "hunter2")
-      @deletion = UserDeletion.new(user: @user, deleter: create(:owner_user), password: "hunter2")
+      @user = create(:user, name: "fumimi", password: "secure-delete-pass-789")
+      @deletion = UserDeletion.new(user: @user, deleter: create(:owner_user), password: "secure-delete-pass-789")
 
       @deletion.delete!
       assert_equal("user_#{@user.id}", @user.reload.name)
       assert_equal(true, @user.is_deleted)
-      assert_equal(false, @user.authenticate_password("hunter2").present?)
+      assert_equal(false, @user.authenticate_password("secure-delete-pass-789").present?)
       assert_equal("deleted user ##{@user.id}", ModAction.last.description)
       assert_equal("user_delete", ModAction.last.category)
       assert_equal(@deletion.deleter, ModAction.last.creator)
@@ -234,7 +234,7 @@ class UserDeletionTest < ActiveSupport::TestCase
       @deletion.undelete!
       assert_equal("fumimi", @user.reload.name)
       assert_equal(false, @user.is_deleted)
-      assert_equal(true, @user.authenticate_password("hunter2").present?)
+      assert_equal(true, @user.authenticate_password("secure-delete-pass-789").present?)
       assert_equal("undeleted user ##{@user.id}", ModAction.last.description)
       assert_equal("user_undelete", ModAction.last.category)
       assert_equal(@deletion.deleter, ModAction.last.creator)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -130,7 +130,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     should "authenticate password" do
-      assert_equal(@user, @user.authenticate_password("password"))
+      assert_equal(@user, @user.authenticate_password("correct horse battery staple"))
       assert_equal(false, @user.authenticate_password("password2"))
     end
 

--- a/test/unit/zxcvbn_password_validator_test.rb
+++ b/test/unit/zxcvbn_password_validator_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ZxcvbnPasswordValidatorTest < ActiveSupport::TestCase
+  context "ZxcvbnPasswordValidator" do
+    should "reject a common weak password" do
+      user = build(:user, password: "password")
+      assert_not(user.valid?)
+      assert(user.errors[:password].any? { |e| e.include?("weak") || e.include?("common") })
+    end
+
+    should "reject a short dictionary word" do
+      user = build(:user, password: "letmein")
+      assert_not(user.valid?)
+    end
+
+    should "accept a strong passphrase" do
+      user = build(:user, password: "correct horse battery staple")
+      assert(user.valid?, "Expected passphrase to be valid, got errors: #{user.errors.full_messages}")
+    end
+
+    should "include the zxcvbn warning in the error message when available" do
+      user = build(:user, password: "qwerty")
+      user.valid?
+      assert(user.errors[:password].any? { |e| e.match?(/common|keyboard|sequence|row/i) })
+    end
+  end
+end


### PR DESCRIPTION
Adds a validator that estimates password strength using [zxcvbn](https://github.com/envato/zxcvbn-ruby), a pattern-matching password strength estimator originally from Dropbox. It catches common words, keyboard patterns ("qwerty"), short sequences ("abc123"), dates, and l33t speak that simple length rules miss. Passwords scoring below 2 on the 0-4 scale are rejected with an error that includes zxcvbn's own feedback ("This is a top-10 common password", "Add another word or two", etc).

Default minimum score is 2 - "protect from unthrottled online attacks". Can be overridden per-use-case via validates :password, zxcvbn_password: { min_score: 3 } for stricter checking.

Many tests used passwords like "password", "xxxxx1", "12345", "hunter2" etc. that no longer pass validation. These were replaced with strong fixtures. Two unrelated users_controller_test.rb tests that were already failing on master (DNS lookup for email deliverability) remain failing - not introduced by this PR.

Related issue: #6608