### PR TITLE
Fix #5914: shrink oversized Edit Appeal reason text box

### DIFF
--- a/app/views/post_appeals/edit.html.erb
+++ b/app/views/post_appeals/edit.html.erb
@@ -7,7 +7,7 @@
     </p>
 
     <%= edit_form_for(@post_appeal) do |f| %>
-      <%= f.input :reason, as: :dtext, input_html: { autofocus: true } %>
+      <%= f.input :reason, as: :dtext, input_html: { autofocus: true }, wrapper_html: { class: "max-w-480px" } %>
       <%= f.button :submit, "Submit" %>
     <% end %>
   </div>


### PR DESCRIPTION
## Summary

The Edit Appeal reason field renders as a single-line `<input type="text">` (`PostAppeal` declares `dtext_attribute :reason, inline: true`), and the site's global simple_form CSS forces all text inputs to `width: 100%`. Since the Edit Appeal page is full-width, the 140-character reason field stretched across the whole page.

This constrains the field's wrapper to `max-w-480px` so it renders at a reasonable size instead.

This does not add a live character counter. That's tracked separately in #4519.