### PR TITLE
Fix #5675: Feature Request for Private Community Boards

### DIFF
--- a/app/policies/ai_tag_policy.rb
+++ b/app/policies/ai_tag_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class AITagPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
   def tag?
     unbanned? && record.post.present? && policy(record.post).update?
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,6 +9,7 @@ class ApplicationPolicy
   end
 
   def index?
+    return false if Danbooru.config.force_authenticated? && user.is_anonymous?
     true
   end
 

--- a/app/policies/background_job_policy.rb
+++ b/app/policies/background_job_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class BackgroundJobPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
   def update?
     user.is_admin?
   end

--- a/app/policies/email_notification_policy.rb
+++ b/app/policies/email_notification_policy.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class EmailNotificationPolicy < ApplicationPolicy
+  # Override the parent method from ApplicationPolicy to ensure that users can always access the unsubscribe links.
+  # This is a public-facing endpoint that needs to remain accessible regardless of the force_authenticated setting.
+  def show?
+    true
+  end
+
   def destroy?
     true
   end

--- a/app/policies/forum_post_policy.rb
+++ b/app/policies/forum_post_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class ForumPostPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
   def show?
     policy(record.topic).show? && (!record.is_deleted? || show_deleted?)
   end

--- a/app/policies/forum_topic_policy.rb
+++ b/app/policies/forum_topic_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class ForumTopicPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
   def show?
     user.level >= record.min_level_id
   end

--- a/app/policies/media_asset_policy.rb
+++ b/app/policies/media_asset_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class MediaAssetPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
   def destroy?
     user.is_admin?
   end

--- a/app/policies/media_metadata_policy.rb
+++ b/app/policies/media_metadata_policy.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
 class MediaMetadataPolicy < ApplicationPolicy
-  def index?
-    true
-  end
 end

--- a/app/policies/rate_limit_policy.rb
+++ b/app/policies/rate_limit_policy.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
 class RateLimitPolicy < ApplicationPolicy
-  def index?
-    true
-  end
 end

--- a/app/policies/server_status_policy.rb
+++ b/app/policies/server_status_policy.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class ServerStatusPolicy < ApplicationPolicy
+  # Override the parent method from ApplicationPolicy to ensure that users can always access the server status page.
+  # This is a public-facing endpoint that needs to remain accessible regardless of the force_authenticated setting.
+  def show?
+    true
+  end
 end

--- a/app/policies/user_event_policy.rb
+++ b/app/policies/user_event_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class UserEventPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
   def can_see_events_by_others?
     user.is_moderator?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,11 +2,15 @@
 
 class UserPolicy < ApplicationPolicy
   def create?
-    user.is_anonymous?
+    if Danbooru.config.signups_restricted_to_admin?
+      user.is_admin?
+    else
+      user.is_anonymous?
+    end
   end
 
   def new?
-    user.is_anonymous?
+    create?
   end
 
   def custom_style?

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -2,7 +2,8 @@
   <%= quick_search_form_for(:name_matches, users_path, "users", autocomplete: "user", redirect: true) %>
   <%= subnav_link_to "Listing", users_path %>
 
-  <% if CurrentUser.user.is_anonymous? %>
+  <%# Show signup link when the current user is able to create an account: anonymous by default, admin only when restricted. %>
+  <% if Danbooru.config.signups_restricted_to_admin? ? CurrentUser.user.is_admin? : CurrentUser.user.is_anonymous? %>
     <%= subnav_link_to "Sign up", new_user_path %>
   <% end %>
 

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -667,6 +667,22 @@ module Danbooru
       false
     end
 
+    # If true, only authenticated users can access the site. Anonymous users will be redirected to the login page.
+    #
+    # This applies to all pages and API endpoints. Authentication routes (login, signup, password reset) are excluded.
+    #
+    # Usage: DANBOORU_FORCE_AUTHENTICATED=true
+    def force_authenticated?
+      false
+    end
+
+    # If true, only admins can create new user accounts. Anonymous signups are disabled.
+    #
+    # Usage: DANBOORU_SIGNUPS_RESTRICTED_TO_ADMIN=true
+    def signups_restricted_to_admin?
+      false
+    end
+
     # Whether to enable API rate limits.
     def rate_limits_enabled?
       true

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -344,6 +344,41 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "when force_authenticated is enabled" do
+      setup do
+        Danbooru.config.stubs(:force_authenticated?).returns(true)
+      end
+
+      should "deny anonymous users via the index policy" do
+        get posts_path
+
+        assert_response 403
+      end
+
+      should "deny anonymous users for JSON requests" do
+        get posts_path(format: :json)
+
+        assert_response 403
+      end
+
+      should "allow authenticated users to pass through" do
+        get_auth posts_path, create(:user)
+
+        assert_response :success
+      end
+
+      should "allow anonymous users on pages whose policies explicitly allow it" do
+        get new_session_path
+
+        assert_response :success
+      end
+    end
+
+    should "allow anonymous users when force_authenticated is disabled" do
+      get posts_path
+      assert_response :success
+    end
+
     context "when the api limit is exceeded" do
       should "fail with a 429 error" do
         user = create(:user)

--- a/test/functional/maintenance/user/email_notifications_controller_test.rb
+++ b/test/functional/maintenance/user/email_notifications_controller_test.rb
@@ -15,6 +15,12 @@ module Maintenance
             get_auth maintenance_user_email_notification_path(user_id: @user.id), @user
             assert_response :success
           end
+
+          should "render when force_authenticated is enabled" do
+            Danbooru.config.stubs(:force_authenticated?).returns(true)
+            get maintenance_user_email_notification_path(user_id: @user.id, sig: @sig)
+            assert_response :success
+          end
         end
 
         context "#destroy" do

--- a/test/functional/status_controller_test.rb
+++ b/test/functional/status_controller_test.rb
@@ -27,6 +27,12 @@ class StatusControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
 
+    should "work when force_authenticated is enabled" do
+      Danbooru.config.stubs(:force_authenticated?).returns(true)
+      get status_path
+      assert_response :success
+    end
+
     should "work when the database is down" do
       without_database do
         get status_path

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -446,6 +446,22 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         get new_user_path
         assert_response :success
       end
+
+      context "when signups are restricted to admins" do
+        setup do
+          Danbooru.config.stubs(:signups_restricted_to_admin?).returns(true)
+        end
+
+        should "deny access for anonymous users" do
+          get new_user_path
+          assert_response 403
+        end
+
+        should "allow access for admin users" do
+          get_auth new_user_path, create(:admin_user)
+          assert_response :success
+        end
+      end
     end
 
     context "create action" do
@@ -567,6 +583,26 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
           post_auth users_path, @user, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
 
           assert_response 403
+        end
+      end
+
+      context "when signups are restricted to admins" do
+        setup do
+          Danbooru.config.stubs(:signups_restricted_to_admin?).returns(true)
+        end
+
+        should "deny access for anonymous users" do
+          assert_no_difference("User.count") do
+            post users_path, params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+            assert_response 403
+          end
+        end
+
+        should "allow admin users to create accounts" do
+          post_auth users_path, create(:admin_user), params: { user: { name: "xxx", password: "xxxxx1", password_confirmation: "xxxxx1" }}
+
+          assert_redirected_to User.last
+          assert_equal("xxx", User.last.name)
         end
       end
 
@@ -854,6 +890,42 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         get_auth demote_user_path(@user), @user
 
         assert_response 403
+      end
+    end
+
+    context "secondary links" do
+      should "show the signup link to anonymous users when signups are not restricted" do
+        get users_path
+
+        assert_response :success
+        assert_select "a[href='#{new_user_path}']"
+      end
+
+      should "not show the signup link to admin users when signups are not restricted" do
+        get_auth users_path, create(:admin_user)
+
+        assert_response :success
+        assert_select "a[href='#{new_user_path}']", count: 0
+      end
+
+      context "when signups are restricted to admins" do
+        setup do
+          Danbooru.config.stubs(:signups_restricted_to_admin?).returns(true)
+        end
+
+        should "not show the signup link to anonymous users" do
+          get users_path
+
+          assert_response :success
+          assert_select "a[href='#{new_user_path}']", count: 0
+        end
+
+        should "show the signup link to admin users" do
+          get_auth users_path, create(:admin_user)
+
+          assert_response :success
+          assert_select "a[href='#{new_user_path}']"
+        end
       end
     end
   end


### PR DESCRIPTION
Implemented two config knobs:
- force_authenticated: only authenticated users can access any page (except ones related to login, password reset, 2fa verify etc.)
- signups_restricted_to_admin: turn off the ability to self-register. Only admin (or higher) can register users.

Both of these knobs are false by default, so the original behavior is preserved.

How it is done:
- The application controller gets a new gate `force_authenticated` that is executed for every page. With the `force_authenticated` config knob set to false, it is skipped. 

- To bypass the restriction for certain pages (health checks, password reset, 2fa verification), `skip_force_authenticated` is introduced and used in those views.

- UserPolicy is adjusted to either allow the anonymous users to sign up, or limit it to admin users, depending on the `signups_restricted_to_admin` config value.

- The templates mentioning Sign Up link are edited not to show it when `signups_restricted_to_admin` is set.

I am open to feedback and suggestions. 

Disclaimer: I had not worked with RoR before (I occasionally write in ruby, though), so I leveraged an LLM to produce this. I have read and understood every line in the change though. 

Upd: if this feature feels too big to merge (I understand that Danbooru itself has no plans to use it), then reverting the template changes might also be an option. 