### PR TITLE
Fix #6033: Add a link to the search cheatsheet near the search bar

### DIFF
--- a/app/components/help_tooltip_component.rb
+++ b/app/components/help_tooltip_component.rb
@@ -4,9 +4,14 @@
 class HelpTooltipComponent < ApplicationComponent
   attr_reader :icon, :tooltip_content, :link_class
 
-  def initialize(icon, tooltip_content, link_class: nil)
+  def initialize(icon, tooltip_content, link_class: nil, tooltip_options: {})
     @icon = icon
     @tooltip_content = tooltip_content
     @link_class = link_class
+    @tooltip_options = tooltip_options
+  end
+
+  def tooltip_options
+    helpers.data_attributes_for(@tooltip_options, "data", @tooltip_options)
   end
 end

--- a/app/components/help_tooltip_component/help_tooltip_component.html.erb
+++ b/app/components/help_tooltip_component/help_tooltip_component.html.erb
@@ -1,6 +1,6 @@
-<a class="help-tooltip-link inline-block <%= link_class %>" href="javascript:void(0)">
+<%= tag.a(class: "help-tooltip-link inline-block #{link_class}", href: "javascript:void(0)", **tooltip_options) do %>
   <%= icon %>
-</a>
+<% end %>
 
 <div class="help-tooltip-content" style="display: none;">
   <%= tooltip_content %>

--- a/app/views/posts/partials/common/_search.html.erb
+++ b/app/views/posts/partials/common/_search.html.erb
@@ -1,7 +1,9 @@
 <%# path, tags %>
 
 <section id="search-box">
-  <h2>Search</h2>
+  <h2>
+    Search <%= help_tooltip embed_wiki("help:search_notice", classes: "text-xs"), link_class: "inactive-link", tooltip_options: { "tippy-placement": "right" } %>
+  </h2>
 
   <%= form_tag(path, method: "get", id: "search-box-form", class: "flex") do %>
     <% if current_page?(action: "index") %>


### PR DESCRIPTION
<img width="440" height="307" alt="image" src="https://github.com/user-attachments/assets/40afb6d1-40a4-4405-9662-92256b76fd87" />

It pops up on the right side as requested in Discord, which required adding support for tooltip options. It just embeds the help:search_notice wiki page so it can be customized by editing the wiki.