### PR TITLE
posts: add ordvote metatag

### DIFF
--- a/app/components/post_navbar_component.rb
+++ b/app/components/post_navbar_component.rb
@@ -33,7 +33,7 @@ class PostNavbarComponent < ApplicationComponent
   end
 
   def has_search_navbar?
-    !query.has_metatag?(:order, :ordfav, :ordpool) && selected_pool.blank? && selected_favgroup.blank?
+    !query.has_metatag?(:order, :ordfav, :ordvote, :ordpool) && selected_pool.blank? && selected_favgroup.blank?
   end
 
   def selected_pool

--- a/app/logical/autocomplete_service.rb
+++ b/app/logical/autocomplete_service.rb
@@ -261,7 +261,7 @@ class AutocompleteService
   def autocomplete_metatag(metatag, value)
     results = case metatag.to_sym
     when :user, :approver, :commenter, :comm, :noter, :noteupdater, :commentaryupdater,
-         :artcomm, :fav, :ordfav, :appealer, :flagger, :upvote, :downvote
+         :artcomm, :fav, :ordfav, :ordvote, :appealer, :flagger, :upvote, :downvote
       autocomplete_user(value)
     when :pool, :ordpool
       autocomplete_pool(value)

--- a/app/logical/post_query.rb
+++ b/app/logical/post_query.rb
@@ -14,7 +14,7 @@ class PostQuery
   ]
 
   # Metatags that define the order of search results. These metatags can't be used more than once per query.
-  ORDER_METATAGS = %w[order ordfav ordfavgroup ordpool]
+  ORDER_METATAGS = %w[order ordfav ordvote ordfavgroup ordpool]
 
   # Metatags that can't be used more than once per query, and that can't be used with OR or NOT operators.
   SINGLETON_METATAGS = ORDER_METATAGS + %w[limit random]
@@ -165,7 +165,7 @@ class PostQuery
   def is_user_dependent_search?
     metatags.any? do |metatag|
       # XXX date: is user dependent because it depends on the current user's time zone
-      metatag.name.in?(%w[date upvoter upvote downvoter downvote commenter comm search flagger fav ordfav favgroup ordfavgroup]) ||
+      metatag.name.in?(%w[date upvoter upvote downvoter downvote commenter comm search flagger fav ordfav ordvote favgroup ordfavgroup]) ||
       metatag.name == "status" && metatag.value == "unmoderated" ||
       metatag.name == "disapproved" && !metatag.value.downcase.in?(PostDisapproval::REASONS)
     end

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -30,7 +30,7 @@ class PostQueryBuilder
 
   METATAGS = %w[
     user approver commenter comm noter noteupdater artcomm commentaryupdater
-    flagger appealer upvote downvote fav ordfav favgroup ordfavgroup reacted pool
+    flagger appealer upvote downvote fav ordvote ordfav favgroup ordfavgroup reacted pool
     ordpool note comment commentary id rating source status filetype
     disapproved parent child search embedded md5 pixelhash width height mpixels ratio
     score upvotes downvotes favcount filesize date age order limit tagcount pixiv_id pixiv
@@ -151,7 +151,7 @@ class PostQueryBuilder
       else
         relation = relation.none
       end
-    elsif post_query.has_metatag?(:ordfav, :ordpool, :ordfavgroup)
+    elsif post_query.has_metatag?(:ordfav, :ordvote, :ordpool, :ordfavgroup)
       # no-op
     else
       relation = relation.order_matches(post_query.find_metatag(:order))

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1220,6 +1220,8 @@ class Post < ApplicationRecord
           favorites_include(value, current_user)
         when "ordfav"
           ordfav_matches(value, current_user)
+        when "ordvote"
+          ordvote_matches(value, current_user)
         when "reacted"
           reacted_by(value)
         when "unaliased"
@@ -1491,6 +1493,16 @@ class Post < ApplicationRecord
 
         if user.present? && Pundit.policy!(current_user, user).can_see_favorites?
           joins(:favorites).merge(Favorite.where(user: user)).order("favorites.id DESC")
+        else
+          none
+        end
+      end
+
+      def ordvote_matches(username, current_user = User.anonymous)
+        user = User.find_by_name(username)
+
+        if user.present?
+          joins(:votes).merge(PostVote.active.visible(current_user).where(user: user)).order("post_votes.id DESC")
         else
           none
         end

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -534,6 +534,13 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
         assert_redirected_to(post_path(@post, q: "ordfav:#{@user.name}"))
       end
 
+      should "render for a ordvote: search" do
+        @post = as(@user) { create(:post, tag_string: "downvote:me") }
+        get_auth random_posts_path(tags: "ordvote:#{@user.name}"), @user
+
+        assert_redirected_to(post_path(@post, q: "ordvote:#{@user.name}"))
+      end
+
       should "return a 404 when no random posts can be found" do
         get random_posts_path, params: { tags: "qoigjegoi" }
         assert_response 404

--- a/test/system/autocomplete_test.rb
+++ b/test/system/autocomplete_test.rb
@@ -49,7 +49,7 @@ class AutocompleteTest < ApplicationSystemTestCase
       end
 
       should "work for username metatags" do
-        %w[user approver commenter comm noter noteupdater artcomm fav ordfav appealer flagger upvote downvote].each do |metatag|
+        %w[user approver commenter comm noter noteupdater artcomm upvote downvote fav ordvote ordfav appealer flagger].each do |metatag|
           assert_search_autocomplete_equals(["#{metatag}:DanbooruBot"], "#{metatag}:Danbo")
           assert_search_autocomplete_equals(["#{metatag}:DanbooruBot"], "-#{metatag}:Danbo")
         end

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -338,6 +338,23 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([post1], "ordfav:#{CurrentUser.user.name} filetype:jpg")
     end
 
+    should "return posts for the ordvote:<name> metatag" do
+      post1 = create(:post)
+      post2 = create(:post)
+
+      create(:post_vote, post: post1, user: CurrentUser.user, score: 1)
+      create(:post_vote, post: post2, user: CurrentUser.user, score: -1)
+
+      assert_tag_match([post2, post1], "ordvote:#{CurrentUser.user.name}")
+      assert_tag_match([], "ordvote:does_not_exist")
+
+      assert_tag_match([post2, post1], "ordvote:#{CurrentUser.user.name} commentary:false")
+      assert_tag_match([post1], "ordvote:#{CurrentUser.user.name} upvotes:>0")
+      assert_tag_match([post2], "ordvote:#{CurrentUser.user.name} downvotes:>0")
+      assert_tag_match([post2, post1], "ordvote:#{CurrentUser.user.name} comments:0")
+      assert_tag_match([post2, post1], "ordvote:#{CurrentUser.user.name} -has:comments")
+    end
+
     should "return posts for the pool:<name> metatag" do
       SqsService.any_instance.stubs(:send_message)
 
@@ -1657,14 +1674,17 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
 
     should "not allow conflicting order metatags" do
       assert_search_error("order:score ordfav:a")
+      assert_search_error("order:score ordvote:a")
       assert_search_error("order:score ordfavgroup:a")
       assert_search_error("order:score ordpool:a")
       assert_search_error("ordfav:a ordpool:b")
+      assert_search_error("ordvote:a ordpool:b")
     end
 
     should "not allow metatags that can't be used more than once" do
       assert_search_error("order:score order:favcount")
       assert_search_error("ordfav:a ordfav:b")
+      assert_search_error("ordvote:a ordvote:b")
       assert_search_error("ordfavgroup:a ordfavgroup:b")
       assert_search_error("ordpool:a ordpool:b")
       assert_search_error("limit:5 limit:10")
@@ -1674,6 +1694,7 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
     should "not allow non-negatable metatags to be negated" do
       assert_search_error("-order:score")
       assert_search_error("-ordfav:a")
+      assert_search_error("-ordvote:a")
       assert_search_error("-ordfavgroup:a")
       assert_search_error("-ordpool:a")
       assert_search_error("-limit:20")
@@ -1683,6 +1704,7 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
     should "not allow non-OR'able metatags to be OR'd" do
       assert_search_error("a or order:score")
       assert_search_error("a or ordfav:a")
+      assert_search_error("a or ordvote:a")
       assert_search_error("a or ordfavgroup:a")
       assert_search_error("a or ordpool:a")
       assert_search_error("a or limit:20")


### PR DESCRIPTION
You can already order upvotes at https://danbooru.donmai.us/post_votes?search[user_name]=hdk5, but that's not as convenient way to browse as on the main post index.