### PR TITLE
sources: add api_host to xiaohongshu site credentials

### DIFF
--- a/app/logical/source/extractor/xiaohongshu.rb
+++ b/app/logical/source/extractor/xiaohongshu.rb
@@ -33,6 +33,10 @@ class Source::Extractor::Xiaohongshu < Source::Extractor
     parsed_url.page_url || parsed_referer&.page_url
   end
 
+  def api_host
+    credentials[:api_host].presence || "www.xiaohongshu.com"
+  end
+
   def profile_url
     "https://www.xiaohongshu.com/user/profile/#{user_id}" if user_id.present?
   end
@@ -81,7 +85,8 @@ class Source::Extractor::Xiaohongshu < Source::Extractor
   end
 
   memoize def page
-    http.cache(1.minute).parsed_get(page_url)
+    url = Danbooru::URL.parse(page_url).with(host: api_host).to_s
+    http.cache(1.minute).parsed_get(url)
   end
 
   memoize def page_json

--- a/app/logical/source/url/xiaohongshu.rb
+++ b/app/logical/source/url/xiaohongshu.rb
@@ -6,6 +6,7 @@ class Source::URL::Xiaohongshu < Source::URL
     url "https://www.xiaohongshu.com"
     domains %w[xiaohongshu.com rednote.com xhscdn.com rednotecdn.com xhslink.com]
 
+    credential :api_host, help: %{Your Xiaohongshu site host. Can be either "www.xiaohongshu.com" or "www.rednote.com".}
     credential :session_cookie, help: %{Your Xiaohongshu `gid` cookie.}
     credential :webid_cookie, help: %{Your Xiaohongshu `webId` cookie.}
     credential :web_session_cookie, help: %{Your Xiaohongshu `web_session` cookie.}

--- a/app/models/site_credential.rb
+++ b/app/models/site_credential.rb
@@ -135,7 +135,7 @@ class SiteCredential < ApplicationRecord
     }, {
       id: 2450,
       name: "Xiaohongshu",
-      default_credential: { session_cookie: Danbooru.config.xiaohongshu_session_cookie, web_id: Danbooru.config.xiaohongshu_webid_cookie, web_session: Danbooru.config.xiaohongshu_web_session_cookie },
+      default_credential: { api_host: Danbooru.config.xiaohongshu_api_host, session_cookie: Danbooru.config.xiaohongshu_session_cookie, web_id: Danbooru.config.xiaohongshu_webid_cookie, web_session: Danbooru.config.xiaohongshu_web_session_cookie },
       help: %{Your "Xiaohongshu":https://www.xiaohongshu.com 'gid', 'webId' and 'web_session' cookies.},
     }, {
       id: 2500,

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -610,6 +610,10 @@ module Danbooru
     def reddit_session_cookie
     end
 
+    # Your Xiaohongshu site host. Can be either "www.xiaohongshu.com" or "www.rednote.com".
+    def xiaohongshu_api_host
+    end
+
     # Your Xiaohongshu "gid" cookie. Login to Xiaohongshu then use the devtools to find the "gid" cookie.
     def xiaohongshu_session_cookie
     end


### PR DESCRIPTION
I believe that during the time since #6413, the site has stopped accepting international credentials on the chinese version and vice versa.
However, it is only a guess, as I can't properly test it, as I don't have a chinese site account.