### PR TITLE
Fix #6439: wiki other name dropdown shows dotted list on /posts

### DIFF
--- a/app/helpers/wiki_pages_helper.rb
+++ b/app/helpers/wiki_pages_helper.rb
@@ -6,6 +6,6 @@ module WikiPagesHelper
       render ExternalTagLinkComponent.new(name)
     end
 
-    tag.div safe_join(html, " "), class: "flex gap-1 flex-wrap"
+    tag.div safe_join(html, " "), class: "flex gap-1 flex-wrap mb-3"
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -125,11 +125,10 @@
         <% if policy(wiki_page).edit? %>
           <%= link_to "", edit_wiki_page_path(wiki_page.id), "data-shortcut": "e", style: "display: none;" %>
         <% end %>
+        <% if wiki_page.other_names.present? %>
+          <%= wiki_page_other_names_list(wiki_page) %>
+        <% end %>
         <div class="prose">
-          <% if wiki_page.other_names.present? %>
-            <%= wiki_page_other_names_list(wiki_page) %>
-          <% end %>
-
           <%= wiki_page.dtext_body.format_text %>
           <%= render "tag_relationships/alias_and_implication_list", tag: wiki_page.tag %>
 

--- a/app/views/wiki_page_versions/show.html.erb
+++ b/app/views/wiki_page_versions/show.html.erb
@@ -15,11 +15,11 @@
       <% end %>
     </p>
 
-    <div id="wiki-page-body" class="dtext prose">
-      <% if @wiki_page_version.other_names.present? %>
-        <%= wiki_page_other_names_list(@wiki_page_version) %>
-      <% end %>
+    <% if @wiki_page_version.other_names.present? %>
+      <%= wiki_page_other_names_list(@wiki_page_version) %>
+    <% end %>
 
+    <div id="wiki-page-body" class="dtext prose">
       <%= @wiki_page_version.dtext_body.format_text %>
     </div>
   </div>


### PR DESCRIPTION
The other name list was moved out of the .prose on the wiki page quite a while ago (e788b9e07fb82116ed3c8446fda4a499902fd444), but not the /posts or /wiki_page_versions page, so I just did it here too. Added a .mb-3 to fix the spacing since `.prose p` had a 0.75rem spacer too.