### PR TITLE
Users: add superadmin level

### DIFF
--- a/app/javascript/src/styles/base/040_colors.scss
+++ b/app/javascript/src/styles/base/040_colors.scss
@@ -348,6 +348,7 @@ html, body[data-current-user-theme="light"] {
   --meta-tag-hover-color: var(--orange-2);
 
   --user-owner-color: var(--user-admin-color);
+  --user-superadmin-color: var(--user-admin-color);
   --user-admin-color: var(--red-5);
   --user-moderator-color: var(--character-tag-color);
   --user-builder-color: var(--copyright-tag-color);
@@ -358,6 +359,7 @@ html, body[data-current-user-theme="light"] {
   --user-banned-color: var(--grey-7);
 
   --user-owner-hover-color: var(--user-admin-hover-color);
+  --user-superadmin-hover-color: var(--user-admin-hover-color);
   --user-admin-hover-color: var(--red-4);
   --user-moderator-hover-color: var(--character-tag-hover-color);
   --user-builder-hover-color: var(--copyright-tag-hover-color);
@@ -611,6 +613,7 @@ html, body[data-current-user-theme="light"] {
   --meta-tag-hover-color: var(--yellow-1);
 
   --user-owner-color: var(--user-admin-color);
+  --user-superadmin-color: var(--user-admin-color);
   --user-admin-color: var(--artist-tag-color);
   --user-moderator-color: var(--character-tag-color);
   --user-builder-color: var(--copyright-tag-color);
@@ -621,6 +624,7 @@ html, body[data-current-user-theme="light"] {
   --user-banned-color: var(--grey-5);
 
   --user-owner-hover-color: var(--user-admin-hover-color);
+  --user-superadmin-hover-color: var(--user-admin-hover-color);
   --user-admin-hover-color: var(--artist-tag-hover-color);
   --user-moderator-hover-color: var(--character-tag-hover-color);
   --user-builder-hover-color: var(--copyright-tag-hover-color);

--- a/app/javascript/src/styles/common/user_styles.scss
+++ b/app/javascript/src/styles/common/user_styles.scss
@@ -1,4 +1,5 @@
 a.user-owner { color: var(--user-owner-color); }
+a.user-superadmin { color: var(--user-superadmin-color); }
 a.user-admin { color: var(--user-admin-color); }
 a.user-moderator { color: var(--user-moderator-color); }
 a.user-approver { color: var(--user-builder-color); }
@@ -10,6 +11,7 @@ a.user-member { color: var(--user-member-color); }
 a.user-restricted { color: var(--user-restricted-color); }
 
 a.user-owner:hover { color: var(--user-owner-hover-color); }
+a.user-superadmin:hover { color: var(--user-superadmin-hover-color); }
 a.user-admin:hover { color: var(--user-admin-hover-color); }
 a.user-moderator:hover { color: var(--user-moderator-hover-color); }
 a.user-approver:hover { color: var(--user-builder-hover-color); }

--- a/app/javascript/src/styles/specific/user_tooltips.scss
+++ b/app/javascript/src/styles/specific/user_tooltips.scss
@@ -27,7 +27,8 @@
         margin-right: 0.25em;
         border-radius: 3px;
 
-        &.user-tooltip-badge-owner { background-color: var(--user-admin-color); }
+        &.user-tooltip-badge-owner { background-color: var(--user-owner-color); }
+        &.user-tooltip-badge-superadmin { background-color: var(--user-superadmin-color); }
         &.user-tooltip-badge-admin { background-color: var(--user-admin-color); }
         &.user-tooltip-badge-moderator { background-color: var(--user-moderator-color); }
         &.user-tooltip-badge-approver { background-color: var(--user-builder-color); }

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -30,7 +30,7 @@ class ApiKey < ApplicationRecord
   has_secure_token :key
 
   def self.visible(user)
-    if user.is_owner?
+    if user.is_superadmin?
       all
     else
       where(user: user)

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -29,7 +29,7 @@ class FavoriteGroup < ApplicationRecord
     end
 
     def visible(user)
-      if user.is_owner?
+      if user.is_superadmin?
         all
       elsif user.is_anonymous?
         is_public

--- a/app/models/forum_topic_visit.rb
+++ b/app/models/forum_topic_visit.rb
@@ -5,7 +5,7 @@ class ForumTopicVisit < ApplicationRecord
   belongs_to :forum_topic
 
   def self.visible(user)
-    if user.is_owner?
+    if user.is_superadmin?
       all
     else
       where(user: user)

--- a/app/models/login_session.rb
+++ b/app/models/login_session.rb
@@ -33,7 +33,7 @@ class LoginSession < ApplicationRecord
   end
 
   def self.visible(user)
-    if user.is_owner?
+    if user.is_superadmin?
       all
     else
       where(user: user)

--- a/app/models/rate_limit.rb
+++ b/app/models/rate_limit.rb
@@ -8,7 +8,7 @@ class RateLimit < ApplicationRecord
   end
 
   def self.visible(user)
-    if user.is_owner?
+    if user.is_superadmin?
       all
     elsif user.is_anonymous?
       none

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
     APPROVER = 37
     MODERATOR = 40
     ADMIN = 50
+    SUPERADMIN = 55
     OWNER = 60
   end
 
@@ -521,6 +522,7 @@ class User < ApplicationRecord
           "Approver" => Levels::APPROVER,
           "Moderator" => Levels::MODERATOR,
           "Admin" => Levels::ADMIN,
+          "Superadmin" => Levels::SUPERADMIN,
           "Owner" => Levels::OWNER,
         }
       end
@@ -588,6 +590,10 @@ class User < ApplicationRecord
 
     def is_admin?
       level >= Levels::ADMIN
+    end
+
+    def is_superadmin?
+      level >= Levels::SUPERADMIN
     end
 
     def is_owner?

--- a/app/policies/dmail_policy.rb
+++ b/app/policies/dmail_policy.rb
@@ -18,7 +18,7 @@ class DmailPolicy < ApplicationPolicy
   end
 
   def show?
-    return true if user.is_owner?
+    return true if user.is_superadmin?
     !user.is_anonymous? && record.owner_id == user.id
   end
 

--- a/app/policies/favorite_group_policy.rb
+++ b/app/policies/favorite_group_policy.rb
@@ -2,7 +2,7 @@
 
 class FavoriteGroupPolicy < ApplicationPolicy
   def show?
-    record.creator_id == user.id || record.is_public
+    record.creator_id == user.id || record.is_public || user.is_superadmin?
   end
 
   def create?

--- a/app/policies/site_credential_policy.rb
+++ b/app/policies/site_credential_policy.rb
@@ -27,7 +27,7 @@ class SiteCredentialPolicy < ApplicationPolicy
 
   def destroy?
     if record.is_public?
-      user.is_owner?
+      user.is_superadmin?
     else
       record.creator_id == user.id
     end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,7 +14,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def edit?
-    record.id == user.id || user.is_owner?
+    record.id == user.id || user.is_superadmin?
   end
 
   def update?
@@ -22,7 +22,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def deactivate?
-    (record.id == user.id && !user.is_anonymous?) || user.is_owner?
+    (record.id == user.id && !user.is_anonymous?) || user.is_superadmin?
   end
 
   def destroy?

--- a/test/functional/api_keys_controller_test.rb
+++ b/test/functional/api_keys_controller_test.rb
@@ -22,8 +22,8 @@ class ApiKeysControllerTest < ActionDispatch::IntegrationTest
         assert_select "#api-key-#{@api_key.id}", count: 0
       end
 
-      should "let the owner see all API keys" do
-        get_auth user_api_keys_path(@user.id), create(:owner_user)
+      should "let a superadmin see all API keys" do
+        get_auth user_api_keys_path(@user.id), create(:superadmin_user)
 
         assert_response :success
         assert_select "#api-key-#{@api_key.id}", count: 1

--- a/test/functional/dmails_controller_test.rb
+++ b/test/functional/dmails_controller_test.rb
@@ -99,8 +99,8 @@ class DmailsControllerTest < ActionDispatch::IntegrationTest
         assert_response 403
       end
 
-      should "show dmails to the site owner" do
-        get_auth dmail_path(@dmail), create(:owner_user)
+      should "show any dmail to a superadmin" do
+        get_auth dmail_path(@dmail), create(:superadmin_user)
         assert_response :success
       end
 

--- a/test/functional/favorite_groups_controller_test.rb
+++ b/test/functional/favorite_groups_controller_test.rb
@@ -3,14 +3,14 @@ require "test_helper"
 class FavoriteGroupsControllerTest < ActionDispatch::IntegrationTest
   context "The favorite groups controller" do
     setup do
-      @user = create(:user)
+      @user = create(:gold_user)
       @favgroup = create(:favorite_group, creator: @user)
+      @private_favgroup = create(:private_favorite_group, creator: @user)
     end
 
     context "index action" do
       setup do
         @mod_favgroup = create(:favorite_group, name: "Beautiful Smile", creator: build(:moderator_user))
-        @private_favgroup = create(:private_favorite_group)
       end
 
       should "render" do
@@ -27,7 +27,7 @@ class FavoriteGroupsControllerTest < ActionDispatch::IntegrationTest
       should respond_to_search(name_matches: "smiling beauty").with { @mod_favgroup }
 
       should respond_to_search(creator_name: -> { @mod_favgroup.creator.name }).with { @mod_favgroup }
-      should respond_to_search(creator: { level: User::Levels::MEMBER }).with { @favgroup }
+      should respond_to_search(creator: { level: User::Levels::GOLD }).with { @favgroup }
 
       should respond_to_search(is_public: "false").as_user { @private_favgroup.creator }.with { @private_favgroup }
     end
@@ -39,15 +39,17 @@ class FavoriteGroupsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "show private favgroups to the creator" do
-        @favgroup.is_public = false
-        @favgroup.save!(validate: false)
-        get_auth favorite_group_path(@favgroup), @user
+        get_auth favorite_group_path(@private_favgroup), @user
+        assert_response :success
+      end
+
+      should "show private favgroups to a superadmin" do
+        get_auth favorite_group_path(@private_favgroup), create(:superadmin_user)
         assert_response :success
       end
 
       should "not show private favgroups to other users" do
-        @favgroup = create(:private_favorite_group)
-        get_auth favorite_group_path(@favgroup), create(:user)
+        get_auth favorite_group_path(@private_favgroup), create(:user)
         assert_response 403
       end
     end
@@ -91,10 +93,12 @@ class FavoriteGroupsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not allow non-Gold users to enable private favgroups" do
-        put_auth favorite_group_path(@favgroup), @user, params: { favorite_group: { is_private: true }}
+        @member = create(:user)
+        @member_favgroup = create(:favorite_group, creator: @member)
+        put_auth favorite_group_path(@member_favgroup), @member, params: { favorite_group: { is_private: true }}
 
         assert_response :success
-        assert_equal(false, @favgroup.is_private?)
+        assert_equal(false, @member_favgroup.is_private?)
       end
     end
 

--- a/test/functional/forum_topic_visits_controller_test.rb
+++ b/test/functional/forum_topic_visits_controller_test.rb
@@ -1,13 +1,33 @@
 require "test_helper"
 
 class ForumTopicVisitsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @visit = as(@user) { create(:forum_topic_visit, user: @user) }
+    @mod_user = create(:moderator_user)
+    @mod_visit = as(@mod_user) { create(:forum_topic_visit, user: @mod_user) }
+  end
+
   context "index action" do
     should "work for json responses" do
-      @user = create(:user)
-      @visit = as(@user) { create(:forum_topic_visit, user: @user) }
       get_auth forum_topic_visits_path, @user, as: :json
 
+      assert_equal([@visit.id], response.parsed_body.pluck("id"))
       assert_response :success
+    end
+
+    should "only show the current user's forum topic visits to other users" do
+      get_auth forum_topic_visits_path, @mod_user, as: :json
+
+      assert_response :success
+      assert_equal([@mod_visit.id], response.parsed_body.pluck("id"))
+    end
+
+    should "show all forum topic visits to a superadmin" do
+      get_auth forum_topic_visits_path, create(:superadmin_user), as: :json
+
+      assert_response :success
+      assert_equal([@mod_visit.id, @visit.id], response.parsed_body.pluck("id"))
     end
   end
 end

--- a/test/functional/rate_limits_controller_test.rb
+++ b/test/functional/rate_limits_controller_test.rb
@@ -8,8 +8,8 @@ class RateLimitsControllerTest < ActionDispatch::IntegrationTest
         create(:rate_limit, key: @user.cache_key)
       end
 
-      should "show all rate limits to the owner" do
-        get_auth rate_limits_path, create(:owner_user)
+      should "show all rate limits to a superadmin" do
+        get_auth rate_limits_path, create(:superadmin_user)
 
         assert_response :success
         assert_select "tbody tr", count: 3 # the login action creates 3 rate limits: 1 for the IP, 1 for the user ID, and 1 for the session ID

--- a/test/functional/site_credentials_controller_test.rb
+++ b/test/functional/site_credentials_controller_test.rb
@@ -137,8 +137,8 @@ class SiteCredentialsControllerTest < ActionDispatch::IntegrationTest
     end
 
     context "destroy action" do
-      should "allow the owner to delete credentials" do
-        @user = create(:owner_user)
+      should "allow a superadmin to delete credentials" do
+        @user = create(:superadmin_user)
         @site_credential = create(:site_credential)
         assert_equal(true, ModAction.exists?(category: "site_credential_create"))
 

--- a/test/functional/static_controller_test.rb
+++ b/test/functional/static_controller_test.rb
@@ -114,7 +114,7 @@ class StaticControllerTest < ActionDispatch::IntegrationTest
 
   context "contact action" do
     should "work" do
-      create(:owner_user)
+      create(:user)
 
       get contact_path
       assert_response :success

--- a/test/functional/user_actions_controller_test.rb
+++ b/test/functional/user_actions_controller_test.rb
@@ -47,6 +47,11 @@ class UserActionsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
       end
 
+      should "render for a superadmin" do
+        get_auth user_actions_path(limit: 1000), create(:superadmin_user)
+        assert_response :success
+      end
+
       should "render for an admin" do
         get_auth user_actions_path(limit: 1000), create(:admin_user)
         assert_response :success

--- a/test/functional/user_upgrades_controller_test.rb
+++ b/test/functional/user_upgrades_controller_test.rb
@@ -121,7 +121,7 @@ class UserUpgradesControllerTest < ActionDispatch::IntegrationTest
 
         should "be inaccessible to other users" do
           @user_upgrade = create(:self_gold_upgrade, status: "complete")
-          get_auth user_upgrade_path(@user_upgrade), create(:user)
+          get_auth user_upgrade_path(@user_upgrade), create(:superadmin_user)
 
           assert_response 403
         end
@@ -153,7 +153,7 @@ class UserUpgradesControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not allow unauthorized users to view the receipt" do
-        get_auth receipt_user_upgrade_path(@user_upgrade), create(:user)
+        get_auth receipt_user_upgrade_path(@user_upgrade), create(:superadmin_user)
 
         assert_response 403
       end
@@ -238,7 +238,7 @@ class UserUpgradesControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "not allow unauthorized users to create a refund" do
-        @user_upgrade = create(:self_gold_upgrade, recipient: create(:gold_user), status: "complete")
+        @user_upgrade = create(:self_gold_upgrade, recipient: create(:superadmin_user), status: "complete")
         @user_upgrade.create_checkout!
 
         put_auth refund_user_upgrade_path(@user_upgrade), @user_upgrade.purchaser, xhr: true

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -741,8 +741,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
       end
 
-      should "allow the owner to view another user's settings" do
-        get_auth edit_user_path(@user), create(:owner_user)
+      should "allow a superadmin to view another user's settings" do
+        get_auth edit_user_path(@user), create(:superadmin_user)
         assert_response :success
       end
 

--- a/test/unit/user_deletion_test.rb
+++ b/test/unit/user_deletion_test.rb
@@ -189,9 +189,9 @@ class UserDeletionTest < ActiveSupport::TestCase
   end
 
   context "deleting another user's account" do
-    should "work for the owner-level user" do
+    should "work for a superadmin" do
       @user = create(:user)
-      @deletion = UserDeletion.new(user: @user, deleter: create(:owner_user))
+      @deletion = UserDeletion.new(user: @user, deleter: create(:superadmin_user))
 
       @deletion.delete!
       assert_equal("user_#{@user.id}", @user.reload.name)
@@ -220,7 +220,7 @@ class UserDeletionTest < ActiveSupport::TestCase
   context "undeleting a user's account" do
     should "restore the user's name and reset their password" do
       @user = create(:user, name: "fumimi", password: "hunter2")
-      @deletion = UserDeletion.new(user: @user, deleter: create(:owner_user), password: "hunter2")
+      @deletion = UserDeletion.new(user: @user, deleter: create(:superadmin_user), password: "hunter2")
 
       @deletion.delete!
       assert_equal("user_#{@user.id}", @user.reload.name)

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -24,6 +24,7 @@ class UserTest < ActiveSupport::TestCase
         @builder = create(:builder_user)
         @mod = create(:moderator_user)
         @admin = create(:admin_user)
+        @superadmin = create(:superadmin_user)
         @owner = create(:owner_user)
       end
 
@@ -36,6 +37,7 @@ class UserTest < ActiveSupport::TestCase
 
         assert_not_promoted_to(User::Levels::MODERATOR, @user, @mod)
         assert_not_promoted_to(User::Levels::ADMIN, @user, @mod)
+        assert_not_promoted_to(User::Levels::SUPERADMIN, @user, @mod)
         assert_not_promoted_to(User::Levels::OWNER, @user, @mod)
       end
 
@@ -43,20 +45,33 @@ class UserTest < ActiveSupport::TestCase
         assert_promoted_to(User::Levels::GOLD, @user, @admin)
         assert_promoted_to(User::Levels::PLATINUM, @user, @admin)
         assert_promoted_to(User::Levels::BUILDER, @user, @admin)
-        assert_promoted_to(User::Levels::CONTRIBUTOR, @user, @mod)
+        assert_promoted_to(User::Levels::CONTRIBUTOR, @user, @admin)
         assert_promoted_to(User::Levels::APPROVER, @user, @admin)
         assert_promoted_to(User::Levels::MODERATOR, @user, @admin)
 
         assert_not_promoted_to(User::Levels::ADMIN, @user, @admin)
+        assert_not_promoted_to(User::Levels::SUPERADMIN, @user, @admin)
         assert_not_promoted_to(User::Levels::OWNER, @user, @admin)
       end
 
-      should "allow the owner to promote users up to admin level" do
+      should "allow a superadmin to promote users up to admin level" do
+        assert_promoted_to(User::Levels::GOLD, @user, @superadmin)
+        assert_promoted_to(User::Levels::PLATINUM, @user, @superadmin)
+        assert_promoted_to(User::Levels::BUILDER, @user, @superadmin)
+        assert_promoted_to(User::Levels::MODERATOR, @user, @superadmin)
+        assert_promoted_to(User::Levels::ADMIN, @user, @superadmin)
+
+        assert_not_promoted_to(User::Levels::SUPERADMIN, @user, @superadmin)
+        assert_not_promoted_to(User::Levels::OWNER, @user, @superadmin)
+      end
+
+      should "allow the owner to promote users up to superadmin level" do
         assert_promoted_to(User::Levels::GOLD, @user, @owner)
         assert_promoted_to(User::Levels::PLATINUM, @user, @owner)
         assert_promoted_to(User::Levels::BUILDER, @user, @owner)
         assert_promoted_to(User::Levels::MODERATOR, @user, @owner)
         assert_promoted_to(User::Levels::ADMIN, @user, @owner)
+        assert_promoted_to(User::Levels::SUPERADMIN, @user, @owner)
 
         assert_not_promoted_to(User::Levels::OWNER, @user, @owner)
       end
@@ -67,6 +82,7 @@ class UserTest < ActiveSupport::TestCase
         assert_not_promoted_to(User::Levels::BUILDER, @user, @builder)
         assert_not_promoted_to(User::Levels::MODERATOR, @user, @builder)
         assert_not_promoted_to(User::Levels::ADMIN, @user, @builder)
+        assert_not_promoted_to(User::Levels::SUPERADMIN, @user, @builder)
         assert_not_promoted_to(User::Levels::OWNER, @user, @builder)
       end
 
@@ -75,6 +91,7 @@ class UserTest < ActiveSupport::TestCase
         assert_not_promoted_to(User::Levels::BUILDER, create(:moderator_user), @mod)
 
         assert_not_promoted_to(User::Levels::OWNER, create(:admin_user), @admin)
+        assert_not_promoted_to(User::Levels::SUPERADMIN, create(:admin_user), @admin)
         assert_not_promoted_to(User::Levels::MODERATOR, create(:admin_user), @admin)
 
         assert_not_promoted_to(User::Levels::ADMIN, create(:owner_user), @owner)
@@ -82,6 +99,7 @@ class UserTest < ActiveSupport::TestCase
 
       should "not allow users to promote themselves" do
         assert_not_promoted_to(User::Levels::ADMIN, @mod, @mod)
+        assert_not_promoted_to(User::Levels::SUPERADMIN, @admin, @admin)
         assert_not_promoted_to(User::Levels::OWNER, @admin, @admin)
       end
 
@@ -137,26 +155,40 @@ class UserTest < ActiveSupport::TestCase
     should "normalize its level" do
       user = create(:user, level: User::Levels::OWNER)
       assert(user.is_owner?)
+      assert(user.is_superadmin?)
       assert(user.is_admin?)
       assert(user.is_moderator?)
       assert(user.is_gold?)
 
+      user = create(:user, level: User::Levels::SUPERADMIN)
+      assert_equal(false, user.is_owner?)
+      assert_equal(true, user.is_superadmin?)
+      assert_equal(true, user.is_moderator?)
+      assert_equal(true, user.is_gold?)
+
       user = create(:user, level: User::Levels::ADMIN)
       assert_equal(false, user.is_owner?)
+      assert_equal(false, user.is_superadmin?)
       assert_equal(true, user.is_moderator?)
       assert_equal(true, user.is_gold?)
 
       user = create(:user, level: User::Levels::MODERATOR)
+      assert_equal(false, user.is_owner?)
+      assert_equal(false, user.is_superadmin?)
       assert_equal(false, user.is_admin?)
       assert_equal(true, user.is_moderator?)
       assert_equal(true, user.is_gold?)
 
       user = create(:user, level: User::Levels::GOLD)
+      assert_equal(false, user.is_owner?)
+      assert_equal(false, user.is_superadmin?)
       assert_equal(false, user.is_admin?)
       assert_equal(false, user.is_moderator?)
       assert_equal(true, user.is_gold?)
 
       user = create(:user)
+      assert_equal(false, user.is_owner?)
+      assert_equal(false, user.is_superadmin?)
       assert_equal(false, user.is_admin?)
       assert_equal(false, user.is_moderator?)
       assert_equal(false, user.is_gold?)


### PR DESCRIPTION
Superadmins are a step above admins: they can perform dangerous and potentially irreversible database actions like user deactivation, and sensitive actions such as viewing all dmails and private favorite groups. They can also promote and demote other admins.

This is a role for site staff that already has some degree of access to destructive backend functions and analytics. In the future, this role may be able to perform backend actions such as launching database migrations or metadata regeneration scripts from the site interface, so downstream boorus should be extremely conservative in assigning this role.

Site owners retain the exclusive ability to handle legally sensitive actions, such as those related to DMCA processing or payments/refunds.