### PR TITLE
sources: add rednote.com

### DIFF
--- a/app/logical/source/url/xiaohongshu.rb
+++ b/app/logical/source/url/xiaohongshu.rb
@@ -4,7 +4,7 @@
 class Source::URL::Xiaohongshu < Source::URL
   site "Xiaohongshu" do
     url "https://www.xiaohongshu.com"
-    domains %w[xiaohongshu.com xhscdn.com xhslink.com]
+    domains %w[xiaohongshu.com rednote.com xhscdn.com rednotecdn.com xhslink.com]
 
     credential :session_cookie, help: %{Your Xiaohongshu `gid` cookie.}
     credential :webid_cookie, help: %{Your Xiaohongshu `webId` cookie.}
@@ -16,7 +16,7 @@ class Source::URL::Xiaohongshu < Source::URL
   attr_reader :user_id, :post_id, :full_image_url, :xsec_token, :redirect_id
 
   def self.match?(url)
-    url.domain.in?(%w[xiaohongshu.com xhscdn.com xhslink.com])
+    url.domain.in?(%w[xiaohongshu.com rednote.com xhscdn.com rednotecdn.com xhslink.com])
   end
 
   def parse
@@ -26,7 +26,7 @@ class Source::URL::Xiaohongshu < Source::URL
     # https://sns-webpic-qc.xhscdn.com/202405210829/7c81f7805428d2268d2d0723e0f52ce2/spectrum/1040g0k030p06mpo4k0005ovbk4n9t3fq5ms4iu0!nd_dft_wlteh_webp_3 (sample)
     # https://ci.xiaohongshu.com/1000g00828idf6nofk05g5ohki5uk137o8beqcv8 (full)
     # https://ci.xiaohongshu.com/spectrum/1040g0k030p06mpo4k0005ovbk4n9t3fq5ms4iu0 (full)
-    in _, "xhscdn.com", /^\d{12}$/, /^\h{32}$/, *subdirs, /^([a-z0-9]+)!/
+    in _, ("xhscdn.com" | "rednotecdn.com"), /^\d{12}$/, /^\h{32}$/, *subdirs, /^([a-z0-9]+)!/
       image_id = basename.split("!").first
       @full_image_url = ["https://ci.xiaohongshu.com", *subdirs, image_id].join("/")
 
@@ -44,23 +44,23 @@ class Source::URL::Xiaohongshu < Source::URL
       @full_image_url = "https://img.xiaohongshu.com/avatar/#{basename.split("@").first}"
 
     # https://www.xiaohongshu.com/explore/6421b331000000002702901f
-    in _, "xiaohongshu.com", ("explore" | "search_result"), post_id
+    in _, ("xiaohongshu.com" | "rednote.com"), ("explore" | "search_result"), post_id
       @post_id = post_id
       @xsec_token = params[:xsec_token]
 
     # https://www.xiaohongshu.com/discovery/item/65880524000000000700a643
-    in _, "xiaohongshu.com", "discovery", "item", post_id
+    in _, ("xiaohongshu.com" | "rednote.com"), "discovery", "item", post_id
       @post_id = post_id
       @xsec_token = params[:xsec_token]
 
     # https://www.xiaohongshu.com/user/profile/6234917d0000000010008cf8/6421b331000000002702901f
-    in _, "xiaohongshu.com", "user", "profile", user_id, post_id
+    in _, ("xiaohongshu.com" | "rednote.com"), "user", "profile", user_id, post_id
       @user_id = user_id
       @post_id = post_id
       @xsec_token = params[:xsec_token]
 
     # https://www.xiaohongshu.com/user/profile/6234917d0000000010008cf8
-    in _, "xiaohongshu.com", "user", "profile", user_id
+    in _, ("xiaohongshu.com" | "rednote.com"), "user", "profile", user_id
       @user_id = user_id
 
     # https://xhslink.com/WNd9gI
@@ -83,7 +83,7 @@ class Source::URL::Xiaohongshu < Source::URL
   end
 
   def image_url?
-    host.in?(%w[ci.xiaohongshu.com img.xiaohongshu.com]) || domain == "xhscdn.com"
+    host.in?(%w[ci.xiaohongshu.com img.xiaohongshu.com]) || domain.in?(%w[xhscdn.com rednotecdn.com])
   end
 
   def page_url

--- a/test/unit/source/extractor/xiaohongshu_extractor_test.rb
+++ b/test/unit/source/extractor/xiaohongshu_extractor_test.rb
@@ -51,7 +51,7 @@ module Source::Tests::Extractor
       setup { skip "Xiaohongshu extractor requires credentials" unless Source::Extractor::Xiaohongshu.enabled? }
 
       strategy_should_work(
-        "https://www.xiaohongshu.com/explore/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqACnVpHeS-InXHcQ2BeoLJKfU=&xsec_source=pc_user",
+        "https://www.xiaohongshu.com/explore/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqAClF0o0f3BaJn3Ye5zUIYtms=",
         image_urls: %w[
           https://ci.xiaohongshu.com/1040g2sg31aqeccv4mo704a54lgjgfvujhe954v8
           https://ci.xiaohongshu.com/1040g2sg31aqeccv4mo7g4a54lgjgfvujfhua5oo
@@ -62,10 +62,13 @@ module Source::Tests::Extractor
           { file_size: 699_830 },
           { file_size: 844_990 },
         ],
-        page_url: "https://www.xiaohongshu.com/explore/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqACnVpHeS-InXHcQ2BeoLJKfU=",
+        page_url: "https://www.xiaohongshu.com/explore/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqAClF0o0f3BaJn3Ye5zUIYtms=",
+        profile_url: "https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3",
         profile_urls: %w[https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3],
-        display_name: "撸卜🥕",
+        display_name: "撸卜",
         username: nil,
+        published_at: nil,
+        updated_at: nil,
         tags: [
           ["绘画", "https://www.xiaohongshu.com/search_result?keyword=绘画"],
           ["明日方舟", "https://www.xiaohongshu.com/search_result?keyword=明日方舟"],
@@ -81,7 +84,7 @@ module Source::Tests::Extractor
       setup { skip "Xiaohongshu extractor requires credentials" unless Source::Extractor::Xiaohongshu.enabled? }
 
       strategy_should_work(
-        "https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqACnVpHeS-InXHcQ2BeoLJKfU=&xsec_source=pc_user",
+        "https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqAClF0o0f3BaJn3Ye5zUIYtms=",
         image_urls: %w[
           https://ci.xiaohongshu.com/1040g2sg31aqeccv4mo704a54lgjgfvujhe954v8
           https://ci.xiaohongshu.com/1040g2sg31aqeccv4mo7g4a54lgjgfvujfhua5oo
@@ -92,10 +95,13 @@ module Source::Tests::Extractor
           { file_size: 699_830 },
           { file_size: 844_990 },
         ],
-        page_url: "https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqACnVpHeS-InXHcQ2BeoLJKfU=",
+        page_url: "https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3/674a802f0000000007029471?xsec_token=ABgt_jFg7t-LqYcRm3UlqAClF0o0f3BaJn3Ye5zUIYtms=",
+        profile_url: "https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3",
         profile_urls: %w[https://www.xiaohongshu.com/user/profile/5af06707db2e600283b2ffd3],
-        display_name: "撸卜🥕",
+        display_name: "撸卜",
         username: nil,
+        published_at: nil,
+        updated_at: nil,
         tags: [
           ["绘画", "https://www.xiaohongshu.com/search_result?keyword=绘画"],
           ["明日方舟", "https://www.xiaohongshu.com/search_result?keyword=明日方舟"],
@@ -111,7 +117,7 @@ module Source::Tests::Extractor
       setup { skip "Xiaohongshu extractor requires credentials" unless Source::Extractor::Xiaohongshu.enabled? }
 
       strategy_should_work(
-        "https://www.xiaohongshu.com/explore/676692a9000000000b022e4d?xsec_token=ABp9YCBRRqv5v30dlFfxzHw8HBaoViPhFHlY2eTE035AM=",
+        "https://www.xiaohongshu.com/explore/676692a9000000000b022e4d?xsec_token=ABp9YCBRRqv5v30dlFfxzHwyv1xk_xBquzQJZeoJf5H7g=",
         image_urls: %w[
           https://ci.xiaohongshu.com/spectrum/1040g0k031blr5gcag8005o752t9g90v028pbu80
           https://ci.xiaohongshu.com/spectrum/1040g0k031blr5mbl0c005o752t9g90v0ah6ctv0
@@ -125,7 +131,7 @@ module Source::Tests::Extractor
           https://ci.xiaohongshu.com/spectrum/1040g0k031blr5mbl0c405o752t9g90v03m2llno
         ],
         media_files: [
-          { file_size: 2_432_700 },
+          { file_size: 2_434_034 },
           { file_size: 1_543_097 },
           { file_size: 1_475_318 },
           { file_size: 1_552_256 },
@@ -136,10 +142,13 @@ module Source::Tests::Extractor
           { file_size: 1_523_305 },
           { file_size: 1_613_587 },
         ],
-        page_url: "https://www.xiaohongshu.com/explore/676692a9000000000b022e4d?xsec_token=ABp9YCBRRqv5v30dlFfxzHw8HBaoViPhFHlY2eTE035AM=",
+        page_url: "https://www.xiaohongshu.com/explore/676692a9000000000b022e4d?xsec_token=ABp9YCBRRqv5v30dlFfxzHwyv1xk_xBquzQJZeoJf5H7g=",
+        profile_url: "https://www.xiaohongshu.com/user/profile/60e5175300000000010083e0",
         profile_urls: %w[https://www.xiaohongshu.com/user/profile/60e5175300000000010083e0],
-        display_name: "面包棍棍",
+        display_name: "面包棍🥖",
         username: nil,
+        published_at: nil,
+        updated_at: nil,
         tags: [
           ["明日方舟", "https://www.xiaohongshu.com/search_result?keyword=明日方舟"],
           ["搬空罗德岛食堂", "https://www.xiaohongshu.com/search_result?keyword=搬空罗德岛食堂"],
@@ -193,21 +202,24 @@ module Source::Tests::Extractor
       setup { skip "Xiaohongshu extractor requires credentials" unless Source::Extractor::Xiaohongshu.enabled? }
 
       strategy_should_work(
-        "https://www.xiaohongshu.com/explore/67a396a7000000002503cbd3?xsec_token=CBRIrPInWF5UjSI0_h4-v2v6nT1TXLzRXVwp_ng-vPOLQ=",
+        "https://www.xiaohongshu.com/explore/67a396a7000000002503cbd3?xsec_token=AB4LyC1SEvdhEyOhMoeo9jT30BdU1-uQcUDPBgukFMt4g=&xsec_source=pc_user",
         image_urls: %w[
           https://ci.xiaohongshu.com/1040g00831dhec8sn16005ps3g6f23fi49d2j5ao
           https://ci.xiaohongshu.com/1040g00831dhec8sn160g5ps3g6f23fi4fohe6vo
-          http://sns-video-ak.xhscdn.com/stream/1/10/19/01e7a396a34b27470100500394d7049ff0_19.mp4
+          http://sns-video-alos.xhscdn.com/stream/1/10/19/01e7a396a34b27470100500394d7049ff0_19.mp4
         ],
         media_files: [
           { file_size: 627_574 },
           { file_size: 294_766 },
           { file_size: 867_997 },
         ],
-        page_url: "https://www.xiaohongshu.com/explore/67a396a7000000002503cbd3?xsec_token=CBRIrPInWF5UjSI0_h4-v2v6nT1TXLzRXVwp_ng-vPOLQ=",
+        page_url: "https://www.xiaohongshu.com/explore/67a396a7000000002503cbd3?xsec_token=AB4LyC1SEvdhEyOhMoeo9jT30BdU1-uQcUDPBgukFMt4g=",
+        profile_url: "https://www.xiaohongshu.com/user/profile/6783819e000000000801be44",
         profile_urls: %w[https://www.xiaohongshu.com/user/profile/6783819e000000000801be44],
         display_name: "梦游蝴蝶的日常",
         username: nil,
+        published_at: nil,
+        updated_at: nil,
         tags: [
           ["Mbti", "https://www.xiaohongshu.com/search_result?keyword=Mbti"],
           ["infp", "https://www.xiaohongshu.com/search_result?keyword=infp"],
@@ -225,6 +237,43 @@ module Source::Tests::Extractor
 
           "#mbti16人格":[https://www.xiaohongshu.com/search_result?keyword=mbti16人格]
           封面来自：九言绘一
+        EOS
+      )
+    end
+
+    context "A post on rednote.com" do
+      setup { skip "Xiaohongshu extractor requires credentials" unless Source::Extractor::Xiaohongshu.enabled? }
+    
+      strategy_should_work(
+        "https://www.rednote.com/explore/69d503c7000000001f007995?xsec_token=ABR7xc7xnydtN9Cqof7XXZDNQnk_bgI9LF753p_b_5IZg=",
+        image_urls: %w[
+          https://ci.xiaohongshu.com/notes_pre_post/1040g3k031ulmkboi2i6g5ohqnak0jie6odk9k0o
+          https://ci.xiaohongshu.com/notes_pre_post/1040g3k031ulmkboi2i605ohqnak0jie6kit9f58
+          https://ci.xiaohongshu.com/notes_pre_post/1040g3k031ulmkboi2i505ohqnak0jie6a6iu50o
+        ],
+        media_files: [
+          { file_size: 3_439_122 },
+          { file_size: 5_734_475 },
+          { file_size: 2_344_734 },
+        ],
+        page_url: "https://www.xiaohongshu.com/explore/69d503c7000000001f007995?xsec_token=ABR7xc7xnydtN9Cqof7XXZDNQnk_bgI9LF753p_b_5IZg=",
+        profile_url: "https://www.xiaohongshu.com/user/profile/623abaa8000000000201c9c6",
+        profile_urls: %w[https://www.xiaohongshu.com/user/profile/623abaa8000000000201c9c6],
+        display_name: "火叶叶",
+        username: nil,
+        published_at: nil,
+        updated_at: nil,
+        tags: [
+          ["明日方舟终末地", "https://www.xiaohongshu.com/search_result?keyword=明日方舟终末地"],
+          ["新潮起故渊离", "https://www.xiaohongshu.com/search_result?keyword=新潮起故渊离"],
+          ["洛茜", "https://www.xiaohongshu.com/search_result?keyword=洛茜"],
+          ["明日方舟终末地创作应援", "https://www.xiaohongshu.com/search_result?keyword=明日方舟终末地创作应援"],
+          ["全世界最可爱的小狼宝宝", "https://www.xiaohongshu.com/search_result?keyword=全世界最可爱的小狼宝宝"],
+        ],
+        dtext_artist_commentary_title: "秘密基地里的洛茜和小管",
+        dtext_artist_commentary_desc: <<~EOS.chomp,
+          扎小辫子的游戏对洛茜来说可能有点幼稚，但是对于管理员来说刚刚好！
+          "#明日方舟终末地":[https://www.xiaohongshu.com/search_result?keyword=明日方舟终末地] "#新潮起故渊离":[https://www.xiaohongshu.com/search_result?keyword=新潮起故渊离] "#洛茜":[https://www.xiaohongshu.com/search_result?keyword=洛茜] "#明日方舟终末地创作应援":[https://www.xiaohongshu.com/search_result?keyword=明日方舟终末地创作应援] "#全世界最可爱的小狼宝宝":[https://www.xiaohongshu.com/search_result?keyword=全世界最可爱的小狼宝宝]
         EOS
       )
     end

--- a/test/unit/source/url/xiaohongshu_url_test.rb
+++ b/test/unit/source/url/xiaohongshu_url_test.rb
@@ -5,18 +5,23 @@ module Source::Tests::URL
     context "Xiaohongshu URLs" do
       should be_image_url(
         "http://sns-webpic-qc.xhscdn.com/202405050857/60985d4963cfb500a9b0838667eb3adc/1000g00828idf6nofk05g5ohki5uk137o8beqcv8!nd_dft_wgth_webp_3",
+        "https://sns-web-i10.rednotecdn.com/202605022153/beebca051fa7f146cac83b58b49f020e/notes_pre_post/1040g3k831ugifr7iip205o4ptfh0814d1eq53fo!nd_dft_wlteh_webp_3?src=A",
         "https://ci.xiaohongshu.com/1000g00828idf6nofk05g5ohki5uk137o8beqcv8",
         "https://sns-avatar-qc.xhscdn.com/avatar/1040g2jo30s5tg4ugig605ohki5uk137o34ug2fo",
       )
 
       should be_page_url(
         "https://www.xiaohongshu.com/explore/6421b331000000002702901f",
+        "https://www.rednote.com/explore/6421b331000000002702901f",
         "https://www.xiaohongshu.com/user/profile/6234917d0000000010008cf8/6421b331000000002702901f",
+        "https://www.rednote.com/user/profile/6234917d0000000010008cf8/6421b331000000002702901f",
         "https://www.xiaohongshu.com/discovery/item/65880524000000000700a643",
+        "https://www.rednote.com/discovery/item/65880524000000000700a643",
       )
 
       should be_profile_url(
         "https://www.xiaohongshu.com/user/profile/6234917d0000000010008cf8",
+        "https://www.rednote.com/user/profile/6234917d0000000010008cf8",
       )
 
       should be_bad_source(


### PR DESCRIPTION
Only the url parser is modified to recognize the alternative domain.
No actual extractor changes are needed, as at the moment everything, including credentials, works interchangeably.

Fixes #6402