### PR TITLE
Make rate limits page readable for non-technical users

### DIFF
--- a/app/components/user_profile_component/user_profile_component.html.erb
+++ b/app/components/user_profile_component/user_profile_component.html.erb
@@ -287,6 +287,13 @@
               (<%= link_to_wiki "help", "help:api" %>)
             </td>
           </tr>
+
+          <tr>
+            <th>Rate Limits</th>
+            <td>
+              <%= link_to "View", rate_limits_path %>
+            </td>
+          </tr>
         <% end %>
       </tbody>
     </table>

--- a/app/controllers/rate_limits_controller.rb
+++ b/app/controllers/rate_limits_controller.rb
@@ -5,6 +5,13 @@ class RateLimitsController < ApplicationController
 
   def index
     @rate_limits = authorize RateLimit.visible(CurrentUser.user).paginated_search(params, count_pages: true)
+
+    # Several rows can share the same key and humanized action (e.g. separate
+    # per-post buckets for "notes:write:post-1" and "notes:write:post-2" both
+    # humanize to "Notes: write"). Collapse those to the most limited row so
+    # the table doesn't show confusing, unexplained duplicates.
+    @displayed_rate_limits = @rate_limits.group_by { |rate_limit| [rate_limit.key, rate_limit.humanized_action] }.map { |_, group| group.min_by(&:points) }
+
     respond_with(@rate_limits)
   end
 end

--- a/app/helpers/rate_limits_helper.rb
+++ b/app/helpers/rate_limits_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RateLimitsHelper
+  # Format a points-per-second refill rate as a human-readable string, picking
+  # the most natural time unit (per hour if under 1/minute, otherwise per minute).
+  def humanize_rate(rate)
+    per_minute = rate * 60
+    if per_minute < 1
+      "#{(rate * 3600).round} per hour"
+    else
+      "#{per_minute.round} per minute"
+    end
+  end
+end

--- a/app/models/rate_limit.rb
+++ b/app/models/rate_limit.rb
@@ -76,4 +76,66 @@ class RateLimit < ApplicationRecord
 
     RateLimit.find_by_sql([sql, sql_params])
   end
+
+  # A human-readable version of the `action` string. Record-specific suffixes
+  # like ":post-123" or ":wiki-page-45" are stripped; non-id modifiers like
+  # ":invalid" or ":large" are preserved as parenthesized qualifiers.
+  def humanized_action
+    return "Unknown" if action.blank?
+
+    controller, action_name, modifier = parsed_action
+    return action.humanize if controller.blank? || action_name.blank?
+
+    label = "#{controller.humanize}: #{action_name.humanize(capitalize: false)}"
+    label += " (#{modifier.humanize(capitalize: false)})" if modifier.present? && !record_suffix?(modifier)
+    label
+  end
+
+  # Returns the `{ burst:, rate: }` values currently applicable to this rate
+  # limit's action when invoked by `user`, by calling into the corresponding
+  # Pundit policy. Returns nil if the policy/action can't be resolved or the
+  # method raises (e.g. record-dependent branches with no available record).
+  def limit_config(user)
+    controller, action_name, = parsed_action
+    policy_class = resolve_policy_class(controller)
+    return nil unless policy_class && action_name.present?
+
+    record = build_dummy_record(controller)
+    policy = policy_class.new(user, record)
+    method = :"rate_limit_for_#{action_name}"
+    return nil unless policy.respond_to?(method)
+
+    config = policy.send(method, request: nil)
+    return nil if config.blank? || config[:burst].nil? || config[:rate].nil?
+
+    { burst: config[:burst].to_f, rate: config[:rate].to_f }
+  rescue StandardError
+    nil
+  end
+
+  private
+
+  def parsed_action
+    parts = action.to_s.split(":")
+    [parts[0], parts[1], parts[2..]&.join(":")]
+  end
+
+  def record_suffix?(modifier)
+    modifier.match?(/\A[a-z-]+-\d+\z/)
+  end
+
+  def resolve_policy_class(controller)
+    return nil if controller.blank?
+
+    ["#{controller.classify}Policy", "#{controller.camelize}Policy"].each do |name|
+      return name.constantize if Object.const_defined?(name)
+    end
+    nil
+  end
+
+  def build_dummy_record(controller)
+    controller.classify.constantize.new
+  rescue StandardError
+    nil
+  end
 end

--- a/app/models/rate_limit.rb
+++ b/app/models/rate_limit.rb
@@ -95,47 +95,30 @@ class RateLimit < ApplicationRecord
   # limit's action when invoked by `user`, by calling into the corresponding
   # Pundit policy. Returns nil if the policy/action can't be resolved or the
   # method raises (e.g. record-dependent branches with no available record).
+  #
+  # Memoized because the view calls this once per column, for the same user.
   def limit_config(user)
+    return @limit_config if defined?(@limit_config)
+
     controller, action_name, = parsed_action
-    policy_class = resolve_policy_class(controller)
-    return nil unless policy_class && action_name.present?
-
-    record = build_dummy_record(controller)
-    policy = policy_class.new(user, record)
-    method = :"rate_limit_for_#{action_name}"
-    return nil unless policy.respond_to?(method)
-
-    config = policy.send(method, request: nil)
-    return nil if config.blank? || config[:burst].nil? || config[:rate].nil?
-
-    { burst: config[:burst].to_f, rate: config[:rate].to_f }
+    @limit_config =
+      if controller.present? && action_name.present?
+        dummy_record = controller.classify.safe_constantize&.new
+        policy = dummy_record&.policy(user)
+        config = policy.try(:"rate_limit_for_#{action_name}", request: nil)
+        { burst: config[:burst].to_f, rate: config[:rate].to_f } if config.present? && config[:burst] && config[:rate]
+      end
   rescue StandardError
-    nil
+    @limit_config = nil
   end
 
   private
 
   def parsed_action
-    parts = action.to_s.split(":")
-    [parts[0], parts[1], parts[2..]&.join(":")]
+    action.split(":", 3)
   end
 
   def record_suffix?(modifier)
     modifier.match?(/\A[a-z-]+-\d+\z/)
-  end
-
-  def resolve_policy_class(controller)
-    return nil if controller.blank?
-
-    ["#{controller.classify}Policy", "#{controller.camelize}Policy"].each do |name|
-      return name.constantize if Object.const_defined?(name)
-    end
-    nil
-  end
-
-  def build_dummy_record(controller)
-    controller.classify.constantize.new
-  rescue StandardError
-    nil
   end
 end

--- a/app/views/rate_limits/index.html.erb
+++ b/app/views/rate_limits/index.html.erb
@@ -1,17 +1,46 @@
 <div id="c-rate-limits">
   <div id="a-index">
+    <p class="prose mb-4">
+      Rate limits cap how many times you can perform certain actions within a given period. Each bucket refills over time, so unused capacity returns if you take a break.
+    </p>
+
     <%= table_for @rate_limits, class: "striped autofit" do |t| %>
-      <% t.column :action %>
-
-      <% t.column :key %>
-
-      <% t.column :points do |rate_limit| %>
-        <%= rate_limit.points.round(2) %>
+      <% t.column "Action" do |rate_limit| %>
+        <%= rate_limit.humanized_action %>
+        <% if CurrentUser.user.is_owner? %>
+          <div class="text-xs text-muted"><%= rate_limit.key %></div>
+        <% end %>
       <% end %>
 
-      <% t.column :limited? %>
+      <% t.column "Usage" do |rate_limit| %>
+        <% config = rate_limit.limit_config(CurrentUser.user) %>
+        <% if config %>
+          <% remaining = [rate_limit.points, 0].max.round %>
+          <% burst = config[:burst].round %>
+          <%= "#{remaining} of #{burst} left" %>
+        <% else %>
+          <%= "~#{[rate_limit.points, 0].max.round} left" %>
+        <% end %>
+      <% end %>
 
-      <% t.column :updated_at do |rate_limit| %>
+      <% t.column "Refills" do |rate_limit| %>
+        <% config = rate_limit.limit_config(CurrentUser.user) %>
+        <% if config %>
+          <%= humanize_rate(config[:rate]) %>
+        <% else %>
+          &mdash;
+        <% end %>
+      <% end %>
+
+      <% t.column "Status" do |rate_limit| %>
+        <% if rate_limit.limited? %>
+          <span class="chip-red text-error text-xs px-2 rounded">Limited</span>
+        <% else %>
+          <span class="chip-green text-success text-xs px-2 rounded">OK</span>
+        <% end %>
+      <% end %>
+
+      <% t.column "Last used" do |rate_limit| %>
         <%= time_ago_in_words_tagged rate_limit.updated_at %>
       <% end %>
     <% end %>

--- a/app/views/rate_limits/index.html.erb
+++ b/app/views/rate_limits/index.html.erb
@@ -4,12 +4,10 @@
       Rate limits cap how many times you can perform certain actions within a given period. Each bucket refills over time, so unused capacity returns if you take a break.
     </p>
 
-    <%= table_for @rate_limits, class: "striped autofit" do |t| %>
+    <%= table_for @displayed_rate_limits, class: "striped autofit" do |t| %>
       <% t.column "Action" do |rate_limit| %>
         <%= rate_limit.humanized_action %>
-        <% if CurrentUser.user.is_owner? %>
-          <div class="text-xs text-muted"><%= rate_limit.key %></div>
-        <% end %>
+        <div class="text-xs text-muted"><%= rate_limit.key %></div>
       <% end %>
 
       <% t.column "Usage" do |rate_limit| %>

--- a/test/functional/rate_limits_controller_test.rb
+++ b/test/functional/rate_limits_controller_test.rb
@@ -28,6 +28,19 @@ class RateLimitsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
         assert_select "tbody tr", count: 0
       end
+
+      should "render humanized action names and status pills" do
+        create(:rate_limit, action: "posts:create", key: @user.cache_key, points: 40)
+        create(:rate_limit, action: "notes:write:post-1", key: @user.cache_key, points: -1, limited: true)
+
+        get_auth rate_limits_path, @user
+
+        assert_response :success
+        assert_select "td", text: /Posts: create/
+        assert_select "td", text: /Notes: write/
+        assert_select ".chip-green", text: "OK"
+        assert_select ".chip-red", text: "Limited"
+      end
     end
   end
 end

--- a/test/functional/rate_limits_controller_test.rb
+++ b/test/functional/rate_limits_controller_test.rb
@@ -41,6 +41,25 @@ class RateLimitsControllerTest < ActionDispatch::IntegrationTest
         assert_select ".chip-green", text: "OK"
         assert_select ".chip-red", text: "Limited"
       end
+
+      should "collapse rows that share the same key and humanized action into the most limited one" do
+        create(:rate_limit, action: "notes:write:post-1", key: @user.cache_key, points: 10)
+        create(:rate_limit, action: "notes:write:post-2", key: @user.cache_key, points: -1, limited: true)
+
+        get_auth rate_limits_path, @user
+
+        assert_response :success
+        assert_select "td", text: /Notes: write/, count: 1
+        assert_select ".chip-red", text: "Limited"
+      end
+
+      should "not collapse rows that share the same humanized action but belong to different keys" do
+        create(:rate_limit, action: "test", key: SecureRandom.hex)
+
+        get_auth rate_limits_path, create(:owner_user)
+
+        assert_select "td", text: /Test/, count: 2
+      end
     end
   end
 end

--- a/test/unit/rate_limit_test.rb
+++ b/test/unit/rate_limit_test.rb
@@ -72,5 +72,42 @@ class RateLimitTest < ActiveSupport::TestCase
         assert_equal(9, limiter.rate_limits.first.points)
       end
     end
+
+    context "#humanized_action" do
+      should "strip record-specific suffixes and humanize" do
+        assert_equal("Posts: create", RateLimit.new(action: "posts:create").humanized_action)
+        assert_equal("Notes: write", RateLimit.new(action: "notes:write:post-123").humanized_action)
+        assert_equal("Notes: write", RateLimit.new(action: "notes:write:note-7").humanized_action)
+        assert_equal("Wiki pages: write", RateLimit.new(action: "wiki_pages:write:wiki-page-45").humanized_action)
+        assert_equal("Wiki pages: write (large)", RateLimit.new(action: "wiki_pages:write:large").humanized_action)
+        assert_equal("Uploads: create (invalid)", RateLimit.new(action: "uploads:create:invalid").humanized_action)
+        assert_equal("Unknown", RateLimit.new(action: "").humanized_action)
+      end
+    end
+
+    context "#limit_config" do
+      should "return burst and rate for a simple user-level policy method" do
+        user = create(:user)
+        rate_limit = RateLimit.new(action: "artists:write", key: user.cache_key)
+        config = rate_limit.limit_config(user)
+
+        assert_not_nil(config)
+        assert_operator(config[:burst], :>, 0)
+        assert_operator(config[:rate], :>, 0)
+      end
+
+      should "return nil for unknown actions" do
+        user = create(:user)
+        rate_limit = RateLimit.new(action: "unknown_controller:foo", key: user.cache_key)
+        assert_nil(rate_limit.limit_config(user))
+      end
+
+      should "return nil when the policy method raises" do
+        user = create(:user)
+        rate_limit = RateLimit.new(action: "posts:create", key: user.cache_key)
+        PostPolicy.any_instance.stubs(:rate_limit_for_create).raises(StandardError)
+        assert_nil(rate_limit.limit_config(user))
+      end
+    end
   end
 end

--- a/test/unit/rate_limit_test.rb
+++ b/test/unit/rate_limit_test.rb
@@ -108,6 +108,15 @@ class RateLimitTest < ActiveSupport::TestCase
         PostPolicy.any_instance.stubs(:rate_limit_for_create).raises(StandardError)
         assert_nil(rate_limit.limit_config(user))
       end
+
+      should "memoize the result instead of resolving the policy again on each call" do
+        user = create(:user)
+        rate_limit = RateLimit.new(action: "artists:write", key: user.cache_key)
+
+        ArtistPolicy.any_instance.expects(:rate_limit_for_write).once.returns(burst: 10, rate: 1)
+
+        2.times { rate_limit.limit_config(user) }
+      end
     end
   end
 end


### PR DESCRIPTION
The `/rate_limits` page currently shows raw technical columns (`action`, `key`, `points`, `limited?`) and isn't linked from anywhere visible, so most users never find it and can't make sense of it if they do.

This PR:

- Adds a Rate Limits row to the user profile (next to the API Key row) so the page is actually reachable.
- Replaces the raw columns with: humanized action, usage (`X of Y left`), refill rate, status pill (OK / Limited), and last used.
- The owner still sees the raw `key` as a subtext under each action for debugging.

The `rate_limits` table only stores `points`, not the `burst`/`rate` the bucket was configured with. Per maintainer guidance I avoided a migration and instead resolve these at render time: for each row, `RateLimit#limit_config(user)` looks up the policy class by controller name, invokes the matching `rate_limit_for_*` method, and returns `{burst:, rate:}`.

Caveats worth knowing:

- For policies that branch on `record.invalid?` or specific record state, I pass a fresh `.new` record. This may not match the branch that was actually in effect when the bucket was last updated, so the displayed burst/rate is "what applies right now for a typical action of this type" rather than a historical replay.
- When the policy method raises or the policy/record class can't be resolved, the column falls back to `~N left` (just `points`) and the Refills column shows a dash.


<img width="1202" height="404" alt="Screenshot from 2026-04-17 17-49-53" src="https://github.com/user-attachments/assets/53ade212-cb97-4541-b19d-17afce2ada06" />

#6363