### PR TITLE
tooltips: fix user tooltip selector

### DIFF
--- a/app/javascript/src/javascripts/user_tooltips.js
+++ b/app/javascript/src/javascripts/user_tooltips.js
@@ -42,7 +42,7 @@ UserTooltip.on_show = async function (instance) {
   let $tooltip = $(instance.popper);
 
   // skip if tooltip has already been rendered.
-  if ($tooltip.has(".user-tooltip-body").length) {
+  if ($tooltip.has(".user-tooltip").length) {
     return;
   }
 


### PR DESCRIPTION
`.user-tooltip-body` doesn't exist and as far as I can tell never existed.