### PR TITLE
Fix performance on media assets page with many uploads.

### DIFF
--- a/app/controllers/media_assets_controller.rb
+++ b/app/controllers/media_assets_controller.rb
@@ -13,10 +13,14 @@ class MediaAssetsController < ApplicationController
   end
 
   def show
-    @media_asset = authorize MediaAsset.includes(uploads: :uploader).find(params[:id])
+    @media_asset = authorize MediaAsset.find(params[:id])
     @post = Post.find_by_md5(@media_asset.md5)
 
-    @visible_uma = @media_asset.upload_media_assets.sort_by(&:created_at).select { |uma| policy(uma.upload).show? }
+    if request.format.html?
+      @visible_uma = @media_asset.upload_media_assets.visible(CurrentUser.user).select("*, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY id DESC) AS n")
+      @visible_uma = UploadMediaAsset.from(@visible_uma).where("n < 6").select("*").order(id: :desc)
+      @visible_uma = @visible_uma.includes(upload: :uploader)
+    end
 
     if CurrentUser.is_owner? && request.format.symbol.in?(%i[jpeg webp avif])
       width = params.fetch(:width, @media_asset.image_width).to_i

--- a/app/models/media_asset.rb
+++ b/app/models/media_asset.rb
@@ -582,7 +582,7 @@ class MediaAsset < ApplicationRecord
   end
 
   def source_urls
-    urls = upload_media_assets.map do |uma|
+    urls = upload_media_assets.limit(10).map do |uma|
       Source::URL.page_url(uma.source_url) || Source::URL.page_url(uma.page_url) || uma.page_url || uma.source_url
     end
 

--- a/app/models/upload_media_asset.rb
+++ b/app/models/upload_media_asset.rb
@@ -29,7 +29,7 @@ class UploadMediaAsset < ApplicationRecord
   scope :expired, -> { unfinished.where(created_at: ..4.hours.ago) }
 
   def self.visible(user)
-    if user.is_admin?
+    if user.is_moderator?
       all
     elsif user.is_anonymous?
       none

--- a/app/policies/upload_media_asset_policy.rb
+++ b/app/policies/upload_media_asset_policy.rb
@@ -2,6 +2,6 @@
 
 class UploadMediaAssetPolicy < ApplicationPolicy
   def show?
-    user.is_admin? || record.upload.uploader_id == user.id
+    user.is_moderator? || record.upload.uploader_id == user.id
   end
 end


### PR DESCRIPTION
Fixes #6444. Primary cause was the source URL links under the image parsing every UMA's source, so limit to 10. Secondary cause was the table so limit to showing 5 uploads per user. Also check if HTML to avoid running extra queries for JSON requests.

Also fixup from 507ef5f8228dbc09b6d986b6df1c117c071d5a6d and d2d65f8103f1c3cab60295fdbb870c4d496bd404 which was only applied to uploads and not upload media assets.

It might be better to do some deduplication logic for the source urls query (say only taking 5 urls per domain), but I'm not sure what would be best.