### PR TITLE
Add ability to bulk regenerate media assets

### DIFF
--- a/app/controllers/bulk_media_regenerations_controller.rb
+++ b/app/controllers/bulk_media_regenerations_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class BulkMediaRegenerationsController < ApplicationController
+  skip_before_action :normalize_search, only: [:new]
+
+  def new
+    @query = search_params[:ai_tags_match]
+    authorize MediaAsset, :bulk_regenerate?
+
+    if search_params.present? && @query.blank?
+      @error = "You must enter a search query"
+    elsif @query.present?
+      @media_assets = MediaAsset.active.ai_tags_match(@query).order(id: :desc)
+    end
+  end
+
+  def create
+    @query = search_params[:ai_tags_match]
+    authorize MediaAsset, :bulk_regenerate?
+
+    if @query.blank?
+      redirect_to new_bulk_media_regeneration_path, notice: "You must enter a search query"
+      return
+    end
+
+    count = MediaAsset.active.ai_tags_match(@query).count
+    ModAction.log(%{started a bulk regeneration of #{count} #{"media asset".pluralize(count)} matching "#{@query}"}, :media_asset_bulk_regenerate, subject: nil, user: CurrentUser.user)
+    BulkMediaRegenerationJob.perform_later(query: @query)
+
+    redirect_to new_bulk_media_regeneration_path(search: { ai_tags_match: @query }), notice: "Media asset regeneration scheduled for #{count} #{"asset".pluralize(count)}"
+  end
+end

--- a/app/jobs/bulk_media_regeneration_job.rb
+++ b/app/jobs/bulk_media_regeneration_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# A job that regenerates the metadata, files, and AI tags of all media assets matching a search query.
+# Used to mass-fix media assets after a bug in file processing is fixed.
+#
+# @see BulkMediaRegenerationsController
+class BulkMediaRegenerationJob < ApplicationJob
+  def perform(query:)
+    MediaAsset.active.ai_tags_match(query).parallel_find_each(order: :asc) do |media_asset|
+      media_asset.regenerate!
+    rescue StandardError => e
+      DanbooruLogger.log(e, media_asset_id: media_asset.id)
+    end
+  end
+end

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -58,6 +58,7 @@ class ModAction < ApplicationRecord
     pool_undelete: 63,
     media_asset_delete: 72,
     media_asset_expunge: 76,
+    media_asset_bulk_regenerate: 77,
     artist_ban: 184,
     artist_unban: 185,
     comment_update: 81,

--- a/app/policies/media_asset_policy.rb
+++ b/app/policies/media_asset_policy.rb
@@ -9,6 +9,10 @@ class MediaAssetPolicy < ApplicationPolicy
     user.is_admin?
   end
 
+  def bulk_regenerate?
+    user.is_admin?
+  end
+
   def image?
     can_see_image?
   end

--- a/app/views/bulk_media_regenerations/new.html.erb
+++ b/app/views/bulk_media_regenerations/new.html.erb
@@ -1,0 +1,42 @@
+<% page_title "Bulk Media Regeneration" %>
+
+<div id="c-bulk-media-regenerations">
+  <div id="a-new">
+    <h1>Bulk Media Regeneration</h1>
+
+    <p class="prose">
+      Regenerate the metadata, thumbnails, samples, and IQDB entries of every media asset matching a search query, along with associated posts' metadata and automatic tags.
+      <br>
+      A preview of affected media assets will be displayed after you hit search. You can use the <%= link_to "media assets index", media_assets_path %> to browse for all the affected files and test your searches.
+      <br>
+      You can chain multiple valid media asset values in the search, including an ID range (e.g. <code>id:1000..2000</code>), <code>filetype:</code>, <code>exif:</code>, and more.
+    </p>
+
+    <% if @error.present? %>
+      <div class="notice notice-error notice-small prose"><%= @error %></div>
+    <% end %>
+
+    <%= search_form_for(new_bulk_media_regeneration_path) do |f| %>
+      <%= f.input :ai_tags_match, label: "Tags", input_html: { value: @query, data: { autocomplete: "tag-query" } } %>
+      <%= f.submit "Search" %>
+    <% end %>
+
+    <% if @query.present? %>
+      <% count = @media_assets.count %>
+
+      <p>
+        <%= count %> <%= "asset".pluralize(count) %> will be affected. You can view all the affected posts
+        <%= link_to "here", media_assets_path(search: { ai_tags_match: @query }) %>, or see a preview of some below.
+      </p>
+
+      <% if count > 0 %>
+        <p>
+          <%= link_to "Regenerate #{count} #{"asset".pluralize(count)}", bulk_media_regenerations_path(search: { ai_tags_match: @query }), method: :post, class: "button-danger",
+                       "data-confirm": "#{count} #{"asset".pluralize(count)} will be affected. Are you sure you want to regenerate them?" %>
+        </p>
+
+        <%= render "media_assets/gallery", media_assets: @media_assets.limit(60), size: 180 %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -190,6 +190,10 @@
         <% if policy(SiteCredential).create? %>
           <li><%= link_to("Site Credentials", site_credentials_path) %></li>
         <% end %>
+
+        <% if policy(MediaAsset).bulk_regenerate? %>
+          <li><%= link_to("Bulk Media Regeneration", new_bulk_media_regeneration_path) %></li>
+        <% end %>
       </ul>
 
       <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,7 @@ Rails.application.routes.draw do
     get "/:variant", to: "media_assets#image", as: :image
   end
   resources :media_metadata, only: [:index]
+  resources :bulk_media_regenerations, only: [:new, :create]
 
   resources :metrics, only: [:index], defaults: { format: :text } do
     get "/statistics", on: :collection, to: "metrics#statistics", as: :statistics

--- a/test/functional/bulk_media_regenerations_controller_test.rb
+++ b/test/functional/bulk_media_regenerations_controller_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class BulkMediaRegenerationsControllerTest < ActionDispatch::IntegrationTest
+  context "The bulk media regenerations controller" do
+    setup do
+      @admin = create(:admin_user)
+      @png = create(:media_asset, file_ext: "png")
+      @jpg = create(:media_asset, file_ext: "jpg")
+    end
+
+    context "new action" do
+      should "render" do
+        get_auth new_bulk_media_regeneration_path, @admin
+
+        assert_response :success
+      end
+
+      should "show the number of matching assets when a query is given" do
+        get_auth new_bulk_media_regeneration_path, @admin, params: { search: { ai_tags_match: "filetype:png" }}
+
+        assert_response :success
+        assert_select "a.button-danger", text: "Regenerate 1 asset"
+      end
+
+      should "not allow non-admins to see the page" do
+        get_auth new_bulk_media_regeneration_path, create(:mod_user)
+
+        assert_response 403
+      end
+
+      should "show an error if the search is blank" do
+        get_auth new_bulk_media_regeneration_path, @admin, params: { search: { ai_tags_match: "" }}
+
+        assert_response :success
+        assert_select "#a-new .notice-error", text: "You must enter a search query"
+      end
+
+      should "not show an error on the first visit to the page" do
+        get_auth new_bulk_media_regeneration_path, @admin
+
+        assert_response :success
+        assert_select "#a-new .notice-error", count: 0
+      end
+    end
+
+    context "create action" do
+      should "log a mod action and schedule a regeneration job" do
+        assert_difference("ModAction.count", 1) do
+          post_auth bulk_media_regenerations_path, @admin, params: { search: { ai_tags_match: "filetype:png" }}
+        end
+
+        assert_redirected_to new_bulk_media_regeneration_path(search: { ai_tags_match: "filetype:png" })
+        assert_enqueued_with(job: BulkMediaRegenerationJob, args: [{ query: "filetype:png" }])
+
+        mod_action = ModAction.last
+        assert_equal("media_asset_bulk_regenerate", mod_action.category)
+        assert_equal(%{started a bulk regeneration of 1 media asset matching "filetype:png"}, mod_action.description)
+        assert_nil(mod_action.subject)
+        assert_equal(@admin, mod_action.creator)
+      end
+
+      should "not do anything if no query is given" do
+        assert_no_difference("ModAction.count") do
+          assert_no_enqueued_jobs(only: BulkMediaRegenerationJob) do
+            post_auth bulk_media_regenerations_path, @admin
+          end
+        end
+
+        assert_redirected_to new_bulk_media_regeneration_path
+      end
+
+      should "not allow non-admins to regenerate assets" do
+        assert_no_difference("ModAction.count") do
+          post_auth bulk_media_regenerations_path, create(:mod_user), params: { search: { ai_tags_match: "filetype:png" }}
+        end
+
+        assert_response 403
+      end
+    end
+  end
+end

--- a/test/jobs/bulk_media_regeneration_job_test.rb
+++ b/test/jobs/bulk_media_regeneration_job_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class BulkMediaRegenerationJobTest < ActiveSupport::TestCase
+  context "BulkMediaRegenerationJob" do
+    should "regenerate the metadata, files, and post tags for matching assets" do
+      @post = create(:post_with_file, filename: "png/test-rotation-good-chunk.png")
+      @media_asset = @post.media_asset
+      assert_includes(@post.tag_array, "exif_rotation")
+
+      # Simulate a bug where the pre-rotation width, height, and metadata were stored instead of the rotated ones.
+      @media_asset.media_metadata.update_column(:metadata, {}) # rubocop:disable Rails/SkipsModelValidations
+      @media_asset.update_columns(image_width: 128, image_height: 64) # rubocop:disable Rails/SkipsModelValidations
+      CurrentUser.scoped(User.system) do
+        @post.update!(image_width: 128, image_height: 64, tag_string: @post.tag_string.gsub("exif_rotation", ""))
+      end
+      assert_not_includes(@post.reload.tag_array, "exif_rotation")
+
+      BulkMediaRegenerationJob.perform_now(query: "id:#{@media_asset.id}")
+      @media_asset.reload
+      @post.reload
+
+      assert_equal(64, @media_asset.image_width)
+      assert_equal(128, @media_asset.image_height)
+      assert_equal(64, @post.image_width)
+      assert_equal(128, @post.image_height)
+      assert_includes(@post.tag_array, "exif_rotation")
+    end
+
+    should "not regenerate assets that don't match the query" do
+      @post = create(:post_with_file, filename: "png/test-rotation-good-chunk.png")
+      @media_asset = @post.media_asset
+      @media_asset.update_columns(image_width: 128, image_height: 64) # rubocop:disable Rails/SkipsModelValidations
+
+      BulkMediaRegenerationJob.perform_now(query: "id:#{@media_asset.id + 1}")
+
+      assert_equal(128, @media_asset.reload.image_width)
+    end
+
+    should "not abort the whole batch if one asset fails to regenerate" do
+      create(:media_asset, file_ext: "png")
+      create(:media_asset, file_ext: "png")
+
+      MediaAsset.any_instance.stubs(:regenerate!).raises(StandardError, "boom")
+
+      assert_nothing_raised do
+        BulkMediaRegenerationJob.perform_now(query: "filetype:png")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #6576. Very rough draft.

Adds a new page at `/bulk_media_regenerations/new` that accepts the same query as /media_assets.

<img width="1977" height="327" alt="image" src="https://github.com/user-attachments/assets/144090d4-37a6-425a-b94d-47e413c48585" />


<img width="2473" height="857" alt="image" src="https://github.com/user-attachments/assets/5dbc6caf-cb66-444f-98cb-22661f69c89f" />


<img width="1040" height="197" alt="image" src="https://github.com/user-attachments/assets/262355a6-90eb-4cb8-a2ee-85a8d6573053" />


Todo: 

- [ ] set find_in_batches, not sure what a reasonable amount of parallel processing is.
- [ ] add checkboxes to decide what to regenerate: we usually don't want to regenerate AI tags for example.
- [ ] if pull #6578 is merged, switch to that user level
- [ ] look into [Continuation](https://api.rubyonrails.org/classes/ActiveJob/Continuation.html) to make running these tasks smoother