### PR TITLE
fix: restore long press on mobile

### DIFF
--- a/app/components/post_preview_component/post_preview_component.scss
+++ b/app/components/post_preview_component/post_preview_component.scss
@@ -3,6 +3,9 @@ article.post-preview {
     display: block;
     position: relative;
     margin: 0 auto;
+    // hammer.js defaults to none, disabling long press on mobile
+    // https://hammerjs.github.io/jsdoc/hammer.js.html
+    -webkit-touch-callout: default;
 
     .post-animation-icon {
       color: var(--preview-icon-color);
@@ -20,6 +23,9 @@ article.post-preview {
 .post-preview-image {
   max-width: 100%;
   height: auto;
+  // hammer.js defaults to none, disabling long press on mobile
+  // https://hammerjs.github.io/jsdoc/hammer.js.html
+  -webkit-touch-callout: default;
 }
 
 .post-preview-fit-fixed {


### PR DESCRIPTION
problem: I can't long press thumbnails on mobile to open new tab    
root cause: hammer.js defaults touch callout to `none` instead of `default`, disabling the whole thing    
solution: injects `webkit-touch-callout: default` to css component `post-preview-link` and `post-preview-link`    

how I tested: opens thumbnail on my mobile in dev local network
test result:    

https://github.com/user-attachments/assets/b94fa4e0-c746-45cf-9e8e-fcbcaa922a1e

