### PR TITLE
Fix NoMethodError in Xiaohongshu extractor when the source has no page URL

### DIFF
--- a/app/logical/source/extractor/xiaohongshu.rb
+++ b/app/logical/source/extractor/xiaohongshu.rb
@@ -85,6 +85,8 @@ class Source::Extractor::Xiaohongshu < Source::Extractor
   end
 
   memoize def page
+    return nil if page_url.blank?
+
     url = Danbooru::URL.parse(page_url).with(host: api_host).to_s
     http.cache(1.minute).parsed_get(url)
   end

--- a/test/unit/source/extractor/xiaohongshu_extractor_test.rb
+++ b/test/unit/source/extractor/xiaohongshu_extractor_test.rb
@@ -47,6 +47,16 @@ module Source::Tests::Extractor
       )
     end
 
+    context "A source with no page URL" do
+      should "not raise when fetching the page" do
+        source = Source::Extractor.find("https://ci.xiaohongshu.com/1000g00828idf6nofk05g5ohki5uk137o8beqcv8")
+
+        assert_nil(source.page_url)
+        assert_nil(source.send(:page))
+        assert_nothing_raised { source.profile_urls }
+      end
+    end
+
     context "A post with multiple images" do
       setup { skip "Xiaohongshu extractor requires credentials" unless Source::Extractor::Xiaohongshu.enabled? }
 

--- a/test/unit/source/extractor/xiaohongshu_extractor_test.rb
+++ b/test/unit/source/extractor/xiaohongshu_extractor_test.rb
@@ -48,13 +48,12 @@ module Source::Tests::Extractor
     end
 
     context "A source with no page URL" do
-      should "not raise when fetching the page" do
-        source = Source::Extractor.find("https://ci.xiaohongshu.com/1000g00828idf6nofk05g5ohki5uk137o8beqcv8")
-
-        assert_nil(source.page_url)
-        assert_nil(source.send(:page))
-        assert_nothing_raised { source.profile_urls }
-      end
+      strategy_should_work(
+        "https://ci.xiaohongshu.com/1000g00828idf6nofk05g5ohki5uk137o8beqcv8",
+        image_urls: %w[https://ci.xiaohongshu.com/1000g00828idf6nofk05g5ohki5uk137o8beqcv8],
+        media_files: [{ file_size: 561_862 }],
+        page_url: nil,
+      )
     end
 
     context "A post with multiple images" do
@@ -253,7 +252,7 @@ module Source::Tests::Extractor
 
     context "A post on rednote.com" do
       setup { skip "Xiaohongshu extractor requires credentials" unless Source::Extractor::Xiaohongshu.enabled? }
-    
+
       strategy_should_work(
         "https://www.rednote.com/explore/69d503c7000000001f007995?xsec_token=ABR7xc7xnydtN9Cqof7XXZDNQnk_bgI9LF753p_b_5IZg=",
         image_urls: %w[


### PR DESCRIPTION
Fixes #6473. When a Xiaohongshu source has no `page_url` (for example an image URL, or a URL that resolves to a profile without a post id), `Danbooru::URL.parse(page_url)` returns nil and `page` raised `NoMethodError` on `.with(host: api_host)`. Guard `page` to return nil when `page_url` is blank, matching how `hentai_foundry` handles the same case; `page_json` already falls back to `{}` from there.