### PR TITLE
fix: support Naver Cafe modern article URLs and embedded videos

### DIFF
--- a/app/logical/source/extractor/naver_cafe.rb
+++ b/app/logical/source/extractor/naver_cafe.rb
@@ -8,11 +8,24 @@ class Source::Extractor::NaverCafe < Source::Extractor
     elsif parsed_url.image_url?
       [parsed_url.to_s]
     else
-      html_artist_commentary_desc&.parse_html&.css("img").to_a.pluck("src").filter_map do |src|
-        url = Source::URL.parse(src)
+      html_artist_commentary_desc&.parse_html&.css("img, script.__se_module_data").to_a.filter_map do |element|
+        if element.name == "img"
+          url = Source::URL.parse(element["src"])
 
-        # exclude stickers (ex: https://storep-phinf.pstatic.net/ogq_57f943581ff20/original_16.png?type=p50_50)
-        url.full_image_url if url.is_a?(Source::URL::NaverCafe)
+          # exclude stickers (ex: https://storep-phinf.pstatic.net/ogq_57f943581ff20/original_16.png?type=p50_50)
+          url.full_image_url if url.is_a?(Source::URL::NaverCafe)
+        else
+          video = (element["data-module"] || element["data-module-v2"]).to_s.parse_json
+          next unless video&.dig(:type) == "v2_video"
+
+          video_id = video.dig(:data, :vid)
+          inkey = video.dig(:data, :inkey)
+          next if video_id.blank? || inkey.blank?
+
+          api_url = "https://apis.naver.com/rmcnmv/rmcnmv/vod/play/v2.0/#{video_id}"
+          videos = http.cache(1.minute).parsed_get(api_url, params: { key: inkey })&.dig(:videos, :list).to_a
+          videos.max_by { |item| item.dig(:encodingOption, :width).to_i * item.dig(:encodingOption, :height).to_i }&.dig(:source)
+        end
       end
     end
   end

--- a/app/logical/source/url/naver_cafe.rb
+++ b/app/logical/source/url/naver_cafe.rb
@@ -34,7 +34,8 @@ class Source::URL::NaverCafe < Source::URL
       @full_image_url = Source::URL.parse(params[:src]).try(:full_image_url)
 
     # https://cafe.naver.com/ca-fe/cafes/29767250/articles/785
-    in "cafe", "naver.com", "ca-fe", "cafes", club_id, "articles", article_id
+    # https://cafe.naver.com/f-e/cafes/27842958/articles/20970846
+    in "cafe", "naver.com", ("ca-fe" | "f-e"), "cafes", club_id, "articles", article_id
       @club_id = club_id
       @article_id = article_id
 

--- a/app/logical/source/url/naver_cafe.rb
+++ b/app/logical/source/url/naver_cafe.rb
@@ -34,7 +34,7 @@ class Source::URL::NaverCafe < Source::URL
       @full_image_url = Source::URL.parse(params[:src]).try(:full_image_url)
 
     # https://cafe.naver.com/ca-fe/cafes/29767250/articles/785
-    # https://cafe.naver.com/f-e/cafes/27842958/articles/20970846
+    # https://cafe.naver.com/f-e/cafes/30487825/articles/787181
     in "cafe", "naver.com", ("ca-fe" | "f-e"), "cafes", club_id, "articles", article_id
       @club_id = club_id
       @article_id = article_id

--- a/test/unit/source/extractor/naver_cafe_extractor_test.rb
+++ b/test/unit/source/extractor/naver_cafe_extractor_test.rb
@@ -109,20 +109,18 @@ module Source::Tests::Extractor
 
     context "An /f-e/ article with an embedded video" do
       strategy_should_work(
-        "https://cafe.naver.com/f-e/cafes/27842958/articles/20970846",
+        "https://cafe.naver.com/f-e/cafes/30487825/articles/787181",
         image_urls: [
-          %r{\Ahttp://cafefiles\.naver\.net/.+\.png\z},
-          %r{\Ahttps://[^/]+-naver-vod\.pstatic\.net/.+\.mp4\?},
+          %r{\Ahttps://[^/]+-naver-vod\.(?:pstatic|akamaized)\.net/.+\.mp4\?},
         ],
         media_files: [
-          { file_size: 503_415 },
-          { file_size: 831_253 },
+          { file_size: 3_362_200 },
         ],
-        page_url: "https://cafe.naver.com/ca-fe/cafes/27842958/articles/20970846",
-        profile_urls: %w[https://cafe.naver.com/ca-fe/cafes/27842958/members/CywxX84zY2F5lhajKwDhEA5s3VFsUBi0v3Ukn9mFwzw https://cafe.naver.com/steamindiegame],
-        display_name: "이건또뭐라니",
+        page_url: "https://cafe.naver.com/ca-fe/cafes/30487825/articles/787181",
+        profile_urls: %w[https://cafe.naver.com/ca-fe/cafes/30487825/members/ka3gDYkoYjVkd95BS9avn4zvOB0Z3BiM1qz-NYC1FH0 https://cafe.naver.com/honkaistarrail],
+        display_name: "세레븐",
         username: nil,
-        dtext_artist_commentary_title: "내 골반이 멈추지 않는 탓일까 ㅜ.ㅜ(+영상",
+        dtext_artist_commentary_title: "마이데이 더빙해봤는데 봐주랍",
       )
     end
 

--- a/test/unit/source/extractor/naver_cafe_extractor_test.rb
+++ b/test/unit/source/extractor/naver_cafe_extractor_test.rb
@@ -107,6 +107,25 @@ module Source::Tests::Extractor
       )
     end
 
+    context "An /f-e/ article with an embedded video" do
+      strategy_should_work(
+        "https://cafe.naver.com/f-e/cafes/27842958/articles/20970846",
+        image_urls: [
+          %r{\Ahttp://cafefiles\.naver\.net/.+\.png\z},
+          %r{\Ahttps://[^/]+-naver-vod\.pstatic\.net/.+\.mp4\?},
+        ],
+        media_files: [
+          { file_size: 503_415 },
+          { file_size: 831_253 },
+        ],
+        page_url: "https://cafe.naver.com/ca-fe/cafes/27842958/articles/20970846",
+        profile_urls: %w[https://cafe.naver.com/ca-fe/cafes/27842958/members/CywxX84zY2F5lhajKwDhEA5s3VFsUBi0v3Ukn9mFwzw https://cafe.naver.com/steamindiegame],
+        display_name: "이건또뭐라니",
+        username: nil,
+        dtext_artist_commentary_title: "내 골반이 멈추지 않는 탓일까 ㅜ.ㅜ(+영상",
+      )
+    end
+
     context "An article with images as attachments" do
       strategy_should_work(
         "https://cafe.naver.com/ca-fe/cafes/29767250/articles/785",

--- a/test/unit/source/url/naver_cafe_url_test.rb
+++ b/test/unit/source/url/naver_cafe_url_test.rb
@@ -15,6 +15,7 @@ module Source::Tests::URL
 
       should be_page_url(
         "https://cafe.naver.com/ca-fe/cafes/29767250/articles/785",
+        "https://cafe.naver.com/f-e/cafes/27842958/articles/20970846",
         "https://m.cafe.naver.com/ca-fe/web/cafes/29767250/articles/785",
         "https://cafe.naver.com/ArticleRead.nhn?clubid=29767250&articleid=793",
         "https://m.cafe.naver.com/ArticleRead.nhn?clubid=29767250&articleid=793",

--- a/test/unit/source/url/naver_cafe_url_test.rb
+++ b/test/unit/source/url/naver_cafe_url_test.rb
@@ -15,7 +15,7 @@ module Source::Tests::URL
 
       should be_page_url(
         "https://cafe.naver.com/ca-fe/cafes/29767250/articles/785",
-        "https://cafe.naver.com/f-e/cafes/27842958/articles/20970846",
+        "https://cafe.naver.com/f-e/cafes/30487825/articles/787181",
         "https://m.cafe.naver.com/ca-fe/web/cafes/29767250/articles/785",
         "https://cafe.naver.com/ArticleRead.nhn?clubid=29767250&articleid=793",
         "https://m.cafe.naver.com/ArticleRead.nhn?clubid=29767250&articleid=793",


### PR DESCRIPTION
Fixes #6500.

This adds support for Naver Cafe article URLs using the newer `/f-e/cafes/:cafe_id/articles/:article_id` form. Recognizing these URLs allows the existing article API integration to retrieve the writer nickname and member profile again.

The extractor now also reads SmartEditor `script.__se_module_data` elements containing `v2_video` metadata, requests the available signed VOD variants, and returns the MP4 with the largest resolution alongside regular images. The regression test accepts both the Pstatic and Akamai CDN hosts returned in different regions.

Tests run in GitHub Codespaces:

- `bin/rails test test/unit/source/url/naver_cafe_url_test.rb` (5 tests, 5 assertions)
- `bin/rails test test/unit/source/extractor/naver_cafe_extractor_test.rb` (9 tests, 144 assertions)
