### PR TITLE
Fix `bad_source` on slugless apple music URLs

### DIFF
--- a/app/logical/source/url/apple_music.rb
+++ b/app/logical/source/url/apple_music.rb
@@ -19,6 +19,13 @@ class Source::URL::AppleMusic < Source::URL
       @album_name = album_name
       @album_id = album_id.delete_prefix("id")
 
+    # https://music.apple.com/jp/album/mágico-catástrofe-digital-edition/1503302894
+    # https://music.apple.com/jp/album/track-name/1503302894?i=1503302895
+    # https://itunes.apple.com/us/album/disasterpiece/id1870255337
+    in "music" | "itunes", "apple.com", country_code, "album", album_id
+      @country_code = country_code
+      @album_id = album_id.delete_prefix("id")
+
     # https://music.apple.com/us/artist/mori-calliope/1536368549
     # https://itunes.apple.com/us/artist/mori-calliope/id1536368549
     # https://music.apple.com/us/artist/guchiry/1438071892
@@ -32,6 +39,11 @@ class Source::URL::AppleMusic < Source::URL
     # https://itunes.apple.com/album/mágico-catástrofe-digital-edition/id1503302894
     in "music" | "itunes", "apple.com", "album", album_name, album_id
       @album_name = album_name
+      @album_id = album_id.delete_prefix("id")
+
+    # https://music.apple.com/album/1503302894
+    # https://itunes.apple.com/album/id1503302894
+    in "music" | "itunes", "apple.com", "album", album_id
       @album_id = album_id.delete_prefix("id")
 
     # https://a1.mzstatic.com/us/r1000/0/Music113/v4/9e/22/c2/9e22c2fb-ef9c-b79b-7417-8bc714b85e51/4580547326338.jpg
@@ -63,8 +75,10 @@ class Source::URL::AppleMusic < Source::URL
   end
 
   def page_url
-    if album_id.present?
+    if album_id.present? && album_name.present?
       ["https://music.apple.com", country_code, "album", album_name, album_id].compact.join("/")
+    elsif album_id.present?
+      ["https://music.apple.com", country_code, "album", album_id].compact.join("/")
     end
   end
 

--- a/test/unit/source/extractor/apple_music_extractor_test.rb
+++ b/test/unit/source/extractor/apple_music_extractor_test.rb
@@ -13,6 +13,28 @@ module Source::Tests::Extractor
       )
     end
 
+    context "A slugless Apple Music album page" do
+      strategy_should_work(
+        "https://music.apple.com/jp/album/1503302894",
+        image_urls: %w[https://a1.mzstatic.com/us/r1000/0/Music113/v4/9e/22/c2/9e22c2fb-ef9c-b79b-7417-8bc714b85e51/4580547326338.jpg],
+        page_url: "https://music.apple.com/jp/album/1503302894",
+        tags: [],
+        dtext_artist_commentary_title: "マジコカタストロフィ - Digital Edition",
+        dtext_artist_commentary_desc: "",
+      )
+    end
+
+    context "A slugless countryless Apple Music album page" do
+      strategy_should_work(
+        "https://music.apple.com/album/1742535680",
+        image_urls: %w[https://a1.mzstatic.com/us/r1000/0/Music221/v4/1b/e7/ac/1be7accb-63a2-b95f-ad85-50bc6a60ee92/0198448234047_cover.jpg],
+        page_url: "https://music.apple.com/album/1742535680",
+        tags: [],
+        dtext_artist_commentary_title: "Grown-Up's Paradise - Single",
+        dtext_artist_commentary_desc: "",
+      )
+    end
+
     context "A direct mzstatic image thumb URL with a referer" do
       strategy_should_work(
         "https://is1-ssl.mzstatic.com/image/thumb/Music113/v4/9e/22/c2/9e22c2fb-ef9c-b79b-7417-8bc714b85e51/4580547326338.jpg/296x296bb.webp",

--- a/test/unit/source/url/apple_music_test.rb
+++ b/test/unit/source/url/apple_music_test.rb
@@ -11,8 +11,10 @@ module Source::Tests::URL
 
       should be_page_url(
         "https://music.apple.com/jp/album/mágico-catástrofe-digital-edition/1503302894",
+        "https://music.apple.com/jp/album/1503302894",
         "https://music.apple.com/jp/album/track-name/1503302894?i=1503302895",
         "https://music.apple.com/album/mágico-catástrofe-digital-edition/1503302894",
+        "https://music.apple.com/album/1742535680",
       )
 
       should be_profile_url(
@@ -26,6 +28,19 @@ module Source::Tests::URL
         album_name: "mágico-catástrofe-digital-edition",
         country_code: "jp",
         page_url: "https://music.apple.com/jp/album/mágico-catástrofe-digital-edition/1503302894",
+      )
+
+      should parse_url("https://music.apple.com/jp/album/1503302894").into(
+        site_name: "Apple Music",
+        album_id: "1503302894",
+        country_code: "jp",
+        page_url: "https://music.apple.com/jp/album/1503302894",
+      )
+
+      should parse_url("https://music.apple.com/album/1503302894").into(
+        site_name: "Apple Music",
+        album_id: "1503302894",
+        page_url: "https://music.apple.com/album/1503302894",
       )
 
       should parse_url("https://itunes.apple.com/jp/album/mágico-catástrofe-digital-edition/id1503302894").into(


### PR DESCRIPTION
Posts with an apple music source without a slug are getting `bad_source` applied to them because the parser was missing support for them. This adds support to the parser for them.