### PR TITLE
sidebar: add optional pin/dock menu

### DIFF
--- a/app/components/sidebar_component.rb
+++ b/app/components/sidebar_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SidebarComponent < ApplicationComponent
+  attr_reader :dock_position
+
+  def initialize(sidebar_dock: nil)
+    @dock_position = Danbooru::JSON.parse(sidebar_dock)
+    @dock_position = "default" if !dock_position.in?(%w[default left right])
+    super
+  end
+end

--- a/app/components/sidebar_component/sidebar_component.html.erb
+++ b/app/components/sidebar_component/sidebar_component.html.erb
@@ -1,0 +1,35 @@
+<%= tag.aside id: "sidebar", class: "flex-0 break-words sm:order-2",
+            "x-data": "{ sidebar: new Danbooru.SidebarComponent($el) }",
+            "x-bind:data-dock": "sidebar.dock",
+            "data-dock": dock_position do %>
+  <div class="flex justify-end">
+    <%= render PopupMenuComponent.new(button_classes: "inactive-link", button_html: { title: "Sidebar position" }) do |menu| %>
+      <% menu.with_button do %>
+        <%= dock_position == "default" ? unsticky_icon : sticky_icon %>
+      <% end %>
+
+      <% menu.with_item do %>
+        <%= link_to "javascript:void(0)", "x-on:click": "sidebar.dock = 'default'",
+              class: ("font-bold" if dock_position == "default"), "x-bind:class": "{ 'font-bold': sidebar.dock === 'default' }" do %>
+          <%= unsticky_icon %> Default
+        <% end %>
+      <% end %>
+
+      <% menu.with_item do %>
+        <%= link_to "javascript:void(0)", "x-on:click": "sidebar.dock = 'left'",
+              class: ("font-bold" if dock_position == "left"), "x-bind:class": "{ 'font-bold': sidebar.dock === 'left' }" do %>
+          <%= dock_left_icon %> Pin to Left
+        <% end %>
+      <% end %>
+
+      <% menu.with_item do %>
+        <%= link_to "javascript:void(0)", "x-on:click": "sidebar.dock = 'right'",
+              class: ("font-bold" if dock_position == "right"), "x-bind:class": "{ 'font-bold': sidebar.dock === 'right' }" do %>
+          <%= dock_right_icon %> Pin to Right
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= content %>
+<% end %>

--- a/app/components/sidebar_component/sidebar_component.scss
+++ b/app/components/sidebar_component/sidebar_component.scss
@@ -1,0 +1,19 @@
+@media screen and (width >= 660px) {
+  #sidebar {
+    &[data-dock="left"],
+    &[data-dock="right"] {
+      position: sticky;
+      top: 0.75rem;
+      z-index: 1;
+      align-self: flex-start;
+      max-height: calc(100vh - 1.5rem);
+      overflow-y: auto;
+      scrollbar-gutter: stable;
+      padding-right: 0.5rem;
+    }
+
+    &[data-dock="right"] {
+      order: 1;
+    }
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -57,6 +57,7 @@ import PostVotesTooltipComponent from "../src/javascripts/post_votes_tooltip_com
 import PreviewSizeMenuComponent from "../src/javascripts/preview_size_menu_component.js";
 import RelatedTag from "../src/javascripts/related_tag.js";
 import Shortcuts from "../src/javascripts/shortcuts.js";
+import SidebarComponent from "../src/javascripts/sidebar_component.js";
 import TagCounter from "../src/javascripts/tag_counter.js";
 import TimeSeriesComponent from "../src/javascripts/time_series_component.js";
 import UploadPostComponent from "../src/javascripts/upload_post_component.js";
@@ -93,6 +94,7 @@ Danbooru.PostVotesTooltipComponent = PostVotesTooltipComponent;
 Danbooru.PreviewSizeMenuComponent = PreviewSizeMenuComponent;
 Danbooru.RelatedTag = RelatedTag;
 Danbooru.Shortcuts = Shortcuts;
+Danbooru.SidebarComponent = SidebarComponent;
 Danbooru.TagCounter = TagCounter;
 Danbooru.TimeSeriesComponent = TimeSeriesComponent;
 Danbooru.UploadPostComponent = UploadPostComponent;

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -63,6 +63,7 @@ export default class Autocomplete {
 
   initializeFieldAutocomplete() {
     this.$element.autocomplete({
+      appendTo: "body",
       select: (event, ui) => {
         if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
           this.insertCompletion(ui.item.value);
@@ -80,6 +81,7 @@ export default class Autocomplete {
 
   initializeTagAutocomplete() {
     this.$element.autocomplete({
+      appendTo: "body",
       select: (event, ui) => {
         if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
           this.insertCompletion(ui.item.value);

--- a/app/javascript/src/javascripts/sidebar_component.js
+++ b/app/javascript/src/javascripts/sidebar_component.js
@@ -1,0 +1,8 @@
+import AlpineCookieStorage from "./alpine_cookie_storage";
+
+export default class SidebarComponent {
+  constructor(container) {
+    this.$container = $(container);
+    this.dock = Alpine.$persist(this.$container.data("dock")).as("sidebar_dock").using(AlpineCookieStorage);
+  }
+}

--- a/app/views/layouts/sidebar.html.erb
+++ b/app/views/layouts/sidebar.html.erb
@@ -8,9 +8,9 @@
       <% end %>
 
       <div class="sidebar-container flex sm:flex-col gap-3">
-        <aside id="sidebar" class="flex-0 break-words sm:order-2">
+        <%= render SidebarComponent.new(sidebar_dock: cookies[:sidebar_dock]) do %>
           <%= yield :sidebar %>
-        </aside>
+        <% end %>
 
         <section id="content" class="flex-1 min-w-0 sm:order-1">
           <%= yield :content %>

--- a/test/components/sidebar_component_test.rb
+++ b/test/components/sidebar_component_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class SidebarComponentTest < ViewComponent::TestCase
+  context "The SidebarComponent" do
+    should "default to unpinned for a missing cookie" do
+      render_inline(SidebarComponent.new) { "sidebar content" }
+
+      assert_css("aside#sidebar[data-dock='default']")
+      assert_css("a.font-bold", text: "Default")
+    end
+
+    should "respect a valid dock cookie" do
+      render_inline(SidebarComponent.new(sidebar_dock: "left".to_json)) { "sidebar content" }
+
+      assert_css("aside#sidebar[data-dock='left']")
+      assert_css("a.font-bold", text: "Pin to Left")
+    end
+
+    should "ignore an invalid dock cookie" do
+      render_inline(SidebarComponent.new(sidebar_dock: "not-json")) { "sidebar content" }
+
+      assert_css("aside#sidebar[data-dock='default']")
+    end
+
+    should "render the given block as its content" do
+      render_inline(SidebarComponent.new) { "sidebar content" }
+
+      assert_text("sidebar content")
+    end
+  end
+end

--- a/test/system/sidebar_test.rb
+++ b/test/system/sidebar_test.rb
@@ -1,0 +1,15 @@
+require "application_system_test_case"
+
+class SidebarTest < ApplicationSystemTestCase
+  context "The sidebar" do
+    should "let a user pin it to the right and persist the choice" do
+      visit posts_path
+
+      find("aside#sidebar .popup-menu-button").click
+      click_link "Pin to Right"
+
+      assert_selector "aside#sidebar[data-dock='right']"
+      assert_equal "right", page.driver.browser.manage.cookie_named("sidebar_dock")[:value].delete('"')
+    end
+  end
+end


### PR DESCRIPTION
Lets users pin the sidebar to the left or right so it stays in view and scrolls independently of the main content, instead of scrolling away with the page. Mirrors the upload page's panel-docking pattern (cookie-persisted position, Alpine, PopupMenuComponent).

Related issue: #6360