### PR TITLE
uploads: process file uploads asynchronously

### DIFF
--- a/app/models/upload_media_asset.rb
+++ b/app/models/upload_media_asset.rb
@@ -136,10 +136,9 @@ class UploadMediaAsset < ApplicationRecord
   # Calls `process_upload!`
   def async_process_upload!
     if file.present?
-      ProcessUploadMediaAssetJob.perform_now(self)
-    else
-      ProcessUploadMediaAssetJob.perform_later(self)
+      storage_service.store(file, staged_file_path)
     end
+    ProcessUploadMediaAssetJob.perform_later(self)
   end
 
   def process_upload!
@@ -147,6 +146,9 @@ class UploadMediaAsset < ApplicationRecord
 
     if file.present?
       media_file = MediaFile.open(file)
+    elsif file_upload?
+      staged_file = storage_service.open(staged_file_path)
+      media_file = MediaFile.open(staged_file)
     else
       media_file = source_extractor.download_file!(source_url)
     end
@@ -161,6 +163,15 @@ class UploadMediaAsset < ApplicationRecord
     update!(status: :failed, error: e.message)
   ensure
     media_file&.close
+    storage_service.delete(staged_file_path) if file_upload?
+  end
+
+  def storage_service
+    Danbooru.config.storage_manager
+  end
+
+  def staged_file_path
+    "tmp/upload-media-asset/#{id}"
   end
 
   def update_upload_status


### PR DESCRIPTION
Fixes #6617. Reopened from pull #6166. 
Todo (evazion feedback): 

> needs a background job to ensure leftover temp files are deleted
> doing it in the exception handler isn't enough in case the whole process dies
> needs a separate storage service for temp files so it can be configured separately
> 
> should probably only process files in the background if it's an upload that is expected to take a long time (i.e. a multi-file upload, a zip, or a video/animated/large file)
> otherwise it will noticeably slow down normal file uploads while it uploads files to remote storage only to immediately turn around and download them again


Also need to check if #5682 is fixed by this.