### PR TITLE
Artist aliases should link to the artist entry instead of wiki

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -224,6 +224,14 @@ module ApplicationHelper
     link_to text, wiki_page_path(title), class: "wiki-link #{classes}", **options
   end
 
+  def link_to_wiki_or_artist(tag, classes: nil, **options)
+    if tag.artist?
+      link_to tag.name, show_or_new_artists_path(name: tag.name), class: "wiki-link #{classes}", **options
+    else
+      link_to_wiki(tag.name, classes: classes, **options)
+    end
+  end
+
   def link_to_wikis(*wiki_titles, **options)
     links = wiki_titles.map do |title|
       link_to_wiki title.tr("_", " "), title

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -16,67 +16,69 @@
 
 <% if artist.is_banned? && !policy(artist).can_view_banned? %>
   <p>This page has been removed because of a takedown request.</p>
-<% elsif artist.new_record? %>
-  <p>This artist entry does not exist. <%= link_to "Create new artist entry", new_artist_path(artist: { name: artist.name }), rel: "nofollow" %>.</p>
 <% else %>
-  <div class="flex flex-col gap-2">
-    <% if artist.other_names.present? %>
-      <div class="flex flex-wrap gap-1">
-        <% artist.other_names.map do |other_name| %>
-          <%= link_to other_name, artists_path(search: { any_name_matches: other_name }), class: "artist-other-name chip-primary text-sm truncate", rel: "nofollow"%>
-        <% end %>
-      </div>
-    <% end %>
+  <% if artist.new_record? %>
+    <p>This artist entry does not exist. <%= link_to "Create new artist entry", new_artist_path(artist: { name: artist.name }), rel: "nofollow" %>.</p>
+  <% else %>
+    <div class="flex flex-col gap-2">
+      <% if artist.other_names.present? %>
+        <div class="flex flex-wrap gap-1">
+          <% artist.other_names.map do |other_name| %>
+            <%= link_to other_name, artists_path(search: { any_name_matches: other_name }), class: "artist-other-name chip-primary text-sm truncate", rel: "nofollow"%>
+          <% end %>
+        </div>
+      <% end %>
 
-    <% if artist.group_name.present? %>
-      <div>
-        <strong>Group</strong>
-        <%= link_to artist.group_name, artists_path(search: { group_name: artist.group_name }), class: "artist-other-name chip-primary text-sm truncate" %>
-      </div>
-    <% end %>
+      <% if artist.group_name.present? %>
+        <div>
+          <strong>Group</strong>
+          <%= link_to artist.group_name, artists_path(search: { group_name: artist.group_name }), class: "artist-other-name chip-primary text-sm truncate" %>
+        </div>
+      <% end %>
 
-    <% if artist.members.present? %>
-      <div>
-        <strong>Members</strong>
-        <% artist.members.each do |member| %>
-          <%= link_to member.name, artists_path(search: { name: member.name }), class: "artist-other-name chip-primary text-sm truncate" %>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
-
-  <% if artist.wiki_page.present? && !artist.wiki_page.is_deleted? %>
-    <div class="artist-wiki prose mt-4">
-      <%= artist.wiki_page.dtext_body.format_text %>
+      <% if artist.members.present? %>
+        <div>
+          <strong>Members</strong>
+          <% artist.members.each do |member| %>
+            <%= link_to member.name, artists_path(search: { name: member.name }), class: "artist-other-name chip-primary text-sm truncate" %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
-  <% end %>
 
-  <% if artist.urls.present? %>
-    <div class="my-4">
-      <h6>URLs</h6>
-
-      <ul>
-        <% artist.sorted_urls.each do |url| %>
-          <li>
-            <%= external_link_to url.url, external_site_icon(url.site_name, class: "h-4") %>
-            <% if url.is_active? %>
-              <%= external_link_to url.url %>
-            <% else %>
-              <%= external_link_to url.url, class: "inactive-artist-url underline decoration-dotted" %>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <p>
-    <% if artist.wiki_page.present? %>
-      <%= link_to "Edit wiki", edit_wiki_page_path(artist.wiki_page), id: "view-wiki-link" %> |
+    <% if artist.wiki_page.present? && !artist.wiki_page.is_deleted? %>
+      <div class="artist-wiki prose mt-4">
+        <%= artist.wiki_page.dtext_body.format_text %>
+      </div>
     <% end %>
 
-    <%= link_to "Edit artist", edit_artist_path(artist), id: "view-artist-link" %>
-  </p>
+    <% if artist.urls.present? %>
+      <div class="my-4">
+        <h6>URLs</h6>
+
+        <ul>
+          <% artist.sorted_urls.each do |url| %>
+            <li>
+              <%= external_link_to url.url, external_site_icon(url.site_name, class: "h-4") %>
+              <% if url.is_active? %>
+                <%= external_link_to url.url %>
+              <% else %>
+                <%= external_link_to url.url, class: "inactive-artist-url underline decoration-dotted" %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <p>
+      <% if artist.wiki_page.present? %>
+        <%= link_to "Edit wiki", edit_wiki_page_path(artist.wiki_page), id: "view-wiki-link" %> |
+      <% end %>
+
+      <%= link_to "Edit artist", edit_artist_path(artist), id: "view-artist-link" %>
+    </p>
+  <% end %>
 
   <%= render "tag_relationships/alias_and_implication_list", tag: artist.tag %>
 <% end %>

--- a/app/views/tag_relationships/_alias_and_implication_list.html.erb
+++ b/app/views/tag_relationships/_alias_and_implication_list.html.erb
@@ -1,7 +1,7 @@
 <% if tag.present? %>
   <% if tag.antecedent_alias %>
     <p class="fineprint">
-      This tag has been aliased to <%= link_to_wiki(tag.antecedent_alias.consequent_name) %>
+      This tag has been aliased to <%= link_to_wiki_or_artist tag.antecedent_alias.consequent_tag %>
       (<%= link_to_wiki "learn more", "help:tag_aliases" %>).
     </p>
   <% end %>
@@ -9,7 +9,7 @@
   <% if tag.consequent_aliases.present? %>
     <p class="fineprint">
       The following tags are aliased to this tag:
-      <%= to_sentence(tag.consequent_aliases.sort_by(&:antecedent_name).map { |ta| link_to_wiki ta.antecedent_name }) %>
+      <%= to_sentence(tag.consequent_aliases.sort_by(&:antecedent_name).map { |ta| link_to_wiki_or_artist ta.antecedent_tag }) %>
       (<%= link_to_wiki "learn more", "help:tag_aliases" %>).
     </p>
   <% end %>
@@ -27,7 +27,7 @@
   <% if tag.antecedent_implications.present? %>
     <p class="fineprint">
       This tag implicates
-      <%= to_sentence(tag.antecedent_implications.sort_by(&:consequent_name).map { |ti| link_to_wiki ti.consequent_name }) %>
+      <%= to_sentence(tag.antecedent_implications.sort_by(&:consequent_name).map { |ti| link_to_wiki_or_artist ti.consequent_tag }) %>
       (<%= link_to_wiki "learn more", "help:tag_implications" %>).
     </p>
   <% end %>
@@ -35,7 +35,7 @@
   <% if tag.consequent_implications.present? %>
     <p class="fineprint">
       The following tags implicate this tag:
-      <%= to_sentence(tag.consequent_implications.sort_by(&:antecedent_name).map { |ti| link_to_wiki ti.antecedent_name }) %>
+      <%= to_sentence(tag.consequent_implications.sort_by(&:antecedent_name).map { |ti| link_to_wiki_or_artist ti.antecedent_tag }) %>
       (<%= link_to_wiki "learn more", "help:tag_implications" %>).
     </p>
   <% end %>

--- a/test/functional/artists_controller_test.rb
+++ b/test/functional/artists_controller_test.rb
@@ -101,6 +101,16 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
       end
 
+      should "show tag aliases for an artist tag that doesn't have an artist entry" do
+        create(:artist_tag, name: "new_name")
+        as(@user) { create(:tag_alias, antecedent_name: @masao.name, consequent_name: "new_name", status: "active") }
+
+        get_auth show_or_new_artists_path(name: "new_name"), @user
+
+        assert_response :success
+        assert_select ".fineprint", text: /The following tags are aliased to this tag:\s+#{@masao.name}/
+      end
+
       should "redirect to the new artist page for a blank artist" do
         get_auth show_or_new_artists_path, @user
         assert_redirected_to new_artist_path

--- a/test/functional/wiki_pages_controller_test.rb
+++ b/test/functional/wiki_pages_controller_test.rb
@@ -167,6 +167,30 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
 
         assert_response 451
       end
+
+      should "link to aliased artist tags" do
+        create(:artist_tag, name: @wiki_page.title)
+        create(:artist_tag, name: "new_name")
+        as(@user) { create(:tag_alias, antecedent_name: @wiki_page.title, consequent_name: "new_name", status: "active") }
+
+        get wiki_page_path(@wiki_page.title)
+
+        assert_response :success
+        assert_select ".fineprint", text: /This tag has been aliased to new_name/
+        assert_select ".fineprint a.wiki-link[href=?]", show_or_new_artists_path(name: "new_name")
+      end
+
+      should "link to aliased wikis" do
+        create(:general_tag, name: @wiki_page.title)
+        create(:general_tag, name: "new_name")
+        as(@user) { create(:tag_alias, antecedent_name: @wiki_page.title, consequent_name: "new_name", status: "active") }
+
+        get wiki_page_path(@wiki_page.title)
+
+        assert_response :success
+        assert_select ".fineprint", text: /This tag has been aliased to new_name/
+        assert_select ".fineprint a.wiki-link[href=?]", wiki_page_path("new_name")
+      end
     end
 
     context "show_or_new action" do


### PR DESCRIPTION
Fixes #6565, and also shows links to artist aliases even when there's no artist entry.