### PR TITLE
SiteCredential: remove hardcoded credential IDs

### DIFF
--- a/app/logical/source/site.rb
+++ b/app/logical/source/site.rb
@@ -117,6 +117,11 @@ module Source
       option(*args, **params, kind: :credential, &block)
     end
 
+    # @return [Array<OptionDefinition>] The credentials defined for this site.
+    def credentials
+      options.values.select { |option| option.kind == :credential }
+    end
+
     # A class for defining an option or credential used by a site. Option definitions have a name, type (string,
     # boolean, etc), default value, a help string, and a kind (whether they're a normal setting or a credential).
     class OptionDefinition

--- a/app/logical/source/url/art_street.rb
+++ b/app/logical/source/url/art_street.rb
@@ -2,7 +2,7 @@
 
 class Source::URL::ArtStreet < Source::URL
   site "ArtStreet", url: "https://medibang.com", domains: %w[medibang.com cloudfront.net] do
-    credential :session_cookie, help: "Your 'MSID' cookie. Go to your profile settings and set your age to 18+ to view R-18 works."
+    credential :session_cookie, default: Danbooru.config.art_street_session_cookie, help: "Your 'MSID' cookie. Go to your profile settings and set your age to 18+ to view R-18 works."
   end
 
   attr_reader :picture_id, :book_id, :full_image_url, :author_id, :user_id

--- a/app/logical/source/url/behance.rb
+++ b/app/logical/source/url/behance.rb
@@ -3,7 +3,7 @@
 # @see Source::Extractor::Behance
 class Source::URL::Behance < Source::URL
   site "Behance", url: "https://www.behance.net" do
-    credential :session_cookie, help: %{Your Behance `iat0` cookie.}
+    credential :session_cookie, default: Danbooru.config.behance_session_cookie, help: %{Your Behance `iat0` cookie.}
   end
 
   RESERVED_USERNAMES = %w[about assets auth blog careers entries galleries hc hire misc joblist pro search services updates]

--- a/app/logical/source/url/blogger.rb
+++ b/app/logical/source/url/blogger.rb
@@ -5,7 +5,7 @@ class Source::URL::Blogger < Source::URL
     url "https://blogger.com"
     domains %w[blogger.com blogspot.com googleusercontent.com]
 
-    credential :api_key, help: %{Your Blogger API key. Go to https://developers.google.com/blogger/docs/3.0/using#APIKey to create an API key.}
+    credential :api_key, default: Danbooru.config.blogger_api_key, help: %{Your Blogger API key. Go to https://developers.google.com/blogger/docs/3.0/using#APIKey to create an API key.}
   end
 
   RESERVED_SUBDOMAINS = %w[bp cdn www]

--- a/app/logical/source/url/ci_en.rb
+++ b/app/logical/source/url/ci_en.rb
@@ -2,7 +2,7 @@
 
 class Source::URL::CiEn < Source::URL
   site "Ci-En", url: "https://ci-en.net", domains: %w[ci-en.jp ci-en.net dlsite.com] do
-    credential :session_cookie, help: %{Your Ci-En `ci_en_session` cookie.}
+    credential :session_cookie, default: Danbooru.config.ci_en_session_cookie, help: %{Your Ci-En `ci_en_session` cookie.}
   end
 
   attr_reader :creator_id, :article_id, :image_type

--- a/app/logical/source/url/deviant_art.rb
+++ b/app/logical/source/url/deviant_art.rb
@@ -20,11 +20,11 @@ module Source
       url "https://www.deviantart.com"
       domains %w[deviantart.com deviantart.net fav.me sta.sh artworkfolio.com daportfolio.com wixmp.com]
 
-      credential :client_id, help: %{Your DeviantArt client ID. Go to https://www.deviantart.com/developers/ to create a new application.}
-      credential :client_secret, help: %{Your DeviantArt client secret. Go to https://www.deviantart.com/developers/ to create a new application.}
-      credential :auth, help: %{Your DeviantArt `auth` cookie.}
-      credential :auth_secure, help: %{Your DeviantArt `auth_secure` cookie.}
-      credential :userinfo, help: %{Your DeviantArt `userinfo` cookie.}
+      credential :client_id, default: Danbooru.config.deviantart_client_id, help: %{Your DeviantArt client ID. Go to https://www.deviantart.com/developers/ to create a new application.}
+      credential :client_secret, default: Danbooru.config.deviantart_client_secret, help: %{Your DeviantArt client secret. Go to https://www.deviantart.com/developers/ to create a new application.}
+      credential :auth, default: Danbooru.config.deviantart_auth_cookie, help: %{Your DeviantArt `auth` cookie.}
+      credential :auth_secure, default: Danbooru.config.deviantart_auth_secure_cookie, help: %{Your DeviantArt `auth_secure` cookie.}
+      credential :userinfo, default: Danbooru.config.deviantart_userinfo_cookie, help: %{Your DeviantArt `userinfo` cookie.}
     end
 
     extractors { [Source::Extractor::DeviantArt, Source::Extractor::URLShortener] }

--- a/app/logical/source/url/fantia.rb
+++ b/app/logical/source/url/fantia.rb
@@ -7,7 +7,7 @@
 
 class Source::URL::Fantia < Source::URL
   site "Fantia", url: "https://fantia.jp" do
-    credential :session_id, help: %{Your Fantia `_session_id` cookie.}
+    credential :session_id, default: Danbooru.config.fantia_session_id, help: %{Your Fantia `_session_id` cookie.}
   end
 
   attr_reader :full_image_url, :candidate_full_image_urls, :download_url, :fanclub_id, :username, :post_id, :product_id

--- a/app/logical/source/url/furaffinity.rb
+++ b/app/logical/source/url/furaffinity.rb
@@ -5,8 +5,8 @@ class Source::URL::Furaffinity < Source::URL
     url "https://www.furaffinity.net"
     domains %w[furaffinity.net fxraffinity.net fxfuraffinity.net vxfuraffinity.net xfuraffinity.net]
 
-    credential :cookie_a, help: %{Your Furaffinity `cookie_a` cookie. Warning: logging out of Furaffinity will invalidate these cookies.}
-    credential :cookie_b, help: %{Your Furaffinity `cookie_b` cookie. Warning: logging out of Furaffinity will invalidate these cookies.}
+    credential :cookie_a, default: Danbooru.config.furaffinity_cookie_a, help: %{Your Furaffinity `cookie_a` cookie. Warning: logging out of Furaffinity will invalidate this cookie.}
+    credential :cookie_b, default: Danbooru.config.furaffinity_cookie_b, help: %{Your Furaffinity `cookie_b` cookie. Warning: logging out of Furaffinity will invalidate this cookie.}
   end
 
   attr_reader :work_id, :username, :filename

--- a/app/logical/source/url/gelbooru.rb
+++ b/app/logical/source/url/gelbooru.rb
@@ -3,13 +3,13 @@
 # This covers all Gelbooru-based sites.
 class Source::URL::Gelbooru < Source::URL
   site "Gelbooru", url: "https://gelbooru.com" do
-    credential :user_id, help: %{Your Gelbooru user ID.}
-    credential :api_key, help: %{Your Gelbooru API key. Go to https://gelbooru.com/index.php?page=account&s=options to find your API key.}
+    credential :user_id, default: Danbooru.config.gelbooru_user_id, help: %{Your Gelbooru user ID.}
+    credential :api_key, default: Danbooru.config.gelbooru_api_key, help: %{Your Gelbooru API key. Go to https://gelbooru.com/index.php?page=account&s=options to find your API key.}
   end
 
   site "Rule34.xxx", url: "https://rule34.xxx" do
-    credential :user_id, help: %{Your Rule34.xxx user ID.}
-    credential :api_key, help: %{Your Rule34.xxx API key. Go to https://rule34.xxx/index.php?page=account&s=options to find your API key.}
+    credential :user_id, default: Danbooru.config.rule34_xxx_user_id, help: %{Your Rule34.xxx user ID.}
+    credential :api_key, default: Danbooru.config.rule34_xxx_api_key, help: %{Your Rule34.xxx API key. Go to https://rule34.xxx/index.php?page=account&s=options to find your API key.}
   end
 
   site "Safebooru", url: "https://safebooru.org"

--- a/app/logical/source/url/huashijie.rb
+++ b/app/logical/source/url/huashijie.rb
@@ -7,8 +7,8 @@ module Source
         url "https://www.huashijie.art"
         domains %w[huashijie.art pandapaint.net]
 
-        credential :user_id, help: %{Your Huashijie `userId` cookie.}
-        credential :api_key, help: %{Your Huashijie `token` cookie.}
+        credential :user_id, default: Danbooru.config.huashijie_user_id, help: %{Your Huashijie `userId` cookie.}
+        credential :session_cookie, default: Danbooru.config.huashijie_session_cookie, help: %{Your Huashijie `token` cookie.}
       end
 
       attr_reader :user_id, :work_id, :product_id, :full_image_url

--- a/app/logical/source/url/inkbunny.rb
+++ b/app/logical/source/url/inkbunny.rb
@@ -5,8 +5,8 @@ class Source::URL::Inkbunny < Source::URL
     url "https://inkbunny.net"
     domains %w[inkbunny.net metapix.net]
 
-    credential :username, help: %{Your Inkbunny username.}
-    credential :password, help: %{Your Inkbunny password. Go to https://inkbunny.net/account.php and enable API access, then go to https://inkbunny.net/userrate.php and enable all ratings.}
+    credential :username, default: Danbooru.config.inkbunny_username, help: %{Your Inkbunny username.}
+    credential :password, default: Danbooru.config.inkbunny_password, help: %{Your Inkbunny password. Go to https://inkbunny.net/account.php and enable API access, then go to https://inkbunny.net/userrate.php and enable all ratings.}
   end
 
   attr_reader :username, :user_id, :submission_id

--- a/app/logical/source/url/mastodon.rb
+++ b/app/logical/source/url/mastodon.rb
@@ -7,11 +7,11 @@
 
 class Source::URL::Mastodon < Source::URL
   site "Pawoo", url: "https://pawoo.net" do
-    credential :access_token, help: %{Your Pawoo access token. Go to https://pawoo.net/settings/applications, create a new application with the 'read' scope, and copy the access token.}
+    credential :access_token, default: Danbooru.config.pawoo_access_token, help: %{Your Pawoo access token. Go to https://pawoo.net/settings/applications, create a new application with the 'read' scope, and copy the access token.}
   end
 
   site "Baraag", url: "https://baraag.net" do
-    credential :access_token, help: %{Your Baraag access token. Go to https://baraag.net/settings/applications, create a new application with the 'read' scope, and copy the access token.}
+    credential :access_token, default: Danbooru.config.baraag_access_token, help: %{Your Baraag access token. Go to https://baraag.net/settings/applications, create a new application with the 'read' scope, and copy the access token.}
   end
 
   attr_reader :username, :user_id, :work_id, :full_image_url, :media_hash

--- a/app/logical/source/url/newgrounds.rb
+++ b/app/logical/source/url/newgrounds.rb
@@ -10,7 +10,7 @@ class Source::URL::Newgrounds < Source::URL
     url "https://www.newgrounds.com"
     domains %w[newgrounds.com ngfiles.com ungrounded.net]
 
-    credential :ng_remember, help: %{Your Newgrounds `ng_remember` cookie.}
+    credential :session_cookie, default: Danbooru.config.newgrounds_ng_remember_cookie, help: %{Your Newgrounds `ng_remember` cookie.}
   end
 
   attr_reader :username, :work_id, :work_title, :project_id, :image_id, :video_id, :image_hash, :full_image_url, :candidate_full_image_urls

--- a/app/logical/source/url/nico_seiga.rb
+++ b/app/logical/source/url/nico_seiga.rb
@@ -25,7 +25,7 @@ module Source
       url "https://seiga.nicovideo.jp"
       domains %w[nicovideo.jp nicoseiga.jp nicomanga.jp nimg.jp nico.ms]
 
-      credential :user_session, help: %{Your NicoSeiga `user_session` cookie.}
+      credential :user_session, default: Danbooru.config.nico_seiga_user_session, help: %{Your NicoSeiga `user_session` cookie.}
     end
 
     attr_reader :illust_id, :manga_id, :image_id, :oekaki_id, :video_id, :user_id, :username, :profile_url

--- a/app/logical/source/url/nijie.rb
+++ b/app/logical/source/url/nijie.rb
@@ -14,8 +14,8 @@ class Source::URL::Nijie < Source::URL
     url "https://nijie.info"
     domains %w[nijie.net nijie.info]
 
-    credential :login, help: %{Your Nijie login}
-    credential :password, help: %{Your nijie password}
+    credential :login, default: Danbooru.config.nijie_login, help: %{Your Nijie login}
+    credential :password, default: Danbooru.config.nijie_password, help: %{Your nijie password}
   end
 
   extractors { [Source::Extractor::Nijie, Source::Extractor::URLShortener] }

--- a/app/logical/source/url/piapro.rb
+++ b/app/logical/source/url/piapro.rb
@@ -2,7 +2,9 @@
 
 # @see Source::Extractor::Piapro
 class Source::URL::Piapro < Source::URL
-  site "Piapro.jp", url: "https://piapro.jp"
+  site "Piapro.jp", url: "https://piapro.jp" do
+    credential :session_cookie, default: Danbooru.config.piapro_session_cookie, help: %{Your Piapro `piapro_s` cookie.}
+  end
 
   extractors { [Source::Extractor::Piapro, Source::Extractor::URLShortener] }
 

--- a/app/logical/source/url/pixiv.rb
+++ b/app/logical/source/url/pixiv.rb
@@ -6,7 +6,7 @@ module Source
       url "https://www.pixiv.net"
       domains %w[pximg.net pixiv.net pixiv.me pixiv.cc p.tl phixiv.net]
 
-      credential :phpsessid, help: %{Your Pixiv `PHPSESSID` cookie.}
+      credential :phpsessid, default: Danbooru.config.pixiv_phpsessid, help: %{Your Pixiv `PHPSESSID` cookie.}
     end
 
     extractors { [Source::Extractor::Pixiv, Source::Extractor::URLShortener] }

--- a/app/logical/source/url/plurk.rb
+++ b/app/logical/source/url/plurk.rb
@@ -2,7 +2,7 @@
 
 class Source::URL::Plurk < Source::URL
   site "Plurk", url: "https://www.plurk.com" do
-    credential :session_cookie, help: %{Your Plurk `plurktokena` cookie.}
+    credential :session_cookie, default: Danbooru.config.plurk_session_cookie, help: %{Your Plurk `plurktokena` cookie.}
   end
 
   RESERVED_USERNAMES = %w[

--- a/app/logical/source/url/poipiku.rb
+++ b/app/logical/source/url/poipiku.rb
@@ -2,7 +2,7 @@
 
 class Source::URL::Poipiku < Source::URL
   site "Poipiku", url: "https://poipiku.com" do
-    credential :session_cookie, help: %{Your Poipiku `POIPIKU_LK` cookie.}
+    credential :session_cookie, default: Danbooru.config.poipiku_session_cookie, help: %{Your Poipiku `POIPIKU_LK` cookie.}
   end
 
   attr_reader :user_id, :post_id, :image_dir, :image_id, :image_hash, :original_file_ext, :expires, :signature, :key_pair_id

--- a/app/logical/source/url/postype.rb
+++ b/app/logical/source/url/postype.rb
@@ -5,7 +5,7 @@ class Source::URL::Postype < Source::URL
     url "https://www.postype.com"
     domains %w[postype.com posty.pe cloudfront.net]
 
-    credential :session_cookie, help: %{Your Postype `PSE3` cookie. Go to your settings and enable 'Viewing adult content by foreigners' to see all content.}
+    credential :session_cookie, default: Danbooru.config.postype_session_cookie, help: %{Your Postype `PSE3` cookie. Go to your settings and enable 'Viewing adult content by foreigners' to see all content.}
   end
 
   extractors { [Source::Extractor::Postype, Source::Extractor::URLShortener] }

--- a/app/logical/source/url/reddit.rb
+++ b/app/logical/source/url/reddit.rb
@@ -7,7 +7,7 @@ module Source
         url "https://www.reddit.com"
         domains %w[reddit.com redd.it redditmedia.com]
 
-        credential :session_cookie, help: %{Your Reddit `reddit_session` cookie.}
+        credential :session_cookie, default: Danbooru.config.reddit_session_cookie, help: %{Your Reddit `reddit_session` cookie.}
       end
 
       extractors do

--- a/app/logical/source/url/tinami.rb
+++ b/app/logical/source/url/tinami.rb
@@ -13,7 +13,7 @@ class Source::URL::Tinami < Source::URL
     url "https://www.tinami.com"
     domains %w[tinami.com tinami.jp]
 
-    credential :session_id, help: %{Your Tinami `Tinami2SESSID` cookie.}
+    credential :session_id, default: Danbooru.config.tinami_session_id, help: %{Your Tinami `Tinami2SESSID` cookie.}
   end
 
   attr_reader :user_id, :profile_id, :work_id

--- a/app/logical/source/url/tumblr.rb
+++ b/app/logical/source/url/tumblr.rb
@@ -5,7 +5,7 @@ class Source::URL::Tumblr < Source::URL
     url "https://www.tumblr.com"
     domains %w[tumblr.com tmblr.co]
 
-    credential :consumer_key, help: %{Your Tumblr consumer key. Register a new application at https://www.tumblr.com/oauth/register then copy your consumer key from https://www.tumblr.com/oauth/apps.}
+    credential :consumer_key, default: Danbooru.config.tumblr_consumer_key, help: %{Your Tumblr consumer key. Register a new application at https://www.tumblr.com/oauth/register then copy your consumer key from https://www.tumblr.com/oauth/apps.}
   end
 
   extractors { [Source::Extractor::Tumblr, Source::Extractor::URLShortener] }

--- a/app/logical/source/url/twitter.rb
+++ b/app/logical/source/url/twitter.rb
@@ -21,8 +21,8 @@ class Source::URL::Twitter < Source::URL
     url "https://x.com"
     domains DOMAINS + %w[poast.org privacydev.net]
 
-    credential :auth_token, help: %{Your Twitter `auth_token` cookie.}
-    credential :csrf_token, help: %{Your Twitter `ct0` cookie.}
+    credential :auth_token, default: Danbooru.config.twitter_auth_token, help: %{Your Twitter `auth_token` cookie.}
+    credential :csrf_token, default: Danbooru.config.twitter_csrf_token, help: %{Your Twitter `ct0` cookie.}
   end
 
   extractors { [Source::Extractor::Twitter, Source::Extractor::URLShortener] }

--- a/app/logical/source/url/xfolio.rb
+++ b/app/logical/source/url/xfolio.rb
@@ -2,7 +2,7 @@
 
 class Source::URL::Xfolio < Source::URL
   site "Xfolio", url: "https://xfolio.jp" do
-    credential :session_cookie, help: %{Your Xfolio `xfolio_session` cookie}
+    credential :session_cookie, default: Danbooru.config.xfolio_session, help: %{Your Xfolio `xfolio_session` cookie}
   end
 
   attr_reader :username, :work_id, :image_id

--- a/app/logical/source/url/xiaohongshu.rb
+++ b/app/logical/source/url/xiaohongshu.rb
@@ -6,10 +6,10 @@ class Source::URL::Xiaohongshu < Source::URL
     url "https://www.xiaohongshu.com"
     domains %w[xiaohongshu.com rednote.com xhscdn.com rednotecdn.com xhslink.com]
 
-    credential :api_host, help: %{Your Xiaohongshu site host. Can be either "www.xiaohongshu.com" or "www.rednote.com".}
-    credential :session_cookie, help: %{Your Xiaohongshu `gid` cookie.}
-    credential :webid_cookie, help: %{Your Xiaohongshu `webId` cookie.}
-    credential :web_session_cookie, help: %{Your Xiaohongshu `web_session` cookie.}
+    credential :api_host, default: Danbooru.config.xiaohongshu_api_host, help: %{Your Xiaohongshu site host. Can be either "www.xiaohongshu.com" or "www.rednote.com".}
+    credential :session_cookie, default: Danbooru.config.xiaohongshu_session_cookie, help: %{Your Xiaohongshu `gid` cookie.}
+    credential :web_id, default: Danbooru.config.xiaohongshu_webid_cookie, help: %{Your Xiaohongshu `webId` cookie.}
+    credential :web_session, default: Danbooru.config.xiaohongshu_web_session_cookie, help: %{Your Xiaohongshu `web_session` cookie.}
   end
 
   extractors { [Source::Extractor::Xiaohongshu, Source::Extractor::URLShortener] }

--- a/app/logical/source/url/zerochan.rb
+++ b/app/logical/source/url/zerochan.rb
@@ -2,8 +2,8 @@
 
 class Source::URL::Zerochan < Source::URL
   site "Zerochan", url: "https://www.zerochan.net" do
-    credential :user_id, help: %{Your Zerochan `z_id` cookie.}
-    credential :session_cookie, help: %{Your Zerochan `z_hash` cookie.}
+    credential :user_id, default: Danbooru.config.zerochan_user_id, help: %{Your Zerochan `z_id` cookie.}
+    credential :session_cookie, default: Danbooru.config.zerochan_session_cookie, help: %{Your Zerochan `z_hash` cookie.}
   end
 
   attr_reader :full_image_url, :title, :size, :work_id, :filetype

--- a/app/models/site_credential.rb
+++ b/app/models/site_credential.rb
@@ -2,164 +2,19 @@
 
 # Stores credentials used by extractors (usernames, passwords, cookies, API keys, etc) in the database.
 class SiteCredential < ApplicationRecord
-  SITES = [
-    {
-      id: 100,
-      name: "ArtStreet",
-      default_credential: { session_cookie: Danbooru.config.art_street_session_cookie },
-      help: %{Your "ArtStreet":https://medibang.com 'MSID' cookie. Go to your profile settings and set your age to 18+ to view R-18 works.},
-    }, {
-      id: 200,
-      name: "Baraag",
-      default_credential: { access_token: Danbooru.config.baraag_access_token },
-      help: %{Your "Baraag":https://baraag.net access token. Go to "Preferences > Development":[https://baraag.net/settings/applications], create a new application with the 'read' scope, and copy the access token.},
-    }, {
-      id: 300,
-      name: "Behance",
-      default_credential: { session_cookie: Danbooru.config.behance_session_cookie },
-      help: %{Your "Behance":https://www.behance.net 'iat0' cookie.},
-    }, {
-      id: 400,
-      name: "Blogger",
-      default_credential: { api_key: Danbooru.config.blogger_api_key },
-      help: %{Your "Blogger":https://blogger.com API key. Go to https://developers.google.com/blogger/docs/3.0/using#APIKey to create an API key.},
-    },
-    # { id: 500, name: "Bluesky" }, # we now use a loginless method
-    {
-      id: 600,
-      name: "Ci-En",
-      default_credential: { session_cookie: Danbooru.config.ci_en_session_cookie },
-      help: %{Your "Ci-En":https://ci-en.net 'ci_en_session' cookie.},
-    },
-    # { id: 700, name: "Cohost" }, # site was shut down
-    {
-      id: 800,
-      name: "Deviant Art",
-      default_credential: { client_id: Danbooru.config.deviantart_client_id, client_secret: Danbooru.config.deviantart_client_secret, auth: Danbooru.config.deviantart_auth_cookie, auth_secure: Danbooru.config.deviantart_auth_secure_cookie, userinfo: Danbooru.config.deviantart_userinfo_cookie },
-      help: %{Your "DeviantArt":https://www.deviantart.com 'client_id' and 'cilent_secret' from https://www.deviantart.com/developers/, and your 'auth', 'auth_secure', and 'userinfo' cookies.},
-    }, {
-      id: 900,
-      name: "Fantia",
-      default_credential: { session_id: Danbooru.config.fantia_session_id },
-      help: %{Your "Fantia":https://fantia.jp '_session_id' cookie.},
-    }, {
-      id: 1000,
-      name: "Furaffinity",
-      default_credential: { cookie_a: Danbooru.config.furaffinity_cookie_a, cookie_b: Danbooru.config.furaffinity_cookie_b },
-      help: %{Your "Furaffinity":https://www.furaffinity.net 'cookie_a' and 'cookie_b' cookies. Warning: logging out of Furaffinity will invalidate these cookies.},
-    }, {
-      id: 1050,
-      name: "Gelbooru",
-      default_credential: { user_id: Danbooru.config.gelbooru_user_id, api_key: Danbooru.config.gelbooru_api_key },
-      help: %{Your "Gelbooru":https://gelbooru.com user ID and API key. Go to https://gelbooru.com/index.php?page=account&s=options to find your API key.},
-    }, {
-      id: 1075,
-      name: "Huashijie",
-      default_credential: { user_id: Danbooru.config.huashijie_user_id, session_cookie: Danbooru.config.huashijie_session_cookie },
-      help: %{Your "Huashijie":https://www.huashijie.art 'userId' and 'token' cookies.},
-    }, {
-      id: 1100,
-      name: "Inkbunny",
-      default_credential: { username: Danbooru.config.inkbunny_username, password: Danbooru.config.inkbunny_password },
-      help: %{Your "Inkbunny":https://inkbunny.net username and password. Go to https://inkbunny.net/account.php and enable API access, then go to https://inkbunny.net/userrate.php and enable all ratings.},
-    }, {
-      id: 1200,
-      name: "Newgrounds",
-      default_credential: { session_cookie: Danbooru.config.newgrounds_ng_remember_cookie },
-      help: %{Your "Newgrounds":https://www.newgrounds.com 'ng_remember' cookie.},
-    }, {
-      id: 1300,
-      name: "Nico Seiga",
-      default_credential: { user_session: Danbooru.config.nico_seiga_user_session },
-      help: %{Your "NicoSeiga":https://seiga.nicovideo.jp 'user_session' cookie.},
-    }, {
-      id: 1400,
-      name: "Nijie",
-      default_credential: { login: Danbooru.config.nijie_login, password: Danbooru.config.nijie_password },
-      help: %{Your "Nijie":https://nijie.info login and password.},
-    }, {
-      id: 1500,
-      name: "Pawoo",
-      default_credential: { access_token: Danbooru.config.pawoo_access_token },
-      help: %{Your "Pawoo":https://pawoo.net access token. Go to "Preferences > Development":[https://pawoo.net/settings/applications], create a new application with the 'read' scope, and copy the access token.},
-    }, {
-      id: 1600,
-      name: "Piapro.jp",
-      default_credential: { session_cookie: Danbooru.config.piapro_session_cookie },
-      help: %{Your "Piapro":https://piapro.jp 'piapro_s' cookie.},
-    }, {
-      id: 1700,
-      name: "Pixiv",
-      default_credential: { phpsessid: Danbooru.config.pixiv_phpsessid },
-      help: %{Your "Pixiv":https://www.pixiv.net 'PHPSESSID' cookie.},
-    }, {
-      id: 1800,
-      name: "Poipiku",
-      default_credential: { session_cookie: Danbooru.config.poipiku_session_cookie },
-      help: %{Your "Poipiku":https://poipiku.com 'POIPIKU_LK' cookie.},
-    }, {
-      id: 1900,
-      name: "Postype",
-      default_credential: { session_cookie: Danbooru.config.postype_session_cookie },
-      help: %{Your "Postype":https://www.postype.com 'PSE3' cookie. Go to your settings and enable 'Viewing adult content by foreigners' to see all content.},
-    }, {
-      id: 2000,
-      name: "Plurk",
-      default_credential: { session_cookie: Danbooru.config.plurk_session_cookie },
-      help: %{Your "Plurk":https://www.plurk.com 'plurktokena' cookie.},
-    }, {
-      id: 2050,
-      name: "Reddit",
-      default_credential: { session_cookie: Danbooru.config.reddit_session_cookie },
-      help: %{Your "Reddit":https://reddit.com 'reddit_session' cookie.},
-    }, {
-      id: 2075,
-      name: "Rule34.xxx",
-      default_credential: { user_id: Danbooru.config.rule34_xxx_user_id, api_key: Danbooru.config.rule34_xxx_api_key },
-      help: %{Your "Rule34.xxx":https://rule34.xxx user ID and API key. Go to https://rule34.xxx/index.php?page=account&s=options to find your API key.},
-    }, {
-      id: 2100,
-      name: "Tinami",
-      default_credential: { session_id: Danbooru.config.tinami_session_id },
-      help: %{Your "Tinami":https://www.tinami.com 'Tinami2SESSID' cookie.},
-    }, {
-      id: 2200,
-      name: "Tumblr",
-      default_credential: { consumer_key: Danbooru.config.tumblr_consumer_key },
-      help: %{Your "Tumblr":https://www.tumblr.com consumer key. Register a new application at https://www.tumblr.com/oauth/register then copy your consumer key from <https://www.tumblr.com/oauth/apps>.},
-    }, {
-      id: 2300,
-      name: "Twitter",
-      default_credential: { auth_token: Danbooru.config.twitter_auth_token, csrf_token: Danbooru.config.twitter_csrf_token },
-      help: %{Your "Twitter":https://x.com 'auth_token' and 'ct0' cookies.},
-    }, {
-      id: 2400,
-      name: "Xfolio",
-      default_credential: { session_cookie: Danbooru.config.xfolio_session },
-      help: %{Your "Xfolio":https://xfolio.jp 'xfolio_session' cookie.},
-    }, {
-      id: 2450,
-      name: "Xiaohongshu",
-      default_credential: { api_host: Danbooru.config.xiaohongshu_api_host, session_cookie: Danbooru.config.xiaohongshu_session_cookie, web_id: Danbooru.config.xiaohongshu_webid_cookie, web_session: Danbooru.config.xiaohongshu_web_session_cookie },
-      help: %{Your "Xiaohongshu":https://www.xiaohongshu.com 'gid', 'webId' and 'web_session' cookies.},
-    }, {
-      id: 2500,
-      name: "Zerochan",
-      default_credential: { user_id: Danbooru.config.zerochan_user_id, session_cookie: Danbooru.config.zerochan_session_cookie },
-      help: %{Your "Zerochan":https://www.zerochan.net 'z_id' and 'z_hash' cookies.},
-    },
-  ]
+  # @return [Array<Source::Site>] The list of sites that have credentials defined.
+  SITES = Source::Site.sites.select { |site| site.credentials.present? }.sort_by(&:name).freeze
 
   # @return [Hash<String, Hash<String, String>>] The set of default credentials for each site. Default credentials come
   #   from the environment or from the danbooru_local_config.rb file.
   DEFAULT_CREDENTIALS = SITES.filter_map do |site|
-    next if site[:default_credential].values.any?(&:blank?)
-    [site[:name], site[:default_credential]]
+    next if site.credentials.any? { |credential| credential.default.blank? }
+    [site.name, site.credentials.to_h { |credential| [credential.name.to_s, credential.default] }]
   end.to_h.with_indifferent_access
 
   attr_accessor :updater
 
-  enum :site, SITES.to_h { |site| [site[:name], site[:id]] }, scopes: false, instance_methods: false, validate: true
+  enum :site, SITES.to_h { |site| [site.name, site.site_id] }, scopes: false, instance_methods: false, validate: true
 
   enum :status, {
     unknown: 0,        # The credential hasn't been used yet, or failed for an unknown reason.
@@ -244,7 +99,7 @@ class SiteCredential < ApplicationRecord
   end
 
   def credential_names
-    SITES.find { |site| site[:name] == self.site }&.dig(:default_credential)&.keys.to_a.map(&:to_s)
+    Source::Site.find(site)&.credentials&.map { |credential| credential.name.to_s }.to_a
   end
 
   def validate_credential

--- a/app/views/site_credentials/new.html.erb
+++ b/app/views/site_credentials/new.html.erb
@@ -9,17 +9,17 @@
 
       <% SiteCredential::SITES.each do |site| %>
         <%= f.simple_fields_for :credential do |fa| %>
-          <div x-cloak x-show="site === <%= site[:name].to_json %>">
-            <% site[:default_credential].keys.each do |credential_name| %>
-              <%= fa.input credential_name, label: credential_name.to_s.humanize(keep_id_suffix: true), as: :string, required: false, input_html: { "x-bind:disabled": "site !== '#{site[:name]}'", "x-bind:required": "site === '#{site[:name]}'", value: params.dig(:credential, credential_name) } %>
-            <% end %>
+          <div x-cloak x-show="site === <%= site.name.to_json %>">
+            <% site.credentials.each do |credential| %>
+              <%= fa.input credential.name, label: credential.name.to_s.humanize(keep_id_suffix: true), as: :string, required: false, input_html: { "x-bind:disabled": "site !== '#{site.name}'", "x-bind:required": "site === '#{site.name}'", value: params.dig(:credential, credential.name) } %>
 
-            <div class="prose fineprint mb-4">
-              <%= format_text(site[:help]) %>
-            </div>
-          <% end %>
+              <div class="prose fineprint mb-4">
+                <%= format_text(credential.help) %>
+              </div>
+            <% end %>
           </div>
         <% end %>
+      <% end %>
 
       <%= f.submit "Create", class: "button-primary", disabled: true, "x-bind:disabled": "!valid" %>
     <% end %>

--- a/db/migrate/20260823164959_change_site_credentials_site_to_bigint.rb
+++ b/db/migrate/20260823164959_change_site_credentials_site_to_bigint.rb
@@ -1,0 +1,48 @@
+class ChangeSiteCredentialsSiteToBigint < ActiveRecord::Migration[7.1]
+  OLD_TO_NEW_SITE_IDS = {
+    100 => 1_582_834_045,  # ArtStreet
+    200 => 852_466_962,    # Baraag
+    300 => 905_104_270,    # Behance
+    400 => 920_474_887,    # Blogger
+    600 => 95_964_253,     # Ci-En
+    800 => 1_911_975_415,  # Deviant Art
+    900 => 2_232_280_694,  # Fantia
+    1000 => 1_642_487_372, # Furaffinity
+    1050 => 1_346_832_700, # Gelbooru
+    1075 => 1_704_236_765, # Huashijie
+    1100 => 458_145_355,   # Inkbunny
+    1200 => 3_521_172_851, # Newgrounds
+    1300 => 417_925_447,   # Nico Seiga
+    1400 => 3_621_127_813, # Nijie
+    1500 => 849_706_620,   # Pawoo
+    1600 => 2_803_769_957, # Piapro.jp
+    1700 => 11_197_707,    # Pixiv
+    1800 => 847_520_205,   # Poipiku
+    1900 => 2_910_390_220, # Postype
+    2000 => 4_178_719_682, # Plurk
+    2050 => 708_778_030,   # Reddit
+    2075 => 442_776_123,   # Rule34.xxx
+    2100 => 3_174_565_713, # Tinami
+    2200 => 526_816_551,   # Tumblr
+    2300 => 1_408_455_283, # Twitter
+    2400 => 3_859_330_323, # Xfolio
+    2450 => 1_935_345_289, # Xiaohongshu
+    2500 => 143_330_298,   # Zerochan
+  }.freeze
+
+  def up
+    change_column :site_credentials, :site, :bigint
+
+    OLD_TO_NEW_SITE_IDS.each do |old_id, new_id|
+      execute "UPDATE site_credentials SET site = #{new_id} WHERE site = #{old_id}"
+    end
+  end
+
+  def down
+    OLD_TO_NEW_SITE_IDS.each do |old_id, new_id|
+      execute "UPDATE site_credentials SET site = #{old_id} WHERE site = #{new_id}"
+    end
+
+    change_column :site_credentials, :site, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1894,7 +1894,7 @@ CREATE TABLE public.site_credentials (
     id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    site integer NOT NULL,
+    site bigint NOT NULL,
     creator_id bigint NOT NULL,
     is_enabled boolean DEFAULT true NOT NULL,
     is_public boolean DEFAULT true NOT NULL,
@@ -7156,6 +7156,7 @@ ALTER TABLE ONLY public.user_upgrades
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260823164959'),
 ('20260323172054'),
 ('20260323172053'),
 ('20260323172052'),


### PR DESCRIPTION
Centralize all credential definitions on their respective Source::URL subclasses, where they were already duplicated. 

This commit requires a migration, because site ids are 32-bit integers, so they can be bigger than what the integer columns allow.

I noticed this while working on adding site proxies, since those will probably require a similar mechanism.