### PR TITLE
Remove .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,9 +1,0 @@
-# This lists major dependencies required by the current version of Danbooru.
-# The Dockerfile must be updated too when these are updated.
-
-ruby 4.0.2
-mozjpeg 4.1.5
-vips 8.14.2
-ffmpeg 7.1.1
-exiftool 13.50
-node 24.14.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@
 # See https://github.com/danbooru/danbooru/wiki/Docker-Guide for more details.
 
 # You must also update .ruby-version and the Gemfile when updating the Ruby version.
+# These versions are used by bin/danbooru-dev-entrypoint to detect whether the current installed docker containers are outdated
 ARG RUBY_VERSION="4.0.2"
 ARG RUBY_MAJOR_VERSION="4.0"
 
-# Update .tool-versions too when updating these.
 ARG MOZJPEG_VERSION="4.1.5"
 ARG VIPS_VERSION="8.14.2"
 ARG FFMPEG_VERSION="7.1.1"

--- a/bin/danbooru-dev-entrypoint
+++ b/bin/danbooru-dev-entrypoint
@@ -2,18 +2,19 @@
 
 # This is the entrypoint for Docker containers started with `bin/dev` or `docker compose -f docker-compose.dev.yaml`.
 
-# Warn if the programs listed in .tool-versions don't match the versions installed in the Docker image.
+# Warn if the ARG *_VERSION values in the Dockerfile don't match the versions installed in the Docker image.
 warn_if_outdated_image() {
-  while read -r tool required_version; do
-    installed_version=${tool^^}_VERSION # RUBY_VERSION, NODE_VERSION, etc
+  versions=$(grep -E '^ARG [A-Z]+_VERSION="' Dockerfile | sed 's/^ARG \([^=]*\)="\([^"]*\)"/\1 \2/' | sort -u)
 
-    if [[ -z ${!installed_version} ]]; then
+  while read -r var_name required_version; do
+    if [[ -z ${!var_name} ]]; then
       out_of_date=true
-    elif [[ $required_version != ${!installed_version} ]]; then
-      echo "Warning: $tool-${!installed_version} is installed, but $tool-$required_version is required."
+    elif [[ $required_version != ${!var_name} ]]; then
+      tool=${var_name%_VERSION}
+      echo "Warning: ${tool,,}-${!var_name} is installed, but ${tool,,}-${required_version} is required."
       out_of_date=true
     fi
-  done < <(sed -e 's/[[:space:]]*#.*// ; /^[[:space:]]*$/d' .tool-versions)
+  done <<< "$versions"
 
   if [[ -n $out_of_date ]]; then
     echo 'Warning: Your docker image is out of date. Run `bin/dev pull` to update if you encounter any errors.'


### PR DESCRIPTION
Detect installed version for outdated check directly from the Dockerfile instead. This makes it easier to adopt something like Renovate without having to track the same application's version across multiple places.


.tool-versions was the wrong tool to track this, because it's actually an [asdf](https://asdf-vm.com/)/[mise](https://mise.jdx.dev/) file, so those tools trip if you use them in your dev environment with this file, and Renovate gets confused, because these aren't "real" tools in their registries.