### PR TITLE
Fix #5940: Make favgroups easier to create

### DIFF
--- a/app/javascript/src/javascripts/favorite_groups.js
+++ b/app/javascript/src/javascripts/favorite_groups.js
@@ -1,5 +1,3 @@
-import Rails from "@rails/ujs";
-
 let FavoriteGroup = {};
 
 FavoriteGroup.initialize_all = function() {
@@ -23,13 +21,7 @@ FavoriteGroup.initialize_add_to_favgroup_dialog = function() {
 }
 
 FavoriteGroup.open_favgroup_dialog = function(e) {
-  if ($(".add-to-favgroup").length === 1) {
-    // If the user only has one favorite group we don't need to ask which group to add the post to.
-    let favgroup = $(".add-to-favgroup").get(0);
-    Rails.fire(favgroup, "click");
-  } else {
-    $("#add-to-favgroup-dialog").dialog("open");
-  }
+  $("#add-to-favgroup-dialog").dialog("open");
   e.preventDefault();
 }
 

--- a/app/logical/post_edit.rb
+++ b/app/logical/post_edit.rb
@@ -17,7 +17,7 @@ class PostEdit
   PRE_METATAGS = %w[parent -parent rating source status] + CATEGORIZATION_METATAGS
 
   # Post-metatags rely on the post's ID, so they must be applied after the post is saved to ensure the ID has been created.
-  POST_METATAGS = %w[newpool pool -pool favgroup -favgroup fav -fav child -child upvote downvote disapproved status -status]
+  POST_METATAGS = %w[newpool newfavgroup pool -pool favgroup -favgroup fav -fav child -child upvote downvote disapproved status -status]
 
   METATAGS = PRE_METATAGS + POST_METATAGS
   METATAG_NAME_REGEX = /(#{METATAGS.join("|")}):/io
@@ -140,7 +140,7 @@ class PostEdit
 
       name = name.delete_suffix(":").downcase
       name = TagCategory.short_name_mapping.fetch(name, name) # 'art:bkub' => 'artist:bkub'
-      value = value.downcase unless name.in?(["newpool", "source"])
+      value = value.downcase unless name.in?(["newpool", "newfavgroup", "source"])
       value = value.gsub(/[[:space:]]/, "_") unless name == "source"
 
       Metatag.new(name: name, value: value)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -539,6 +539,17 @@ class Post < ApplicationRecord
             pool.add!(self)
           end
 
+        in "newfavgroup", name
+          favgroup = FavoriteGroup.find_by_name_or_id(name, CurrentUser.user)
+
+          # XXX race condition
+          if favgroup.nil?
+            FavoriteGroup.create!(name: name, creator: CurrentUser.user, post_ids: [id])
+          else
+            raise User::PrivilegeError unless Pundit.policy!(CurrentUser.user, favgroup).update?
+            favgroup.add(self)
+          end
+
         in "fav", name
           raise User::PrivilegeError unless Pundit.policy!(CurrentUser.user, Favorite).create?
           Favorite.create(post: self, user: CurrentUser.user)

--- a/app/views/favorite_groups/_add_to_favgroup_dialog.html.erb
+++ b/app/views/favorite_groups/_add_to_favgroup_dialog.html.erb
@@ -1,13 +1,13 @@
-<% if !CurrentUser.favorite_groups.present? %>
-  <p>Add this post to a new favorite group (<%= link_to_wiki "help:favorite_groups" %>):</p>
+<p>Add this post to a new favorite group (<%= link_to_wiki "help:favorite_groups" %>):</p>
 
-  <%= edit_form_for(FavoriteGroup.new, html: { class: "one-line-form" }) do |f| %>
-    <%= f.input :name, as: :string, required: true, input_html: { style: "width: 20em" } %>
-    <%= f.input :post_ids, as: :hidden, input_html: { value: post.id } %>
-    <%= f.submit "Create" %>
-  <% end %>
-<% else %>
-  <p>Select a favorite group to add this post to (<%= link_to_wiki "help:favorite_groups" %>):</p>
+<%= edit_form_for(FavoriteGroup.new, html: { class: "one-line-form" }) do |f| %>
+  <%= f.input :name, as: :string, required: true, input_html: { style: "width: 20em" } %>
+  <%= f.input :post_ids, as: :hidden, input_html: { value: post.id } %>
+  <%= f.submit "Create" %>
+<% end %>
+
+<% if CurrentUser.favorite_groups.present? %>
+  <p class="mt-2">Or add it to an existing favorite group:</p>
 
   <% CurrentUser.favorite_groups.each_with_index do |favgroup, i| %>
     <div>

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -496,6 +496,7 @@ class PostTest < ActiveSupport::TestCase
         should allow_value("touhou pool:foo").for(:tag_string)
         should allow_value("touhou -pool:foo").for(:tag_string)
         should allow_value("touhou newpool:foo").for(:tag_string)
+        should allow_value("touhou newfavgroup:foo").for(:tag_string)
         should allow_value("touhou fav:self").for(:tag_string)
         should allow_value("touhou -fav:self").for(:tag_string)
         should allow_value("touhou upvote:self").for(:tag_string)
@@ -531,6 +532,7 @@ class PostTest < ActiveSupport::TestCase
           assert_invalid_tag("東方")
           assert_invalid_tag("gen:char:foo")
           assert_invalid_tag("general:newpool:a")
+          assert_invalid_tag("general:newfavgroup:a")
           assert_invalid_tag("general:rating:g")
         end
 
@@ -693,6 +695,16 @@ class PostTest < ActiveSupport::TestCase
             assert_match(/Couldn't add tag: 'newpool:blah' cannot begin with 'newpool:'/, post.warnings[:base].join("\n"))
             assert_equal(["tagme"], post.tag_array)
             assert_equal(false, Tag.exists?(name: "newpool:blah"))
+            assert_equal(0, post.tag_count_character)
+            assert_equal(1, post.tag_count_general)
+          end
+
+          should "not raise an exception for char:newfavgroup:blah" do
+            post = create(:post, tag_string: "tagme char:newfavgroup:blah")
+
+            assert_match(/Couldn't add tag: 'newfavgroup:blah' cannot begin with 'newfavgroup:'/i, post.warnings[:base].join("\n"))
+            assert_equal(["tagme"], post.tag_array)
+            assert_equal(false, Tag.exists?(name: "newfavgroup:blah"))
             assert_equal(0, post.tag_count_character)
             assert_equal(1, post.tag_count_general)
           end
@@ -942,6 +954,39 @@ class PostTest < ActiveSupport::TestCase
             @post.update!(tag_string: "a newpool:f123\\")
             assert_equal("a", @post.tag_string)
             assert_equal("f123\\", Pool.last.name)
+          end
+        end
+
+        context "for the newfavgroup: metatag" do
+          should "create a new favgroup and add the post to that favgroup" do
+            @post.update(tag_string: "aaa newfavgroup:abc")
+            @favgroup = FavoriteGroup.find_by_name_or_id("abc", @user)
+
+            assert_not_nil(@favgroup)
+            assert_equal([@post.id], @favgroup.post_ids)
+          end
+
+          should "add the post to an existing favgroup with the same name" do
+            @favgroup = create(:favorite_group, creator: @user, name: "abc")
+
+            @post.update(tag_string: "aaa newfavgroup:abc")
+
+            assert_equal([@post.id], @favgroup.reload.post_ids)
+          end
+
+          should "parse a double-quoted name" do
+            @post.update(tag_string: 'aaa newfavgroup:"foo bar baz" bbb')
+            @favgroup = FavoriteGroup.find_by_name_or_id("foo_bar_baz", @user)
+
+            assert_not_nil(@favgroup)
+            assert_equal([@post.id], @favgroup.post_ids)
+            assert_equal("aaa bbb", @post.tag_string)
+          end
+
+          should "not strip special characters from the name" do
+            @post.update(tag_string: "aaa newfavgroup:ichigo_100%")
+
+            assert_not_nil(FavoriteGroup.find_by_name_or_id("ichigo_100%", @user))
           end
         end
 


### PR DESCRIPTION
- add a new `newfavgroup` edit metatag;
- always ask user to create/pick the favgroup in favgroup dialog window.

This is a breaking change that will affect users who have only one favgroup and are used to click "Add to fav group" link (or use the 'g' shortcut) to add a post to that sole favgroup.

Fixes #5940