### PR TITLE
Fix version history diff rendering

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
     statuses = changed_fields.map { |field, status| status }
     altered = record.updater_id != other.updater_id
 
-    tag.div(class: "version-statuses", "data-altered": altered) do
+    tag.div("class": "version-statuses", "data-altered": altered) do
       safe_join(statuses, tag.br)
     end
   end
@@ -167,7 +167,7 @@ module ApplicationHelper
       if compact
         text = time_ago_in_words(time)
         text = text.gsub(/almost|about|over/, "").strip
-        text = text.gsub(/less than a/, "<1")
+        text = text.gsub("less than a", "<1")
         text = text.gsub(/ minutes?/, "m")
         text = text.gsub(/ hours?/, "h")
         text = text.gsub(/ days?/, "d")
@@ -183,7 +183,7 @@ module ApplicationHelper
     elsif time.future?
       if compact
         text = distance_of_time_in_words(Time.now, time)
-        text = text.gsub(/almost|about|over/, "").gsub(/less than a/, "<1").strip
+        text = text.gsub(/almost|about|over/, "").gsub("less than a", "<1").strip
         time_tag(text, time)
       else
         time_tag("in " + distance_of_time_in_words(Time.now, time), time)
@@ -196,7 +196,7 @@ module ApplicationHelper
   end
 
   def external_link_to(url, text = url, truncate: nil, strip: false, **link_options, &block)
-    text = capture { yield } if block_given?
+    text = capture(&block) if block_given?
     text = text.gsub(%r{\Ahttps?://}i, "") if strip == :scheme
     text = text.gsub(%r{\Ahttps?://(?:www\.)?}i, "") if strip == :subdomain
     text = text.truncate(truncate) if truncate

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,20 +21,18 @@ module ApplicationHelper
   end
 
   def diff_name_html(this_name, other_name)
-    return "<ins>#{h(this_name)}</ins>".html_safe if other_name.blank?
-    return "<del>#{h(other_name)}</del>".html_safe if this_name.blank?
+    return "<ins>#{ERB::Util.html_escape(this_name)}</ins>".html_safe if other_name.blank?
+    return "<del>#{ERB::Util.html_escape(other_name)}</del>".html_safe if this_name.blank?
 
     # Compute the longest common prefix and suffix so we only diff the changed middle.
     min_len = [this_name.length, other_name.length].min
 
     prefix_len = 0
-    while prefix_len < min_len && this_name[prefix_len] == other_name[prefix_len]
-      prefix_len += 1
-    end
+    prefix_len += 1 while prefix_len < min_len && this_name[prefix_len] == other_name[prefix_len]
 
     suffix_len = 0
     while suffix_len < min_len - prefix_len &&
-          this_name[this_name.length - 1 - suffix_len] == other_name[other_name.length - 1 - suffix_len]
+        this_name[this_name.length - 1 - suffix_len] == other_name[other_name.length - 1 - suffix_len]
       suffix_len += 1
     end
 
@@ -44,9 +42,9 @@ module ApplicationHelper
     other_middle = other_name[prefix_len, other_name.length - prefix_len - suffix_len]
 
     if levenshtein_similarity(this_middle, other_middle) < 0.3
-      "#{h(prefix)}<del>#{h(other_middle)}</del><ins>#{h(this_middle)}</ins>#{h(suffix)}".html_safe
+      "#{ERB::Util.html_escape(prefix)}<del>#{ERB::Util.html_escape(other_middle)}</del><ins>#{ERB::Util.html_escape(this_middle)}</ins>#{ERB::Util.html_escape(suffix)}".html_safe
     else
-      "#{h(prefix)}#{DiffBuilder.new(this_middle, other_middle, /./).build}#{h(suffix)}".html_safe
+      "#{ERB::Util.html_escape(prefix)}#{DiffBuilder.new(this_middle, other_middle, /./).build}#{ERB::Util.html_escape(suffix)}".html_safe
     end
   end
 
@@ -63,7 +61,7 @@ module ApplicationHelper
     # check is O(n*m) in pure Ruby, so we only run it when both sides are small
     # enough that the shortcut is worth the cost.
     if new_text.length > 10 && [new_text.length, old_text.length].max <= 5_000 &&
-       levenshtein_similarity(new_text, old_text) < 0.15
+        levenshtein_similarity(new_text, old_text) < 0.15
       "<del>#{format_body_text(old_text)}</del><ins>#{format_body_text(new_text)}</ins>".html_safe
     else
       pattern = %r{
@@ -83,11 +81,11 @@ module ApplicationHelper
     max_len = [a.length, b.length].max
     return 1.0 if max_len.zero?
 
-    1.0 - DidYouMean::Levenshtein.distance(a, b).to_f / max_len
+    1.0 - (DidYouMean::Levenshtein.distance(a, b).to_f / max_len)
   end
 
   private def format_body_text(text)
-    h(text).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>')
+    ERB::Util.html_escape(text).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>')
   end
 
   def status_diff_html(record, type)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,16 +21,16 @@ module ApplicationHelper
   end
 
   def diff_name_html(this_name, other_name)
-    DiffBuilder.diff_name_html(this_name, other_name)
+    DiffBuilder.new(this_name, other_name, DiffBuilder::NAME_PATTERN).diff_name_html
   end
 
   def diff_body_html(record, other, field)
     if record.blank? || other.blank?
       diff_record = other.presence || record
-      return DiffBuilder.format_body_html(diff_record[field])
+      return DiffBuilder.new(diff_record[field], nil).format_body_html
     end
 
-    DiffBuilder.diff_body_html(record[field], other[field])
+    DiffBuilder.new(record[field], other[field]).diff_body_html
   end
 
   def status_diff_html(record, type)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,17 +21,73 @@ module ApplicationHelper
   end
 
   def diff_name_html(this_name, other_name)
-    DiffBuilder.new(this_name, other_name, /./).build
+    return "<ins>#{h(this_name)}</ins>".html_safe if other_name.blank?
+    return "<del>#{h(other_name)}</del>".html_safe if this_name.blank?
+
+    # Compute the longest common prefix and suffix so we only diff the changed middle.
+    min_len = [this_name.length, other_name.length].min
+
+    prefix_len = 0
+    while prefix_len < min_len && this_name[prefix_len] == other_name[prefix_len]
+      prefix_len += 1
+    end
+
+    suffix_len = 0
+    while suffix_len < min_len - prefix_len &&
+          this_name[this_name.length - 1 - suffix_len] == other_name[other_name.length - 1 - suffix_len]
+      suffix_len += 1
+    end
+
+    prefix = this_name[0, prefix_len]
+    suffix = this_name[-suffix_len, suffix_len]
+    this_middle = this_name[prefix_len, this_name.length - prefix_len - suffix_len]
+    other_middle = other_name[prefix_len, other_name.length - prefix_len - suffix_len]
+
+    if levenshtein_similarity(this_middle, other_middle) < 0.3
+      "#{h(prefix)}<del>#{h(other_middle)}</del><ins>#{h(this_middle)}</ins>#{h(suffix)}".html_safe
+    else
+      "#{h(prefix)}#{DiffBuilder.new(this_middle, other_middle, /./).build}#{h(suffix)}".html_safe
+    end
   end
 
   def diff_body_html(record, other, field)
     if record.blank? || other.blank?
       diff_record = other.presence || record
-      return h(diff_record[field]).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>').html_safe
+      return format_body_text(diff_record[field]).html_safe
     end
 
-    pattern = /(?:<.+?>)|(?:\w+)|(?:[ \t]+)|(?:\r?\n)|(?:.+?)/
-    DiffBuilder.new(record[field], other[field], pattern).build
+    new_text = record[field]
+    old_text = other[field]
+
+    # Skip the expensive diff for long, completely different texts. The Levenshtein
+    # check is O(n*m) in pure Ruby, so we only run it when both sides are small
+    # enough that the shortcut is worth the cost.
+    if new_text.length > 10 && [new_text.length, old_text.length].max <= 5_000 &&
+       levenshtein_similarity(new_text, old_text) < 0.15
+      "<del>#{format_body_text(old_text)}</del><ins>#{format_body_text(new_text)}</ins>".html_safe
+    else
+      pattern = %r{
+        (?:<.+?>)               # HTML tags
+        | (?:[\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}]) # CJK / Hangul characters
+        | (?:\w+)               # Latin words
+        | (?:[ \t]+)            # Horizontal whitespace
+        | (?:\r?\n)             # Line breaks
+        | (?:.+?)               # Remaining individual characters
+      }x
+      DiffBuilder.new(new_text, old_text, pattern).build
+    end
+  end
+
+  # Normalized Levenshtein similarity: 0.0 = completely different, 1.0 = identical.
+  private def levenshtein_similarity(a, b)
+    max_len = [a.length, b.length].max
+    return 1.0 if max_len.zero?
+
+    1.0 - DidYouMean::Levenshtein.distance(a, b).to_f / max_len
+  end
+
+  private def format_body_text(text)
+    h(text).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>')
   end
 
   def status_diff_html(record, type)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,71 +21,16 @@ module ApplicationHelper
   end
 
   def diff_name_html(this_name, other_name)
-    return "<ins>#{ERB::Util.html_escape(this_name)}</ins>".html_safe if other_name.blank?
-    return "<del>#{ERB::Util.html_escape(other_name)}</del>".html_safe if this_name.blank?
-
-    # Compute the longest common prefix and suffix so we only diff the changed middle.
-    min_len = [this_name.length, other_name.length].min
-
-    prefix_len = 0
-    prefix_len += 1 while prefix_len < min_len && this_name[prefix_len] == other_name[prefix_len]
-
-    suffix_len = 0
-    while suffix_len < min_len - prefix_len &&
-        this_name[this_name.length - 1 - suffix_len] == other_name[other_name.length - 1 - suffix_len]
-      suffix_len += 1
-    end
-
-    prefix = this_name[0, prefix_len]
-    suffix = this_name[-suffix_len, suffix_len]
-    this_middle = this_name[prefix_len, this_name.length - prefix_len - suffix_len]
-    other_middle = other_name[prefix_len, other_name.length - prefix_len - suffix_len]
-
-    if levenshtein_similarity(this_middle, other_middle) < 0.3
-      "#{ERB::Util.html_escape(prefix)}<del>#{ERB::Util.html_escape(other_middle)}</del><ins>#{ERB::Util.html_escape(this_middle)}</ins>#{ERB::Util.html_escape(suffix)}".html_safe
-    else
-      "#{ERB::Util.html_escape(prefix)}#{DiffBuilder.new(this_middle, other_middle, /./).build}#{ERB::Util.html_escape(suffix)}".html_safe
-    end
+    DiffBuilder.diff_name_html(this_name, other_name)
   end
 
   def diff_body_html(record, other, field)
     if record.blank? || other.blank?
       diff_record = other.presence || record
-      return format_body_text(diff_record[field]).html_safe
+      return DiffBuilder.format_body_html(diff_record[field])
     end
 
-    new_text = record[field]
-    old_text = other[field]
-
-    # Skip the expensive diff for long, completely different texts. The Levenshtein
-    # check is O(n*m) in pure Ruby, so we only run it when both sides are small
-    # enough that the shortcut is worth the cost.
-    if new_text.length > 10 && [new_text.length, old_text.length].max <= 5_000 &&
-        levenshtein_similarity(new_text, old_text) < 0.15
-      "<del>#{format_body_text(old_text)}</del><ins>#{format_body_text(new_text)}</ins>".html_safe
-    else
-      pattern = %r{
-        (?:<.+?>)               # HTML tags
-        | (?:[\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}]) # CJK / Hangul characters
-        | (?:\w+)               # Latin words
-        | (?:[ \t]+)            # Horizontal whitespace
-        | (?:\r?\n)             # Line breaks
-        | (?:.+?)               # Remaining individual characters
-      }x
-      DiffBuilder.new(new_text, old_text, pattern).build
-    end
-  end
-
-  # Normalized Levenshtein similarity: 0.0 = completely different, 1.0 = identical.
-  private def levenshtein_similarity(a, b)
-    max_len = [a.length, b.length].max
-    return 1.0 if max_len.zero?
-
-    1.0 - (DidYouMean::Levenshtein.distance(a, b).to_f / max_len)
-  end
-
-  private def format_body_text(text)
-    ERB::Util.html_escape(text).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>')
+    DiffBuilder.diff_body_html(record[field], other[field])
   end
 
   def status_diff_html(record, type)

--- a/app/logical/diff_builder.rb
+++ b/app/logical/diff_builder.rb
@@ -28,8 +28,8 @@ class DiffBuilder
   end
 
   def diff_name_html
-    return diff_html(new_html: ERB::Util.html_escape(this_text)) if that_text.blank?
-    return diff_html(old_html: ERB::Util.html_escape(that_text)) if this_text.blank?
+    return diff_html(new_text: this_text) if that_text.blank?
+    return diff_html(old_text: that_text) if this_text.blank?
 
     # Compute the longest common prefix and suffix so we only diff the changed middle.
     min_len = [this_text.length, that_text.length].min
@@ -48,31 +48,22 @@ class DiffBuilder
     this_middle = this_text[prefix_len, this_text.length - prefix_len - suffix_len]
     other_middle = that_text[prefix_len, that_text.length - prefix_len - suffix_len]
 
-    escaped_prefix = ERB::Util.html_escape(prefix)
-    escaped_suffix = ERB::Util.html_escape(suffix)
-
     if levenshtein_similarity(this_middle, other_middle) < 0.3
-      old_html = ERB::Util.html_escape(other_middle)
-      new_html = ERB::Util.html_escape(this_middle)
-      diff_html(prefix_html: escaped_prefix, old_html: old_html, new_html: new_html, suffix_html: escaped_suffix)
+      diff_html(prefix: prefix, old_text: other_middle, new_text: this_middle, suffix: suffix)
     else
       middle_html = self.class.new(this_middle, other_middle, pattern).build
-      diff_html(prefix_html: escaped_prefix, middle_html: middle_html, suffix_html: escaped_suffix)
+      diff_html(prefix: prefix, middle_html: middle_html, suffix: suffix)
     end
   end
 
   def diff_body_html
-    # Skip the expensive diff for long, completely different texts. The Levenshtein
-    # check is O(n*m) in pure Ruby, so we only run it when both sides are small
-    # enough that the shortcut is worth the cost.
+    # Avoid an O(n*m) Levenshtein check on long bodies.
     max_length = [this_text.length, that_text.length].max
 
     if max_length > MIN_WHOLESALE_DIFF_LENGTH &&
         max_length <= MAX_LEVENSHTEIN_LENGTH &&
         levenshtein_similarity(this_text, that_text) < WHOLESALE_BODY_DIFF_SIMILARITY
-      old_html = html_escape_with_paragraph_marks(that_text)
-      new_html = html_escape_with_paragraph_marks(this_text)
-      diff_html(old_html: old_html, new_html: new_html)
+      diff_html(old_text: that_text, new_text: this_text, paragraph_marks: true)
     else
       build
     end
@@ -81,7 +72,7 @@ class DiffBuilder
   # Renders one side of a version diff without change markers. Used when the
   # other side is missing, so there is nothing to compare against.
   def format_body_html
-    html_escape_with_paragraph_marks(this_text)
+    format_diff_text(this_text, paragraph_marks: true).html_safe
   end
 
   def build
@@ -142,25 +133,32 @@ class DiffBuilder
 
   private
 
-  def diff_html(prefix_html: nil, old_html: nil, new_html: nil, middle_html: nil, suffix_html: nil)
+  def diff_html(prefix: nil, old_text: nil, new_text: nil, middle_html: nil, suffix: nil, paragraph_marks: false)
     html = +""
 
-    html << prefix_html unless prefix_html.nil?
+    html << format_diff_text(prefix) unless prefix.nil?
 
     if middle_html.nil?
-      html << "<del>#{old_html}</del>" unless old_html.nil? || old_html.empty?
-      html << "<ins>#{new_html}</ins>" unless new_html.nil? || new_html.empty?
+      unless old_text.nil? || old_text.empty?
+        html << "<del>#{format_diff_text(old_text, paragraph_marks: paragraph_marks)}</del>"
+      end
+
+      unless new_text.nil? || new_text.empty?
+        html << "<ins>#{format_diff_text(new_text, paragraph_marks: paragraph_marks)}</ins>"
+      end
     else
       html << middle_html
     end
 
-    html << suffix_html unless suffix_html.nil?
+    html << format_diff_text(suffix) unless suffix.nil?
 
     html.html_safe
   end
 
-  def html_escape_with_paragraph_marks(text)
-    ERB::Util.html_escape(text).gsub(/\r?\n/, PARAGRAPH_MARK_HTML).html_safe
+  def format_diff_text(text, paragraph_marks: false)
+    html = ERB::Util.html_escape(text)
+    html = html.gsub(/\r?\n/, PARAGRAPH_MARK_HTML) if paragraph_marks
+    html
   end
 
   # Normalized Levenshtein similarity: 0.0 = completely different, 1.0 = identical.

--- a/app/logical/diff_builder.rb
+++ b/app/logical/diff_builder.rb
@@ -25,8 +25,8 @@ class DiffBuilder
   end
 
   def diff_name_html
-    return "<ins>#{ERB::Util.html_escape(this_text)}</ins>".html_safe if that_text.blank?
-    return "<del>#{ERB::Util.html_escape(that_text)}</del>".html_safe if this_text.blank?
+    return diff_html(new_html: ERB::Util.html_escape(this_text)) if that_text.blank?
+    return diff_html(old_html: ERB::Util.html_escape(that_text)) if this_text.blank?
 
     # Compute the longest common prefix and suffix so we only diff the changed middle.
     min_len = [this_text.length, that_text.length].min
@@ -51,10 +51,10 @@ class DiffBuilder
     if levenshtein_similarity(this_middle, other_middle) < 0.3
       old_html = ERB::Util.html_escape(other_middle)
       new_html = ERB::Util.html_escape(this_middle)
-      "#{escaped_prefix}<del>#{old_html}</del><ins>#{new_html}</ins>#{escaped_suffix}".html_safe
+      diff_html(prefix_html: escaped_prefix, old_html: old_html, new_html: new_html, suffix_html: escaped_suffix)
     else
       middle_html = self.class.new(this_middle, other_middle, pattern).build
-      "#{escaped_prefix}#{middle_html}#{escaped_suffix}".html_safe
+      diff_html(prefix_html: escaped_prefix, middle_html: middle_html, suffix_html: escaped_suffix)
     end
   end
 
@@ -66,7 +66,7 @@ class DiffBuilder
         levenshtein_similarity(this_text, that_text) < 0.15
       old_html = html_escape_with_paragraph_marks(that_text)
       new_html = html_escape_with_paragraph_marks(this_text)
-      "<del>#{old_html}</del><ins>#{new_html}</ins>".html_safe
+      diff_html(old_html: old_html, new_html: new_html)
     else
       build
     end
@@ -135,6 +135,23 @@ class DiffBuilder
   end
 
   private
+
+  def diff_html(prefix_html: nil, old_html: nil, new_html: nil, middle_html: nil, suffix_html: nil)
+    html = +""
+
+    html << prefix_html unless prefix_html.nil?
+
+    if middle_html.nil?
+      html << "<del>#{old_html}</del>" unless old_html.nil?
+      html << "<ins>#{new_html}</ins>" unless new_html.nil?
+    else
+      html << middle_html
+    end
+
+    html << suffix_html unless suffix_html.nil?
+
+    html.html_safe
+  end
 
   def html_escape_with_paragraph_marks(text)
     ERB::Util.html_escape(text).gsub(/\r?\n/, PARAGRAPH_MARK_HTML).html_safe

--- a/app/logical/diff_builder.rb
+++ b/app/logical/diff_builder.rb
@@ -15,6 +15,9 @@ class DiffBuilder
   }x
   PARAGRAPH_MARK_HTML = '<span class="paragraph-mark">¶</span><br>'
   DIFFED_PARAGRAPH_MARK_HTML = '<del><span class="paragraph-mark">¶</span></del><ins><span class="paragraph-mark">¶</span></ins><br>'
+  MAX_LEVENSHTEIN_LENGTH = 5_000
+  MIN_WHOLESALE_DIFF_LENGTH = 10
+  WHOLESALE_BODY_DIFF_SIMILARITY = 0.15
 
   attr_reader :this_text, :that_text, :pattern
 
@@ -62,8 +65,11 @@ class DiffBuilder
     # Skip the expensive diff for long, completely different texts. The Levenshtein
     # check is O(n*m) in pure Ruby, so we only run it when both sides are small
     # enough that the shortcut is worth the cost.
-    if this_text.length > 10 && [this_text.length, that_text.length].max <= 5_000 &&
-        levenshtein_similarity(this_text, that_text) < 0.15
+    max_length = [this_text.length, that_text.length].max
+
+    if max_length > MIN_WHOLESALE_DIFF_LENGTH &&
+        max_length <= MAX_LEVENSHTEIN_LENGTH &&
+        levenshtein_similarity(this_text, that_text) < WHOLESALE_BODY_DIFF_SIMILARITY
       old_html = html_escape_with_paragraph_marks(that_text)
       new_html = html_escape_with_paragraph_marks(this_text)
       diff_html(old_html: old_html, new_html: new_html)
@@ -142,8 +148,8 @@ class DiffBuilder
     html << prefix_html unless prefix_html.nil?
 
     if middle_html.nil?
-      html << "<del>#{old_html}</del>" unless old_html.nil?
-      html << "<ins>#{new_html}</ins>" unless new_html.nil?
+      html << "<del>#{old_html}</del>" unless old_html.nil? || old_html.empty?
+      html << "<ins>#{new_html}</ins>" unless new_html.nil? || new_html.empty?
     else
       html << middle_html
     end

--- a/app/logical/diff_builder.rb
+++ b/app/logical/diff_builder.rb
@@ -4,6 +4,7 @@ require "diff/lcs/array" # diff-lcs gem
 
 # Builds an HTML diff between two pieces of text.
 class DiffBuilder
+  NAME_PATTERN = /./
   BODY_PATTERN = %r{
     (?:<.+?>)               # HTML tags
     | (?:[\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}]) # CJK / Hangul characters
@@ -12,29 +13,37 @@ class DiffBuilder
     | (?:\r?\n)             # Line breaks
     | (?:.+?)               # Remaining individual characters
   }x
+  PARAGRAPH_MARK_HTML = '<span class="paragraph-mark">¶</span><br>'
+  DIFFED_PARAGRAPH_MARK_HTML = '<del><span class="paragraph-mark">¶</span></del><ins><span class="paragraph-mark">¶</span></ins><br>'
 
   attr_reader :this_text, :that_text, :pattern
 
-  def self.diff_name_html(this_name, other_name)
-    return "<ins>#{ERB::Util.html_escape(this_name)}</ins>".html_safe if other_name.blank?
-    return "<del>#{ERB::Util.html_escape(other_name)}</del>".html_safe if this_name.blank?
+  def initialize(this_text, that_text, pattern = BODY_PATTERN)
+    @this_text = this_text.to_s
+    @that_text = that_text.to_s
+    @pattern = pattern
+  end
+
+  def diff_name_html
+    return "<ins>#{ERB::Util.html_escape(this_text)}</ins>".html_safe if that_text.blank?
+    return "<del>#{ERB::Util.html_escape(that_text)}</del>".html_safe if this_text.blank?
 
     # Compute the longest common prefix and suffix so we only diff the changed middle.
-    min_len = [this_name.length, other_name.length].min
+    min_len = [this_text.length, that_text.length].min
 
     prefix_len = 0
-    prefix_len += 1 while prefix_len < min_len && this_name[prefix_len] == other_name[prefix_len]
+    prefix_len += 1 while prefix_len < min_len && this_text[prefix_len] == that_text[prefix_len]
 
     suffix_len = 0
     while suffix_len < min_len - prefix_len &&
-        this_name[this_name.length - 1 - suffix_len] == other_name[other_name.length - 1 - suffix_len]
+        this_text[this_text.length - 1 - suffix_len] == that_text[that_text.length - 1 - suffix_len]
       suffix_len += 1
     end
 
-    prefix = this_name[0, prefix_len]
-    suffix = this_name[-suffix_len, suffix_len]
-    this_middle = this_name[prefix_len, this_name.length - prefix_len - suffix_len]
-    other_middle = other_name[prefix_len, other_name.length - prefix_len - suffix_len]
+    prefix = this_text[0, prefix_len]
+    suffix = this_text[-suffix_len, suffix_len]
+    this_middle = this_text[prefix_len, this_text.length - prefix_len - suffix_len]
+    other_middle = that_text[prefix_len, that_text.length - prefix_len - suffix_len]
 
     escaped_prefix = ERB::Util.html_escape(prefix)
     escaped_suffix = ERB::Util.html_escape(suffix)
@@ -44,32 +53,29 @@ class DiffBuilder
       new_html = ERB::Util.html_escape(this_middle)
       "#{escaped_prefix}<del>#{old_html}</del><ins>#{new_html}</ins>#{escaped_suffix}".html_safe
     else
-      middle_html = new(this_middle, other_middle, /./).build
+      middle_html = self.class.new(this_middle, other_middle, pattern).build
       "#{escaped_prefix}#{middle_html}#{escaped_suffix}".html_safe
     end
   end
 
-  def self.diff_body_html(new_text, old_text)
-    new_text = new_text.to_s
-    old_text = old_text.to_s
-
+  def diff_body_html
     # Skip the expensive diff for long, completely different texts. The Levenshtein
     # check is O(n*m) in pure Ruby, so we only run it when both sides are small
     # enough that the shortcut is worth the cost.
-    if new_text.length > 10 && [new_text.length, old_text.length].max <= 5_000 &&
-        levenshtein_similarity(new_text, old_text) < 0.15
-      old_html = format_body_html(old_text)
-      new_html = format_body_html(new_text)
+    if this_text.length > 10 && [this_text.length, that_text.length].max <= 5_000 &&
+        levenshtein_similarity(this_text, that_text) < 0.15
+      old_html = html_escape_with_paragraph_marks(that_text)
+      new_html = html_escape_with_paragraph_marks(this_text)
       "<del>#{old_html}</del><ins>#{new_html}</ins>".html_safe
     else
-      new(new_text, old_text, BODY_PATTERN).build
+      build
     end
   end
 
-  def initialize(this_text, that_text, pattern)
-    @this_text = this_text
-    @that_text = that_text
-    @pattern = pattern
+  # Renders one side of a version diff without change markers. Used when the
+  # other side is missing, so there is nothing to compare against.
+  def format_body_html
+    html_escape_with_paragraph_marks(this_text)
   end
 
   def build
@@ -89,7 +95,7 @@ class DiffBuilder
       new_cr = hunk[1].try(:new_element)
       if old_cr && new_cr && old_cr.match?(/^\r?\n$/) && new_cr.match?(/^\r?\n$/)
         hunk_position = hunk[0].old_position
-        output[hunk_position] = '<del><span class="paragraph-mark">¶</span></del><ins><span class="paragraph-mark">¶</span></ins><br>'
+        output[hunk_position] = DIFFED_PARAGRAPH_MARK_HTML
         next
       end
 
@@ -105,10 +111,10 @@ class DiffBuilder
         case chg.action
         when "-"
           oldstart = chg.old_position
-          output[chg.old_position] = '<span class="paragraph-mark">¶</span><br>' if chg.old_element.match(/^\r?\n$/)
+          output[chg.old_position] = PARAGRAPH_MARK_HTML if chg.old_element.match(/^\r?\n$/)
         when "+"
           if chg.new_element.match(/^\r?\n$/)
-            output.insert(chg.old_position, '<span class="paragraph-mark">¶</span><br>')
+            output.insert(chg.old_position, PARAGRAPH_MARK_HTML)
           else
             output.insert(chg.old_position, escape_html[chg.new_element].to_s)
           end
@@ -125,19 +131,20 @@ class DiffBuilder
       end
     end
 
-    output.join.gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>').html_safe
+    output.join.gsub(/\r?\n/, PARAGRAPH_MARK_HTML).html_safe
   end
 
-  def self.format_body_html(text)
-    ERB::Util.html_escape(text).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>').html_safe
+  private
+
+  def html_escape_with_paragraph_marks(text)
+    ERB::Util.html_escape(text).gsub(/\r?\n/, PARAGRAPH_MARK_HTML).html_safe
   end
 
   # Normalized Levenshtein similarity: 0.0 = completely different, 1.0 = identical.
-  def self.levenshtein_similarity(a, b)
+  def levenshtein_similarity(a, b)
     max_len = [a.length, b.length].max
     return 1.0 if max_len.zero?
 
     1.0 - (DidYouMean::Levenshtein.distance(a, b).to_f / max_len)
   end
-  private_class_method :levenshtein_similarity
 end

--- a/app/logical/diff_builder.rb
+++ b/app/logical/diff_builder.rb
@@ -4,7 +4,67 @@ require "diff/lcs/array" # diff-lcs gem
 
 # Builds an HTML diff between two pieces of text.
 class DiffBuilder
+  BODY_PATTERN = %r{
+    (?:<.+?>)               # HTML tags
+    | (?:[\p{Han}\p{Katakana}\p{Hiragana}\p{Hangul}]) # CJK / Hangul characters
+    | (?:\w+)               # Latin words
+    | (?:[ \t]+)            # Horizontal whitespace
+    | (?:\r?\n)             # Line breaks
+    | (?:.+?)               # Remaining individual characters
+  }x
+
   attr_reader :this_text, :that_text, :pattern
+
+  def self.diff_name_html(this_name, other_name)
+    return "<ins>#{ERB::Util.html_escape(this_name)}</ins>".html_safe if other_name.blank?
+    return "<del>#{ERB::Util.html_escape(other_name)}</del>".html_safe if this_name.blank?
+
+    # Compute the longest common prefix and suffix so we only diff the changed middle.
+    min_len = [this_name.length, other_name.length].min
+
+    prefix_len = 0
+    prefix_len += 1 while prefix_len < min_len && this_name[prefix_len] == other_name[prefix_len]
+
+    suffix_len = 0
+    while suffix_len < min_len - prefix_len &&
+        this_name[this_name.length - 1 - suffix_len] == other_name[other_name.length - 1 - suffix_len]
+      suffix_len += 1
+    end
+
+    prefix = this_name[0, prefix_len]
+    suffix = this_name[-suffix_len, suffix_len]
+    this_middle = this_name[prefix_len, this_name.length - prefix_len - suffix_len]
+    other_middle = other_name[prefix_len, other_name.length - prefix_len - suffix_len]
+
+    escaped_prefix = ERB::Util.html_escape(prefix)
+    escaped_suffix = ERB::Util.html_escape(suffix)
+
+    if levenshtein_similarity(this_middle, other_middle) < 0.3
+      old_html = ERB::Util.html_escape(other_middle)
+      new_html = ERB::Util.html_escape(this_middle)
+      "#{escaped_prefix}<del>#{old_html}</del><ins>#{new_html}</ins>#{escaped_suffix}".html_safe
+    else
+      middle_html = new(this_middle, other_middle, /./).build
+      "#{escaped_prefix}#{middle_html}#{escaped_suffix}".html_safe
+    end
+  end
+
+  def self.diff_body_html(new_text, old_text)
+    new_text = new_text.to_s
+    old_text = old_text.to_s
+
+    # Skip the expensive diff for long, completely different texts. The Levenshtein
+    # check is O(n*m) in pure Ruby, so we only run it when both sides are small
+    # enough that the shortcut is worth the cost.
+    if new_text.length > 10 && [new_text.length, old_text.length].max <= 5_000 &&
+        levenshtein_similarity(new_text, old_text) < 0.15
+      old_html = format_body_html(old_text)
+      new_html = format_body_html(new_text)
+      "<del>#{old_html}</del><ins>#{new_html}</ins>".html_safe
+    else
+      new(new_text, old_text, BODY_PATTERN).build
+    end
+  end
 
   def initialize(this_text, that_text, pattern)
     @this_text = this_text
@@ -67,4 +127,17 @@ class DiffBuilder
 
     output.join.gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>').html_safe
   end
+
+  def self.format_body_html(text)
+    ERB::Util.html_escape(text).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>').html_safe
+  end
+
+  # Normalized Levenshtein similarity: 0.0 = completely different, 1.0 = identical.
+  def self.levenshtein_similarity(a, b)
+    max_len = [a.length, b.length].max
+    return 1.0 if max_len.zero?
+
+    1.0 - (DidYouMean::Levenshtein.distance(a, b).to_f / max_len)
+  end
+  private_class_method :levenshtein_similarity
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,11 +1,6 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
-  # ApplicationHelper#diff_name_html / #diff_body_html call `h` directly. In
-  # production those run inside an ActionView::Base instance, which mixes in
-  # ERB::Util; ActionView::TestCase doesn't, so we mix it in here.
-  include ERB::Util
-
   context "The application helper" do
     context "format_text method" do
       should "not raise an exception for invalid DText" do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
+  # ApplicationHelper#diff_name_html / #diff_body_html call `h` directly. In
+  # production those run inside an ActionView::Base instance, which mixes in
+  # ERB::Util; ActionView::TestCase doesn't, so we mix it in here.
+  include ERB::Util
+
   context "The application helper" do
     context "format_text method" do
       should "not raise an exception for invalid DText" do
@@ -31,6 +36,68 @@ class ApplicationHelperTest < ActionView::TestCase
 
         assert_match(/#{Regexp.quote(media_asset_path(media_asset))}/, link)
         assert_match(/#{Regexp.quote(text)}/, link)
+      end
+    end
+
+    context "diff_name_html method" do
+      should "render pure addition when previous name is blank" do
+        assert_equal("<ins>foo</ins>", diff_name_html("foo", ""))
+        assert_equal("<ins>foo</ins>", diff_name_html("foo", nil))
+      end
+
+      should "render pure removal when current name is blank" do
+        assert_equal("<del>foo</del>", diff_name_html("", "foo"))
+        assert_equal("<del>foo</del>", diff_name_html(nil, "foo"))
+      end
+
+      should "return identical names unchanged" do
+        assert_equal("foo", diff_name_html("foo", "foo"))
+      end
+
+      should "preserve common prefix and suffix around the changed middle" do
+        # "foo_bar_baz" vs "foo_qux_baz": only the middle differs
+        html = diff_name_html("foo_bar_baz", "foo_qux_baz")
+        assert_match(/\Afoo_/, html)
+        assert_match(/_baz\z/, html)
+        assert_includes(html, "<ins>")
+        assert_includes(html, "<del>")
+      end
+
+      should "wholesale-replace very dissimilar names" do
+        assert_equal("<del>xyz</del><ins>abc</ins>", diff_name_html("abc", "xyz"))
+      end
+
+      should "html-escape names so raw markup cannot leak through" do
+        html = diff_name_html("<x>", "<y>")
+        refute_includes(html, "<x>")
+        refute_includes(html, "<y>")
+        assert_includes(html, "&lt;")
+        assert_includes(html, "&gt;")
+      end
+    end
+
+    context "diff_body_html method" do
+      should "format the present side when one record is blank" do
+        html = diff_body_html({ body: "hello\nworld" }, {}, :body)
+        assert_includes(html, "paragraph-mark")
+        assert_includes(html, "hello")
+        assert_includes(html, "world")
+      end
+
+      should "wholesale-replace short, very dissimilar bodies" do
+        html = diff_body_html({ body: "totally different content here" }, { body: "x" * 30 }, :body)
+        assert_includes(html, "<del>")
+        assert_includes(html, "<ins>")
+      end
+
+      should "skip the levenshtein shortcut for bodies above the size cap" do
+        # Regression guard: pre-fix this would run an O(n*m) pure-Ruby Levenshtein on
+        # full wiki bodies (up to MAX_WIKI_LENGTH = 80_000), hanging the worker.
+        ::DidYouMean::Levenshtein.expects(:distance).never
+
+        new_rec = { body: "a" * 6_000 }
+        old_rec = { body: "b" * 6_000 }
+        assert_nothing_raised { diff_body_html(new_rec, old_rec, :body) }
       end
     end
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -64,8 +64,8 @@ class ApplicationHelperTest < ActionView::TestCase
 
       should "html-escape names so raw markup cannot leak through" do
         html = diff_name_html("<x>", "<y>")
-        refute_includes(html, "<x>")
-        refute_includes(html, "<y>")
+        assert_not_includes(html, "<x>")
+        assert_not_includes(html, "<y>")
         assert_includes(html, "&lt;")
         assert_includes(html, "&gt;")
       end


### PR DESCRIPTION
Fixes #4788

`diff_body_html` treated every CJK/Hangul character as its own token (old regex only matched `\w+`), making diffs on Japanese/Korean/Chinese text unreadable. `diff_name_html` diffed the entire string character-by-character instead of isolating the changed portion.

- Tokenize CJK/Katakana/Hiragana/Hangul as atomic tokens
- Trim common prefix/suffix from names before diffing
- Skip the expensive diff when texts are >85% different (with a 5k-char cap to keep Levenshtein fast)
- Extract `format_body_text` / `levenshtein_similarity` helpers

Merge to betabooru first for testing against real data.

### Before / After

#### 1. CJK / Hangul tokenization

<img width="212" height="61" alt="PixPin_2026-05-09_23-57-36" src="https://github.com/user-attachments/assets/f4eec9cb-7f16-4f90-9234-79e68012d9de" />
<img width="200" height="55" alt="PixPin_2026-05-09_23-57-41" src="https://github.com/user-attachments/assets/88b12a1c-387c-4aef-9e2e-0af1ae0a29b7" />
<img width="1072" height="44" alt="PixPin_2026-05-09_23-58-25" src="https://github.com/user-attachments/assets/ccaa61f0-3f64-4494-b777-99d6248bd53a" />
<img width="1005" height="49" alt="PixPin_2026-05-09_23-58-32" src="https://github.com/user-attachments/assets/cb91c8dd-62bb-44e1-957e-bd7a1d1509a8" />
<img width="430" height="57" alt="PixPin_2026-05-10_00-01-31" src="https://github.com/user-attachments/assets/f56e17ef-87d7-4072-8de9-feda6416ff6a" />
<img width="429" height="54" alt="PixPin_2026-05-10_00-01-37" src="https://github.com/user-attachments/assets/03150ad1-92b3-4619-9b64-8f86ce5be913" />

#### 2. Long name with small change

<img width="232" height="88" alt="PixPin_2026-05-10_00-00-15" src="https://github.com/user-attachments/assets/e00c6bfa-5e52-48ad-aa27-137d20573283" />
<img width="243" height="82" alt="PixPin_2026-05-10_00-00-20" src="https://github.com/user-attachments/assets/8aec1a97-c71e-4727-a389-36e67d12c010" />
<img width="185" height="86" alt="PixPin_2026-05-10_00-00-58" src="https://github.com/user-attachments/assets/46c6beaf-e175-4312-9403-70c21d661a6d" />
<img width="221" height="86" alt="PixPin_2026-05-10_00-01-07" src="https://github.com/user-attachments/assets/c0440d13-88f4-442b-bd03-56f6b0a34c63" />


#### 3. Very different long bodies (wholesale replace)

<img width="263" height="116" alt="PixPin_2026-05-09_23-57-23" src="https://github.com/user-attachments/assets/2eee23fd-e568-4404-8ffa-c00120dc70b2" />
<img width="290" height="98" alt="PixPin_2026-05-09_23-57-30" src="https://github.com/user-attachments/assets/a26ffdeb-8dec-43e5-ba6e-ef12cfe62c7d" />
<img width="284" height="90" alt="PixPin_2026-05-09_23-59-28" src="https://github.com/user-attachments/assets/a97ee13d-193a-4159-9807-5cba753006ac" />
<img width="320" height="96" alt="PixPin_2026-05-09_23-59-34" src="https://github.com/user-attachments/assets/959154ed-8c3a-4c7d-bf54-3617b6373ad4" />
