### PR TITLE
Fix unreadable version diffs for unrelated text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,17 +21,16 @@ module ApplicationHelper
   end
 
   def diff_name_html(this_name, other_name)
-    DiffBuilder.new(this_name, other_name, /./).build
+    DiffBuilder.new(old_text: other_name, new_text: this_name).name_html
   end
 
   def diff_body_html(record, other, field)
     if record.blank? || other.blank?
-      diff_record = other.presence || record
-      return h(diff_record[field]).gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>').html_safe
+      body = (other.presence || record)&.[](field)
+      return DiffBuilder.new(old_text: body, new_text: body).body_html
     end
 
-    pattern = /(?:<.+?>)|(?:\w+)|(?:[ \t]+)|(?:\r?\n)|(?:.+?)/
-    DiffBuilder.new(record[field], other[field], pattern).build
+    DiffBuilder.new(old_text: other[field], new_text: record[field]).body_html
   end
 
   def status_diff_html(record, type)

--- a/app/logical/diff_builder.rb
+++ b/app/logical/diff_builder.rb
@@ -1,70 +1,357 @@
 # frozen_string_literal: true
 
 require "diff/lcs/array" # diff-lcs gem
+require "erb"
+require "strscan"
 
 # Builds an HTML diff between two pieces of text.
 class DiffBuilder
-  attr_reader :this_text, :that_text, :pattern
+  WORD_TOKEN_PATTERN = /(?:\w\p{M}*)+/
+  HORIZONTAL_WHITESPACE_PATTERN = /[ \t]+/
+  GRAPHEME_PATTERN = /\X/
+  CLOSING_ANGLE_PATTERN = />/
+  TAG_TOKEN_PATTERN = /\A<.+?>\z/
+  CONTENT_GRAPHEME_PATTERN = /[\p{L}\p{M}\p{N}\p{S}]/
+  PARAGRAPH_MARK_HTML = '<span class="paragraph-mark">¶</span><br>'
+  DIFFED_PARAGRAPH_MARK_HTML = '<del><span class="paragraph-mark">¶</span></del><ins><span class="paragraph-mark">¶</span></ins><br>'
+  MAX_LCS_MIDDLE_TOKENS = 20_000
+  MAX_LCS_WORK = 1_000_000
+  MIN_CONTENT_COVERAGE_PERCENT = 10
 
-  def initialize(this_text, that_text, pattern)
-    @this_text = this_text
-    @that_text = that_text
-    @pattern = pattern
+  private_constant :WORD_TOKEN_PATTERN, :HORIZONTAL_WHITESPACE_PATTERN, :GRAPHEME_PATTERN, :CLOSING_ANGLE_PATTERN,
+                   :TAG_TOKEN_PATTERN, :CONTENT_GRAPHEME_PATTERN, :PARAGRAPH_MARK_HTML, :DIFFED_PARAGRAPH_MARK_HTML,
+                   :MAX_LCS_MIDDLE_TOKENS, :MAX_LCS_WORK, :MIN_CONTENT_COVERAGE_PERCENT
+
+  def initialize(old_text:, new_text:)
+    @old_text = untrusted_string(old_text)
+    @new_text = untrusted_string(new_text)
   end
 
-  def build
-    thisarr = this_text.scan(pattern)
-    otharr = that_text.scan(pattern)
+  def name_html
+    old_graphemes = old_text.scan(GRAPHEME_PATTERN)
+    new_graphemes = new_text.scan(GRAPHEME_PATTERN)
+    prefix, old_middle, new_middle, suffix = trim_common_edges(old_graphemes, new_graphemes)
 
-    cbo = Diff::LCS::ContextDiffCallbacks.new
-    diffs = otharr.diff(thisarr, cbo)
+    safe_html([
+      escape_text(prefix.join),
+      render_tagged_text("del", old_middle.join),
+      render_tagged_text("ins", new_middle.join),
+      escape_text(suffix.join),
+    ].join)
+  end
 
-    escape_html = ->(str) { str.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;") }
+  def body_html
+    old_tokens = tokenize_body(old_text)
+    new_tokens = tokenize_body(new_text)
+    prefix, old_middle, new_middle, suffix = trim_common_edges(old_tokens, new_tokens)
 
-    output = otharr
-    output.each { |q| q.replace(escape_html[q]) }
+    safe_html([
+      render_plain_body(prefix),
+      render_body_change(old_middle, new_middle),
+      render_plain_body(suffix),
+    ].join)
+  end
 
-    diffs.reverse_each do |hunk|
-      old_cr = hunk[0].try(:old_element)
-      new_cr = hunk[1].try(:new_element)
-      if old_cr && new_cr && old_cr.match?(/^\r?\n$/) && new_cr.match?(/^\r?\n$/)
-        hunk_position = hunk[0].old_position
-        output[hunk_position] = '<del><span class="paragraph-mark">¶</span></del><ins><span class="paragraph-mark">¶</span></ins><br>'
-        next
-      end
+  private
 
-      newchange = hunk.max { |a, b| a.old_position <=> b.old_position }
-      newstart = newchange.old_position
-      oldstart = hunk.min { |a, b| a.old_position <=> b.old_position }.old_position
+  attr_reader :old_text, :new_text
 
-      if newchange.action == "+"
-        output.insert(newstart, "</ins>")
-      end
+  def untrusted_string(text)
+    String.new(text.to_s)
+  end
 
-      hunk.reverse_each do |chg|
-        case chg.action
-        when "-"
-          oldstart = chg.old_position
-          output[chg.old_position] = '<span class="paragraph-mark">¶</span><br>' if chg.old_element.match(/^\r?\n$/)
-        when "+"
-          if chg.new_element.match(/^\r?\n$/)
-            output.insert(chg.old_position, '<span class="paragraph-mark">¶</span><br>')
-          else
-            output.insert(chg.old_position, escape_html[chg.new_element].to_s)
-          end
+  def tokenize_body(text)
+    text.each_line.flat_map do |line|
+      newline = line[/\r?\n\z/]
+      content = newline ? line.delete_suffix(newline) : line
+
+      tokenize_body_line(content) + Array(newline)
+    end
+  end
+
+  def tokenize_body_line(line)
+    scanner = StringScanner.new(line)
+    # Keep closing-tag searches monotonic so malformed "<" runs stay linear.
+    closing_scanner = StringScanner.new(line)
+    closing_position = next_closing_angle(closing_scanner)
+    tokens = []
+
+    until scanner.eos?
+      if scanner.peek(1) == "<"
+        minimum_closing_position = scanner.pos + 2
+        closing_position = next_closing_angle(closing_scanner) while closing_position && closing_position < minimum_closing_position
+
+        if closing_position
+          tokens << line.byteslice(scanner.pos, closing_position - scanner.pos + 1)
+          scanner.pos = closing_position + 1
+          next
         end
       end
 
-      if newchange.action == "+"
-        output.insert(newstart, "<ins>")
-      end
-
-      if hunk[0].action == "-"
-        output.insert((newstart == oldstart || newchange.action != "+") ? newstart + 1 : newstart, "</del>")
-        output.insert(oldstart, "<del>")
-      end
+      tokens << (scanner.scan(WORD_TOKEN_PATTERN) || scanner.scan(HORIZONTAL_WHITESPACE_PATTERN) || scanner.scan(GRAPHEME_PATTERN))
     end
 
-    output.join.gsub(/\r?\n/, '<span class="paragraph-mark">¶</span><br>').html_safe
+    tokens
+  end
+
+  def next_closing_angle(scanner)
+    return unless scanner.scan_until(CLOSING_ANGLE_PATTERN)
+
+    scanner.pos - 1
+  end
+
+  def trim_common_edges(old_units, new_units)
+    limit = [old_units.length, new_units.length].min
+    prefix_length = limit.times.find { |index| old_units[index] != new_units[index] } || limit
+    suffix_limit = limit - prefix_length
+    suffix_length = suffix_limit.times.find do |offset|
+      old_units[-offset - 1] != new_units[-offset - 1]
+    end || suffix_limit
+
+    old_middle_length = old_units.length - prefix_length - suffix_length
+    new_middle_length = new_units.length - prefix_length - suffix_length
+
+    [
+      old_units.first(prefix_length),
+      old_units[prefix_length, old_middle_length],
+      new_units[prefix_length, new_middle_length],
+      old_units.last(suffix_length),
+    ]
+  end
+
+  def render_body_change(old_tokens, new_tokens)
+    return render_token_change(old_tokens, new_tokens) if old_tokens.empty? || new_tokens.empty?
+
+    old_content_count, new_content_count, content_changed = compare_content(old_tokens, new_tokens)
+    unless within_lcs_budget?(old_tokens, new_tokens)
+      return render_format_only_diff(old_tokens, new_tokens) unless content_changed
+
+      return render_token_change(old_tokens, new_tokens)
+    end
+
+    hunks = Diff::LCS.diff(old_tokens, new_tokens, Diff::LCS::ContextDiffCallbacks.new)
+    low_coverage = content_changed && low_content_coverage?(old_content_count, new_content_count, hunks)
+    return render_token_change(old_tokens, new_tokens) if low_coverage
+
+    render_legacy_diff(old_tokens, hunks)
+  end
+
+  def within_lcs_budget?(old_tokens, new_tokens)
+    return false if old_tokens.length + new_tokens.length > MAX_LCS_MIDDLE_TOKENS
+
+    # diff-lcs work scales with the number of equal-token pairs.
+    new_frequencies = new_tokens.tally
+    matching_pairs = old_tokens.tally.sum do |token, count|
+      count * new_frequencies.fetch(token, 0)
+    end
+    log_factor = [old_tokens.length, new_tokens.length].min.bit_length
+    estimated_work = old_tokens.length + new_tokens.length + (matching_pairs * (1 + log_factor))
+
+    estimated_work <= MAX_LCS_WORK
+  end
+
+  def low_content_coverage?(old_content_count, new_content_count, hunks)
+    total_content = old_content_count + new_content_count
+    return false if total_content.zero?
+
+    deleted_content = hunks.sum do |hunk|
+      hunk.sum { |change| (change.action == "-") ? content_weight(change.old_element) : 0 }
+    end
+    matched_content = old_content_count - deleted_content
+
+    # Dice coverage is twice the matched content divided by both content lengths.
+    (200 * matched_content) < (MIN_CONTENT_COVERAGE_PERCENT * total_content)
+  end
+
+  def compare_content(old_tokens, new_tokens)
+    old_content = each_content_grapheme(old_tokens)
+    new_content = each_content_grapheme(new_tokens)
+    end_marker = Object.new
+    old_count = 0
+    new_count = 0
+    content_changed = false
+
+    loop do
+      old_grapheme = next_content_grapheme(old_content, end_marker)
+      new_grapheme = next_content_grapheme(new_content, end_marker)
+      old_finished = old_grapheme.equal?(end_marker)
+      new_finished = new_grapheme.equal?(end_marker)
+      break if old_finished && new_finished
+
+      old_count += 1 unless old_finished
+      new_count += 1 unless new_finished
+      content_changed = true unless old_grapheme == new_grapheme
+    end
+
+    [old_count, new_count, content_changed]
+  end
+
+  def each_content_grapheme(tokens)
+    # Yield graphemes instead of retaining an array for long single-token bodies.
+    Enumerator.new do |graphemes|
+      tokens.each do |token|
+        next if token.match?(TAG_TOKEN_PATTERN)
+
+        token.scan(GRAPHEME_PATTERN) do |grapheme|
+          graphemes << grapheme if grapheme.match?(CONTENT_GRAPHEME_PATTERN)
+        end
+      end
+    end
+  end
+
+  def next_content_grapheme(graphemes, end_marker)
+    graphemes.next
+  rescue StopIteration
+    end_marker
+  end
+
+  def content_weight(token)
+    return 0 if token.match?(TAG_TOKEN_PATTERN)
+
+    token.to_enum(:scan, GRAPHEME_PATTERN).count { |grapheme| grapheme.match?(CONTENT_GRAPHEME_PATTERN) }
+  end
+
+  def render_format_only_diff(old_tokens, new_tokens)
+    old_atoms = each_body_atom(old_tokens)
+    new_atoms = each_body_atom(new_tokens)
+    end_marker = Object.new
+    output = +""
+
+    loop do
+      old_format, old_content = next_content_segment(old_atoms, end_marker)
+      new_format, new_content = next_content_segment(new_atoms, end_marker)
+      output << render_format_change(old_format, new_format)
+      return output if old_content.equal?(end_marker) && new_content.equal?(end_marker)
+
+      output << escape_text(old_content)
+    end
+  end
+
+  def each_body_atom(tokens)
+    Enumerator.new do |atoms|
+      tokens.each do |token|
+        if token.match?(TAG_TOKEN_PATTERN) || !token.match?(CONTENT_GRAPHEME_PATTERN)
+          atoms << [:format, token]
+          next
+        end
+
+        token.scan(GRAPHEME_PATTERN) do |grapheme|
+          kind = grapheme.match?(CONTENT_GRAPHEME_PATTERN) ? :content : :format
+          atoms << [kind, grapheme]
+        end
+      end
+    end
+  end
+
+  def next_content_segment(atoms, end_marker)
+    format = []
+    kind, value = atoms.next
+
+    until kind == :content
+      format << value
+      kind, value = atoms.next
+    end
+
+    [format, value]
+  rescue StopIteration
+    [format, end_marker]
+  end
+
+  def render_format_change(old_format, new_format)
+    prefix, old_middle, new_middle, suffix = trim_common_edges(old_format, new_format)
+    newline_change = old_middle.one? && new_middle.one? && newline?(old_middle[0]) && newline?(new_middle[0])
+    change = newline_change ? DIFFED_PARAGRAPH_MARK_HTML : render_token_change(old_middle, new_middle)
+
+    render_plain_body(prefix) + change + render_plain_body(suffix)
+  end
+
+  def render_legacy_diff(old_tokens, hunks)
+    output = old_tokens.map { |token| escape_text(token) }
+
+    hunks.reverse_each do |hunk|
+      apply_legacy_hunk(output, hunk)
+    end
+
+    format_paragraphs(output.join)
+  end
+
+  def apply_legacy_hunk(output, hunk)
+    if newline_replacement?(hunk)
+      output[hunk[0].old_position] = DIFFED_PARAGRAPH_MARK_HTML
+      return
+    end
+
+    new_change = hunk.max_by(&:old_position)
+    new_start = new_change.old_position
+    old_start = hunk.min_by(&:old_position).old_position
+    has_insertion = new_change.action == "+"
+    output.insert(new_start, "</ins>") if has_insertion
+
+    hunk.reverse_each do |change|
+      old_start = apply_legacy_change(output, change, old_start)
+    end
+
+    output.insert(new_start, "<ins>") if has_insertion
+    return unless hunk[0].action == "-"
+
+    closing_position = (new_start == old_start || !has_insertion) ? new_start + 1 : new_start
+    output.insert(closing_position, "</del>")
+    output.insert(old_start, "<del>")
+  end
+
+  def apply_legacy_change(output, change, old_start)
+    if change.action == "-"
+      output[change.old_position] = PARAGRAPH_MARK_HTML if newline?(change.old_element)
+      change.old_position
+    elsif newline?(change.new_element)
+      output.insert(change.old_position, PARAGRAPH_MARK_HTML)
+      old_start
+    else
+      output.insert(change.old_position, escape_text(change.new_element))
+      old_start
+    end
+  end
+
+  def newline_replacement?(hunk)
+    old_element = hunk[0]&.old_element
+    new_element = hunk[1]&.new_element
+
+    old_element && new_element && newline?(old_element) && newline?(new_element)
+  end
+
+  def newline?(text)
+    ["\n", "\r\n"].include?(text)
+  end
+
+  def render_token_change(old_tokens, new_tokens)
+    render_tagged_body("del", old_tokens) + render_tagged_body("ins", new_tokens)
+  end
+
+  def render_tagged_body(tag_name, tokens)
+    return "" if tokens.empty?
+
+    "<#{tag_name}>#{render_plain_body(tokens)}</#{tag_name}>"
+  end
+
+  def render_plain_body(tokens)
+    format_paragraphs(escape_text(tokens.join))
+  end
+
+  def render_tagged_text(tag_name, value)
+    return "" if value.empty?
+
+    "<#{tag_name}>#{escape_text(value)}</#{tag_name}>"
+  end
+
+  def format_paragraphs(text)
+    text.gsub(/\r?\n/, PARAGRAPH_MARK_HTML)
+  end
+
+  def escape_text(text)
+    String.new(ERB::Util.html_escape(text))
+  end
+
+  def safe_html(output)
+    output.html_safe # rubocop:disable Rails/OutputSafety
   end
 end

--- a/test/functional/artist_commentary_versions_controller_test.rb
+++ b/test/functional/artist_commentary_versions_controller_test.rb
@@ -26,6 +26,20 @@ class ArtistCommentaryVersionsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
       end
 
+      should "render previous body comparisons from old to new" do
+        get artist_commentary_versions_path, params: { search: { post_id: @commentary.post_id }, type: "previous" }
+
+        assert_response :success
+        assert_body_diff_direction
+      end
+
+      should "render current body comparisons from old to new" do
+        get artist_commentary_versions_path, params: { search: { post_id: @commentary.post_id }, type: "current" }
+
+        assert_response :success
+        assert_body_diff_direction
+      end
+
       should respond_to_search.with { @other_versions + @versions.reverse }
       should respond_to_search(original_title: "translated").with { @versions[2] }
       should respond_to_search(text_matches: "traslated").with { @versions[1] }
@@ -45,6 +59,16 @@ class ArtistCommentaryVersionsControllerTest < ActionDispatch::IntegrationTest
         get artist_commentary_version_path(@commentary.versions.first), as: :json
         assert_response :success
       end
+    end
+  end
+
+  private
+
+  def assert_body_diff_direction
+    assert_select "p.commentary-body-section" do |paragraphs|
+      assert(paragraphs.any? do |paragraph|
+        paragraph.at_css("del")&.text == "traslated" && paragraph.at_css("ins")&.text == "translated"
+      end)
     end
   end
 end

--- a/test/functional/note_versions_controller_test.rb
+++ b/test/functional/note_versions_controller_test.rb
@@ -21,6 +21,20 @@ class NoteVersionsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
       end
 
+      should "render previous comparisons from old to new" do
+        get note_versions_path, params: { search: { note_id: @note.id }, type: "previous" }
+
+        assert_response :success
+        assert_body_diff_direction
+      end
+
+      should "render current comparisons from old to new" do
+        get note_versions_path, params: { search: { note_id: @note.id }, type: "current" }
+
+        assert_response :success
+        assert_body_diff_direction
+      end
+
       should respond_to_search.with { @versions.reverse }
       should respond_to_search(body_matches: "blah").with { @versions[1] }
       should respond_to_search(version: 1).with { @versions[0] }
@@ -40,6 +54,16 @@ class NoteVersionsControllerTest < ActionDispatch::IntegrationTest
         get note_version_path(@note.versions.first), as: :json
         assert_response :success
       end
+    end
+  end
+
+  private
+
+  def assert_body_diff_direction
+    assert_select "td.diff-body" do |cells|
+      assert(cells.any? do |cell|
+        cell.at_css("del")&.text == "blah" && cell.at_css("ins")&.text == "1 2 3"
+      end)
     end
   end
 end

--- a/test/functional/wiki_page_versions_controller_test.rb
+++ b/test/functional/wiki_page_versions_controller_test.rb
@@ -5,7 +5,7 @@ class WikiPageVersionsControllerTest < ActionDispatch::IntegrationTest
     setup do
       @user = create(:user)
       @builder = create(:builder_user)
-      as(@user) { @wiki_page = create(:wiki_page) }
+      as(@user) { @wiki_page = create(:wiki_page, title: "old_name_x") }
       as(@builder) { @wiki_page.update(title: "supreme", body: "blah", other_names: ["not_this"]) }
       as(@user) { @wiki_page.update(body: "blah blah") }
     end
@@ -18,6 +18,20 @@ class WikiPageVersionsControllerTest < ActionDispatch::IntegrationTest
       should "render" do
         get wiki_page_versions_path
         assert_response :success
+      end
+
+      should "render previous title comparisons from old to new" do
+        get wiki_page_versions_path, params: { search: { wiki_page_id: @wiki_page.id }, type: "previous" }
+
+        assert_response :success
+        assert_title_diff_direction
+      end
+
+      should "render current title comparisons from old to new" do
+        get wiki_page_versions_path, params: { search: { wiki_page_id: @wiki_page.id }, type: "current" }
+
+        assert_response :success
+        assert_title_diff_direction
       end
 
       should respond_to_search.with { @versions.reverse }
@@ -56,6 +70,16 @@ class WikiPageVersionsControllerTest < ActionDispatch::IntegrationTest
         get diff_wiki_page_versions_path
         assert_redirected_to wiki_pages_path
       end
+    end
+  end
+
+  private
+
+  def assert_title_diff_direction
+    assert_select "td.diff-body" do |cells|
+      assert(cells.any? do |cell|
+        cell.at_css("del")&.text == "old_name_x" && cell.at_css("ins")&.text == "supreme"
+      end)
     end
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -33,5 +33,24 @@ class ApplicationHelperTest < ActionView::TestCase
         assert_match(/#{Regexp.quote(text)}/, link)
       end
     end
+
+    context "diff helpers" do
+      should "pass names and body fields in old-to-new order" do
+        assert_equal("foo_<del>old</del><ins>new</ins>", diff_name_html("foo_new", "foo_old"))
+        assert_equal(
+          "<del>old</del><ins>new</ins> body",
+          diff_body_html({ body: "new body" }, { body: "old body" }, :body),
+        )
+      end
+
+      should "render a missing comparison record without change tags" do
+        html = diff_body_html({ body: %{<b>&"'\n}.html_safe }, nil, :body)
+
+        assert_equal("&lt;b&gt;&amp;&quot;&#39;<span class=\"paragraph-mark\">¶</span><br>", html)
+        assert_predicate(html, :html_safe?)
+        assert_equal("old body", diff_body_html(nil, { body: "old body" }, :body))
+        assert_equal("", diff_body_html(nil, nil, :body))
+      end
+    end
   end
 end

--- a/test/unit/diff_builder_test.rb
+++ b/test/unit/diff_builder_test.rb
@@ -1,0 +1,324 @@
+require "test_helper"
+require "diff/lcs/array"
+
+class DiffBuilderTest < ActiveSupport::TestCase
+  context "DiffBuilder" do
+    should "only expose the name and body HTML entry points" do
+      builder = DiffBuilder.new(old_text: "old", new_text: "new")
+
+      assert_respond_to(builder, :name_html)
+      assert_respond_to(builder, :body_html)
+      assert_not_respond_to(builder, :build)
+      assert_not_respond_to(builder, :pattern)
+    end
+
+    context "name diffs" do
+      should "render the smallest single changed middle" do
+        html = DiffBuilder.new(old_text: "foo_qux_baz", new_text: "foo_bar_baz").name_html
+
+        assert_equal("foo_<del>qux</del><ins>bar</ins>_baz", html)
+        assert_predicate(html, :html_safe?)
+      end
+
+      should "render unrelated names as one replacement" do
+        html = DiffBuilder.new(old_text: "akiya_akira_(full_accel)", new_text: "neckwrecker").name_html
+
+        assert_equal("<del>akiya_akira_(full_accel)</del><ins>neckwrecker</ins>", html)
+      end
+
+      should "handle empty names as additions and removals" do
+        assert_equal("<ins>new</ins>", DiffBuilder.new(old_text: nil, new_text: "new").name_html)
+        assert_equal("<del>old</del>", DiffBuilder.new(old_text: "old", new_text: nil).name_html)
+        assert_equal("", DiffBuilder.new(old_text: nil, new_text: nil).name_html)
+      end
+
+      should "compare grapheme clusters without normalizing Unicode" do
+        html = DiffBuilder.new(old_text: "A👩‍💻e\u0301Z", new_text: "A👨‍💻éZ").name_html
+
+        assert_equal("A<del>👩‍💻e\u0301</del><ins>👨‍💻é</ins>Z", html)
+      end
+
+      should "escape untrusted and pre-marked-safe names" do
+        text = %{<tag>&"'}.html_safe
+        html = DiffBuilder.new(old_text: text, new_text: text).name_html
+
+        assert_equal("&lt;tag&gt;&amp;&quot;&#39;", html)
+        assert_predicate(html, :html_safe?)
+      end
+    end
+
+    context "body diffs" do
+      should "render exact additions, removals, and replacements" do
+        assert_equal(
+          "hello <ins>brave </ins>world",
+          DiffBuilder.new(old_text: "hello world", new_text: "hello brave world").body_html,
+        )
+        assert_equal(
+          "hello <del>brave </del>world",
+          DiffBuilder.new(old_text: "hello brave world", new_text: "hello world").body_html,
+        )
+        assert_equal(
+          "hello <del>black</del><ins>white</ins> cat",
+          DiffBuilder.new(old_text: "hello black cat", new_text: "hello white cat").body_html,
+        )
+      end
+
+      should "render local CJK changes as a single replacement" do
+        assert_equal(
+          "今日は<del>晴れ</del><ins>雨</ins>です",
+          DiffBuilder.new(old_text: "今日は晴れです", new_text: "今日は雨です").body_html,
+        )
+        assert_equal(
+          "今天<del>晴天</del><ins>下雨</ins>",
+          DiffBuilder.new(old_text: "今天晴天", new_text: "今天下雨").body_html,
+        )
+        assert_equal(
+          "<del>ネコ</del><ins>イヌ</ins>です",
+          DiffBuilder.new(old_text: "ネコです", new_text: "イヌです").body_html,
+        )
+        assert_equal(
+          "<del>검은</del><ins>흰</ins> 고양이",
+          DiffBuilder.new(old_text: "검은 고양이", new_text: "흰 고양이").body_html,
+        )
+      end
+
+      should "keep combining marks and emoji sequences intact" do
+        html = DiffBuilder.new(
+          old_text: "Use cafe\u0301 👩‍💻 now",
+          new_text: "Use cafe\u0300 👨‍💻 now",
+        ).body_html
+
+        assert_equal("Use <del>cafe\u0301 👩‍💻</del><ins>cafe\u0300 👨‍💻</ins> now", html)
+      end
+
+      should "preserve separate edits around matching content" do
+        old_text = "Alpha old first. This middle sentence stays unchanged. Omega old last."
+        new_text = "Alpha new first. This middle sentence stays unchanged. Omega new last."
+
+        assert_equal(
+          "Alpha <del>old</del><ins>new</ins> first. This middle sentence stays unchanged. Omega <del>old</del><ins>new</ins> last.",
+          DiffBuilder.new(old_text:, new_text:).body_html,
+        )
+      end
+
+      should "render full additions, removals, and unchanged paragraphs" do
+        paragraph = "same\nbody"
+        rendered_paragraph = "same<span class=\"paragraph-mark\">¶</span><br>body"
+
+        assert_equal("<ins>new</ins>", DiffBuilder.new(old_text: nil, new_text: "new").body_html)
+        assert_equal("<del>old</del>", DiffBuilder.new(old_text: "old", new_text: nil).body_html)
+        assert_equal(rendered_paragraph, DiffBuilder.new(old_text: paragraph, new_text: paragraph).body_html)
+      end
+
+      should "keep a local edit in an eighty thousand character body" do
+        prefix = "same " * 8_000
+        suffix = " tail" * 7_999
+        old_text = "#{prefix}old#{suffix}"
+        new_text = "#{prefix}new#{suffix}"
+
+        assert_equal(
+          "#{prefix}<del>old</del><ins>new</ins>#{suffix}",
+          DiffBuilder.new(old_text:, new_text:).body_html,
+        )
+      end
+
+      should "handle a long malformed angle-bracket sequence" do
+        old_text = "<" * 79_999
+        new_text = "#{old_text}x"
+
+        assert_equal(
+          "#{"&lt;" * 79_999}<ins>x</ins>",
+          DiffBuilder.new(old_text:, new_text:).body_html,
+        )
+      end
+
+      should "preserve edge-case angle-bracket tokenization" do
+        old_text = "<> <<> <><a> tail"
+        new_text = "<> <<> <><b> tail"
+
+        assert_equal(
+          "&lt;&gt; &lt;&lt;&gt; <del>&lt;&gt;&lt;a&gt;</del><ins>&lt;&gt;&lt;b&gt;</ins> tail",
+          DiffBuilder.new(old_text:, new_text:).body_html,
+        )
+      end
+
+      should "stream content analysis for one long token" do
+        old_text = "#{"a" * 79_999}x"
+        new_text = "#{"a" * 79_999}y"
+
+        assert_equal(
+          "<del>#{old_text}</del><ins>#{new_text}</ins>",
+          DiffBuilder.new(old_text:, new_text:).body_html,
+        )
+      end
+
+      should "render issue 4788 as one unrelated replacement" do
+        old_text = "家主が怖い番組を観ていて怖く出られなくなった幽霊さん。"
+        new_text = "Miss Ghost, unable to show herself because the house owner is watching a scary TV program."
+
+        assert_equal(
+          "<del>#{old_text}</del><ins>#{new_text}</ins>",
+          DiffBuilder.new(old_text:, new_text:).body_html,
+        )
+      end
+
+      should "exclude markup and underscores but count symbols as content" do
+        old_structural_text = "alpha _ <b> beta"
+        new_structural_text = "gamma _ <b> delta"
+        old_symbol_text = "甲乙👩‍💻丙"
+        new_symbol_text = "丁戊👩‍💻己"
+
+        assert_equal(
+          "<del>alpha _ &lt;b&gt; beta</del><ins>gamma _ &lt;b&gt; delta</ins>",
+          DiffBuilder.new(old_text: old_structural_text, new_text: new_structural_text).body_html,
+        )
+        assert_not_equal(
+          replacement_html(old_symbol_text, new_symbol_text),
+          DiffBuilder.new(old_text: old_symbol_text, new_text: new_symbol_text).body_html,
+        )
+      end
+
+      should "use a strict ten percent content coverage threshold" do
+        old_at_threshold = "甲乙丙丁戊己庚辛壬癸"
+        old_below_threshold = "甲乙丙丁戊己庚辛壬癸亥"
+        new_text = "子丑寅卯辰己午未申酉"
+        wholesale_at_threshold = replacement_html(old_at_threshold, new_text)
+
+        assert_not_equal(wholesale_at_threshold, DiffBuilder.new(old_text: old_at_threshold, new_text:).body_html)
+        assert_equal(
+          replacement_html(old_below_threshold, new_text),
+          DiffBuilder.new(old_text: old_below_threshold, new_text:).body_html,
+        )
+      end
+
+      should "send formatting-only changes through the legacy renderer" do
+        assert_equal(
+          "hello<del><span class=\"paragraph-mark\">¶</span></del><ins><span class=\"paragraph-mark\">¶</span></ins><br>world",
+          DiffBuilder.new(old_text: "hello\nworld", new_text: "hello\r\nworld").body_html,
+        )
+        assert_equal(
+          "<del>hellohelloworld<span class=\"paragraph-mark\">¶</span><br></del>world",
+          DiffBuilder.new(old_text: "hello\nworld", new_text: "helloworld").body_html,
+        )
+        assert_equal(
+          "hello<span class=\"paragraph-mark\">¶</span><br><ins><span class=\"paragraph-mark\">¶</span><br></ins>world",
+          DiffBuilder.new(old_text: "hello\nworld", new_text: "hello\n\nworld").body_html,
+        )
+        assert_equal(
+          "hello<del>,</del><ins>!</ins>world",
+          DiffBuilder.new(old_text: "hello,world", new_text: "hello!world").body_html,
+        )
+        assert_equal(
+          "hello<del> </del><ins>\t</ins>world",
+          DiffBuilder.new(old_text: "hello world", new_text: "hello\tworld").body_html,
+        )
+      end
+
+      should "keep formatting-only changes detailed above the LCS budget" do
+        old_text = "#{"a " * 10_001}z"
+        new_text = "#{"a\t" * 10_001}z"
+        expected = "#{"a<del> </del><ins>\t</ins>" * 10_001}z"
+        old_lines = "#{"a\n" * 10_001}z"
+        new_lines = "#{"a\r\n" * 10_001}z"
+        diffed_line = "a<del><span class=\"paragraph-mark\">¶</span></del><ins><span class=\"paragraph-mark\">¶</span></ins><br>"
+
+        Diff::LCS.expects(:diff).never
+        assert_equal(expected, DiffBuilder.new(old_text:, new_text:).body_html)
+        assert_equal("#{diffed_line * 10_001}z", DiffBuilder.new(old_text: old_lines, new_text: new_lines).body_html)
+      end
+
+      should "keep formatting-only changes detailed above the LCS work budget" do
+        repeated_format = "<x>" * 400
+        old_format = "#{repeated_format}<old&>"
+        new_format = "_\"'#{repeated_format}"
+        old_text = ActiveSupport::SafeBuffer.new("a#{old_format}z")
+        new_text = ActiveSupport::SafeBuffer.new("a#{new_format}z")
+        expected = "a<del>#{"&lt;x&gt;" * 400}&lt;old&amp;&gt;</del><ins>_&quot;&#39;#{"&lt;x&gt;" * 400}</ins>z"
+
+        Diff::LCS.expects(:diff).never
+        assert_equal(expected, DiffBuilder.new(old_text:, new_text:).body_html)
+      end
+
+      should "escape all body paths even for a SafeBuffer input" do
+        old_text = %{<b>&"'}.html_safe
+        new_text = %{<script>&"'}.html_safe
+        html = DiffBuilder.new(old_text:, new_text:).body_html
+
+        assert_equal("<del>&lt;b&gt;</del><ins>&lt;script&gt;</ins>&amp;&quot;&#39;", html)
+        assert_predicate(html, :html_safe?)
+      end
+
+      should "run LCS only once for a detailed diff" do
+        old_tokens = ["old", " ", "anchor", " ", "old"]
+        new_tokens = ["new", " ", "anchor", " ", "new"]
+        diffs = Diff::LCS.diff(old_tokens, new_tokens, Diff::LCS::ContextDiffCallbacks.new)
+        Diff::LCS.expects(:diff).once.returns(diffs)
+
+        assert_equal(
+          "<del>old</del><ins>new</ins> anchor <del>old</del><ins>new</ins>",
+          DiffBuilder.new(old_text: old_tokens.join, new_text: new_tokens.join).body_html,
+        )
+      end
+
+      should "run LCS once before replacing unrelated content" do
+        diffs = Diff::LCS.diff(["old"], ["new"], Diff::LCS::ContextDiffCallbacks.new)
+        Diff::LCS.expects(:diff).once.returns(diffs)
+
+        assert_equal(
+          "<del>old</del><ins>new</ins>",
+          DiffBuilder.new(old_text: "old", new_text: "new").body_html,
+        )
+      end
+
+      should "allow work exactly at the LCS budget and reject work above it" do
+        # 5,001 + 5,003 + (265² + 3×163) × (1 + 13) = 1,000,000.
+        old_text = repeated_tag_text(total: 5_001, x_count: 265, y_count: 3, side: "old")
+        new_at_budget = repeated_tag_text(total: 5_003, x_count: 265, y_count: 163, side: "new")
+        new_over_budget = repeated_tag_text(total: 5_003, x_count: 265, y_count: 164, side: "new")
+
+        assert_not_equal(replacement_html(old_text, new_at_budget), DiffBuilder.new(old_text:, new_text: new_at_budget).body_html)
+
+        Diff::LCS.expects(:diff).never
+        assert_equal(
+          replacement_html(old_text, new_over_budget),
+          DiffBuilder.new(old_text:, new_text: new_over_budget).body_html,
+        )
+      end
+
+      should "allow twenty thousand changed tokens and reject more" do
+        old_text = anchored_tag_text(total: 10_000, side: "old")
+        new_at_budget = anchored_tag_text(total: 10_000, side: "new")
+        new_over_budget = anchored_tag_text(total: 10_001, side: "new")
+
+        assert_not_equal(replacement_html(old_text, new_at_budget), DiffBuilder.new(old_text:, new_text: new_at_budget).body_html)
+
+        Diff::LCS.expects(:diff).never
+        assert_equal(
+          replacement_html(old_text, new_over_budget),
+          DiffBuilder.new(old_text:, new_text: new_over_budget).body_html,
+        )
+      end
+    end
+  end
+
+  private
+
+  def replacement_html(old_text, new_text)
+    "<del>#{ERB::Util.html_escape(old_text)}</del><ins>#{ERB::Util.html_escape(new_text)}</ins>"
+  end
+
+  def repeated_tag_text(total:, x_count:, y_count:, side:)
+    unique_count = total - x_count - y_count - 2
+    (["<#{side}-start>"] + Array.new(x_count, "<x>") + Array.new(y_count, "<y>") +
+      Array.new(unique_count) { |index| "<#{side}-#{index}>" } + ["<#{side}-end>"]).join
+  end
+
+  def anchored_tag_text(total:, side:)
+    unique_count = total - 3
+    before_count = unique_count / 2
+    after_count = unique_count - before_count
+
+    (["<#{side}-start>"] + Array.new(before_count) { |index| "<#{side}-before-#{index}>" } + ["<anchor>"] +
+      Array.new(after_count) { |index| "<#{side}-after-#{index}>" } + ["<#{side}-end>"]).join
+  end
+end


### PR DESCRIPTION
This PR supersedes #6418 with a rewrite that fixes #4788 while preserving detailed diffs for related edits.

- Render name changes by Unicode grapheme cluster.
- Tokenize body text semantically and keep common surrounding context.
- Replace unrelated changed sections as a whole instead of matching incidental characters.
- Bound `Diff::LCS` work and use a linear fallback for oversized changes.
- Escape all input consistently, including strings already marked as HTML safe.

Differences from #6418:

#6418 adds CJK-specific token classes and a full-string Levenshtein pass before running LCS. The CJK classes retain the existing character-level behavior, while Levenshtein adds quadratic work.

This implementation instead:

- uses language-independent grapheme and content coverage rules;
- runs LCS at most once and only within deterministic resource limits;
- derives relevance from the resulting ordered matches;
- preserves formatting-only diffs without LCS when over budget;
- exposes only explicit `name_html` and `body_html` operations.