### PR TITLE
Add is:<resolution> metatags.

### DIFF
--- a/app/logical/autocomplete_service.rb
+++ b/app/logical/autocomplete_service.rb
@@ -13,7 +13,7 @@ class AutocompleteService
   POST_STATUSES = %w[active deleted pending flagged appealed banned modqueue unmoderated]
 
   STATIC_METATAGS = {
-    is: %w[parent child sfw nsfw wiki_image] + POST_STATUSES + MediaAsset::FILE_TYPES + Post::RATINGS.values.map(&:downcase),
+    is: %w[parent child sfw nsfw wiki_image] + POST_STATUSES + MediaAsset::FILE_TYPES + Post::RATINGS.values.map(&:downcase) + Post::RESOLUTION_ALIASES.keys,
     has: %w[parent children source appeals flags replacements comments commentary notes pools],
     status: %w[any] + POST_STATUSES,
     child: %w[any none] + POST_STATUSES,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -42,6 +42,13 @@ class Post < ApplicationRecord
     sfw: ["g", "s"],
   }.with_indifferent_access
 
+  RESOLUTION_ALIASES = {
+    lowres: { width: ..640, height: ..640 },
+    highres: { width: 1920.., height: 1080.. }, # 1080p
+    absurdres: { width: 3840.., height: 2160.. }, # 4k
+    incredibly_absurdres: { width: 7680.., height: 4320.. }, # 8k
+  }.with_indifferent_access
+
   deletable
   has_bit_flags %w[has_embedded_notes _unused_has_cropped is_taken_down]
 
@@ -1281,6 +1288,8 @@ class Post < ApplicationRecord
           rating_matches(value)
         when *Post::RATING_ALIASES.keys
           where(rating: Post::RATING_ALIASES.fetch(value.downcase))
+        when *Post::RESOLUTION_ALIASES.keys
+          resolution_matches(value.downcase)
         else
           none
         end
@@ -1494,6 +1503,15 @@ class Post < ApplicationRecord
         else
           none
         end
+      end
+
+      def resolution_matches(value)
+        res = RESOLUTION_ALIASES.fetch(value)
+        height, width = res[:height], res[:width]
+
+        horizontal = attribute_matches(height, "media_assets.image_height").and(attribute_matches(width, "media_assets.image_width"))
+        vertical = attribute_matches(width, "media_assets.image_height").and(attribute_matches(height, "media_assets.image_width"))
+        joins(:media_asset).merge(horizontal.or(vertical))
       end
 
       def reacted_by(username)

--- a/test/unit/post_query_builder_test.rb
+++ b/test/unit/post_query_builder_test.rb
@@ -973,6 +973,22 @@ class PostQueryBuilderTest < ActiveSupport::TestCase
       assert_tag_match([post2], "-is:wiki_image")
     end
 
+    should "return posts for the is:<resolution> metatag" do
+      @lowres = create(:post, media_asset: build(:media_asset, image_height: 600, image_width: 600))
+      @highres_vertical = create(:post, media_asset: build(:media_asset, image_height: 2000, image_width: 1200))
+      @highres_horizontal = create(:post, media_asset: build(:media_asset, image_height: 1200, image_width: 2000))
+      @absurdres_vertical = create(:post, media_asset: build(:media_asset, image_height: 4000, image_width: 2250))
+      @absurdres_horizontal = create(:post, media_asset: build(:media_asset, image_height: 2250, image_width: 4000))
+      @incredibly_absurdres_vertical = create(:post, media_asset: build(:media_asset, image_height: 8000, image_width: 4500))
+      @incredibly_absurdres_horizontal = create(:post, media_asset: build(:media_asset, image_height: 4500, image_width: 8000))
+
+      assert_tag_match([@lowres], "is:lowres")
+      assert_tag_match([@incredibly_absurdres_horizontal, @incredibly_absurdres_vertical, @absurdres_horizontal, @absurdres_vertical, @highres_horizontal, @highres_vertical], "is:highres")
+      assert_tag_match([@incredibly_absurdres_horizontal, @incredibly_absurdres_vertical, @absurdres_horizontal, @absurdres_vertical], "is:absurdres")
+      assert_tag_match([@incredibly_absurdres_horizontal, @incredibly_absurdres_vertical], "is:incredibly_absurdres")
+      assert_tag_match([@absurdres_horizontal], "is:absurdres -is:incredibly_absurdres ratio:16:9")
+    end
+
     should "return posts for the has:<value> metatag" do
       parent = create(:post)
       child = create(:post, parent: parent)


### PR DESCRIPTION
The idea is to replace the meta-tags with is:highres etc. Right now they're kinda bloat (highres is on 7,7M of 11,6M posts) and difficult to ever change as it would require re-tagging every post.