### PR TITLE
Add tag tooltips

### DIFF
--- a/app/components/tag_tooltip_component.rb
+++ b/app/components/tag_tooltip_component.rb
@@ -34,7 +34,9 @@ class TagTooltipComponent < ApplicationComponent
   end
 
   # @return [Nokogiri::HTML5::Node, nil] The wiki page's first media embed, if any.
+  # Not shown for artist wikis or if the wiki page has no meaningful text.
   def embed
+    return nil if tag.artist? || paragraph.blank?
     excerpt&.dig(:embed)
   end
 

--- a/app/components/tag_tooltip_component.rb
+++ b/app/components/tag_tooltip_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# The tooltip that displays when you hover over a tag.
+class TagTooltipComponent < ApplicationComponent
+  attr_reader :tag, :current_user
+
+  delegate :humanized_number, :link_to_wiki_or_artist, to: :helpers
+  delegate :wiki_page, :aliased_tag, :is_aliased?, to: :tag
+
+  def initialize(tag:, current_user: CurrentUser.user)
+    super
+    @tag = tag
+    @current_user = current_user
+  end
+
+  # @return [WikiPage, nil] The wiki page, or nil if it's deleted or hidden and shouldn't be excerpted.
+  def visible_wiki_page
+    return nil if wiki_page.blank? || wiki_page.is_deleted? || tag.artist&.is_banned?
+    wiki_page
+  end
+
+  # @return [Hash, nil] see {DText#tooltip_excerpt}
+  def excerpt
+    @excerpt ||= visible_wiki_page&.dtext_body&.tooltip_excerpt(current_user: current_user)
+  end
+
+  def paragraph
+    excerpt&.dig(:paragraph)
+  end
+
+  # @return [Boolean] true if the tag is an artist tag without a meaningful wiki page.
+  def artist_without_wiki?
+    tag.artist? && paragraph.blank?
+  end
+
+  # @return [Nokogiri::HTML5::Node, nil] The wiki page's first media embed, if any.
+  def embed
+    excerpt&.dig(:embed)
+  end
+
+  # @return [String, nil] The rendered media embed's HTML.
+  def embed_html
+    embed&.to_html&.html_safe
+  end
+
+  # Only place the embed above the text (instead of beside it) if it's substantially wider than tall
+  def horizontal_embed?
+    image = embed&.at_css("img")
+    image.present? && image["width"].to_i > image["height"].to_i * 2
+  end
+
+  # @return [Boolean] true if the small edit button should be displayed
+  def display_edit_button?
+    return false if is_aliased?
+    return false if artist_without_wiki? # we don't want to encourage these
+    wiki_page.present? ? policy(wiki_page).edit? : policy(WikiPage).new?
+  end
+
+  # @return [String] The path to edit the wiki page, or to create it if it doesn't exist yet.
+  def wiki_page_edit_path
+    wiki_page.present? ? edit_wiki_page_path(wiki_page) : new_wiki_page_path(wiki_page: { title: tag.name })
+  end
+end

--- a/app/components/tag_tooltip_component/tag_tooltip_component.html.erb
+++ b/app/components/tag_tooltip_component/tag_tooltip_component.html.erb
@@ -1,0 +1,49 @@
+<div class="tag-tooltip">
+  <div class="tag-tooltip-header flex gap-2">
+    <%= link_to_wiki_or_artist(tag, text: tag.pretty_name, classes: "tag-tooltip-name") %>
+    <span class="tag-tooltip-count text-muted"><%= humanized_number(tag.post_count) %></span>
+
+    <span class="flex-grow-1"></span>
+
+    <% if display_edit_button? && %>
+      <%= link_to edit_icon(class: "h-3"), wiki_page_edit_path, class: "tag-tooltip-edit inactive-link", title: wiki_page.present? ? "Edit wiki page" : "Create wiki page" %>
+    <% end %>
+  </div>
+
+  <div class="tag-tooltip-body flex gap-2 <%= "flex-col" if horizontal_embed? %>">
+    <% if embed.present? && horizontal_embed? %>
+      <div class="tag-tooltip-embed"><%= embed_html %></div>
+    <% end %>
+
+    <div class="tag-tooltip-text prose thin-scrollbar flex-1 min-w-0">
+      <% if paragraph.present? %>
+        <%= paragraph.to_html.html_safe %>
+      <% elsif is_aliased? %>
+        <p class="text-muted">
+          This tag is aliased to <%= link_to_wiki_or_artist(aliased_tag) %>.
+        </p>
+      <% elsif artist_without_wiki? %>
+        <p class="text-muted">Artist.</p>
+      <% else %>
+        <p class="text-muted">
+          This tag doesn't have a wiki page. <%= link_to "Create one now", wiki_page_edit_path %>.
+        </p>
+      <% end %>
+    </div>
+
+    <% if embed.present? && !horizontal_embed? %>
+      <div class="tag-tooltip-embed flex-none"><%= embed_html %></div>
+    <% end %>
+  </div>
+
+  <% if tag.is_deprecated? %>
+    <p class="fineprint">This tag is <%= link_to "deprecated", wiki_page_path("help:deprecation_notice") %>.</p>
+  <% end %>
+
+  <% if tag.antecedent_implications.present? %>
+    <p class="fineprint">
+      This tag implicates
+      <%= to_sentence(tag.antecedent_implications.sort_by(&:consequent_name).map { |ti| link_to_wiki_or_artist ti.consequent_tag }) %>.
+    </p>
+  <% end %>
+</div>

--- a/app/components/tag_tooltip_component/tag_tooltip_component.html.erb
+++ b/app/components/tag_tooltip_component/tag_tooltip_component.html.erb
@@ -24,7 +24,7 @@
         </p>
       <% elsif artist_without_wiki? %>
         <p class="text-muted">Artist.</p>
-      <% else %>
+      <% elsif visible_wiki_page.blank? %>
         <p class="text-muted">
           This tag doesn't have a wiki page. <%= link_to "Create one now", wiki_page_edit_path %>.
         </p>

--- a/app/components/tag_tooltip_component/tag_tooltip_component.scss
+++ b/app/components/tag_tooltip_component/tag_tooltip_component.scss
@@ -1,0 +1,43 @@
+.tippy-box[data-theme~="tag-tooltip"] {
+  width: max-content; // needed to keep nested tooltips from squishing down to their parents' size
+  min-width: 200px;
+  max-width: 400px !important;
+
+  .tag-tooltip-header {
+    margin-bottom: 0.5em;
+    align-items: baseline;
+
+    .tag-tooltip-count {
+      font-size: 0.85em;
+    }
+  }
+
+  .tag-tooltip-body {
+    .tag-tooltip-embed img {
+      display: block;
+      max-width: 150px;
+      max-height: 150px;
+      width: auto;
+      height: auto;
+      margin: 0 auto;
+      border-radius: 4px;
+    }
+
+    .tag-tooltip-text {
+      font-size: 0.9em;
+      max-height: 150px;
+
+      p {
+        margin: 0;
+      }
+    }
+  }
+
+  .fineprint {
+    margin: 0.4em 0 0;
+
+    & + .fineprint {
+      margin-top: 0.2em;
+    }
+  }
+}

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -15,8 +15,10 @@ class TagsController < ApplicationController
   end
 
   def show
-    @tag = authorize Tag.find(params[:id])
-    respond_with(@tag)
+    @tag = authorize Tag.find_by_id_or_name(params[:id])
+    respond_with(@tag) do |format|
+      format.html.tooltip { render layout: false }
+    end
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,7 +49,7 @@ module ApplicationHelper
     statuses = changed_fields.map { |field, status| status }
     altered = record.updater_id != other.updater_id
 
-    tag.div(class: "version-statuses", "data-altered": altered) do
+    tag.div("class": "version-statuses", "data-altered": altered) do
       safe_join(statuses, tag.br)
     end
   end
@@ -168,7 +168,7 @@ module ApplicationHelper
       if compact
         text = time_ago_in_words(time)
         text = text.gsub(/almost|about|over/, "").strip
-        text = text.gsub(/less than a/, "<1")
+        text = text.gsub("less than a", "<1")
         text = text.gsub(/ minutes?/, "m")
         text = text.gsub(/ hours?/, "h")
         text = text.gsub(/ days?/, "d")
@@ -184,7 +184,7 @@ module ApplicationHelper
     elsif time.future?
       if compact
         text = distance_of_time_in_words(Time.now, time)
-        text = text.gsub(/almost|about|over/, "").gsub(/less than a/, "<1").strip
+        text = text.gsub(/almost|about|over/, "").gsub("less than a", "<1").strip
         time_tag(text, time)
       else
         time_tag("in " + distance_of_time_in_words(Time.now, time), time)
@@ -197,7 +197,7 @@ module ApplicationHelper
   end
 
   def external_link_to(url, text = url, truncate: nil, strip: false, **link_options, &block)
-    text = capture { yield } if block_given?
+    text = capture(&block) if block_given?
     text = text.gsub(%r{\Ahttps?://}i, "") if strip == :scheme
     text = text.gsub(%r{\Ahttps?://(?:www\.)?}i, "") if strip == :subdomain
     text = text.truncate(truncate) if truncate

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -224,11 +224,11 @@ module ApplicationHelper
     link_to text, wiki_page_path(title), class: "wiki-link #{classes}", **options
   end
 
-  def link_to_wiki_or_artist(tag, classes: nil, **options)
+  def link_to_wiki_or_artist(tag, text: tag.name, classes: nil, **options)
     if tag.artist?
-      link_to tag.name, show_or_new_artists_path(name: tag.name), class: "wiki-link #{classes}", **options
+      link_to text, show_or_new_artists_path(name: tag.name), "class": "wiki-link #{tag_class(tag)} #{classes}", "data-tag-name": tag.name, **options
     else
-      link_to_wiki(tag.name, classes: classes, **options)
+      link_to_wiki(text, tag.name, "classes": "#{tag_class(tag)} #{classes}", "data-tag-name": tag.name, **options)
     end
   end
 

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -47,6 +47,10 @@ module ComponentsHelper
     render FavoritesTooltipComponent.new(post: post, **options)
   end
 
+  def render_tag_tooltip(tag, **options)
+    render TagTooltipComponent.new(tag: tag, **options)
+  end
+
   def render_post_navbar(post, **options)
     render PostNavbarComponent.new(post: post, **options)
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -59,6 +59,7 @@ import PreviewSizeMenuComponent from "../src/javascripts/preview_size_menu_compo
 import RelatedTag from "../src/javascripts/related_tag.js";
 import Shortcuts from "../src/javascripts/shortcuts.js";
 import TagCounter from "../src/javascripts/tag_counter.js";
+import TagTooltip from "../src/javascripts/tag_tooltips.js";
 import TimeSeriesComponent from "../src/javascripts/time_series_component.js";
 import UploadPostComponent from "../src/javascripts/upload_post_component.js";
 import UploadMediaAsset from "../src/javascripts/upload_media_assets.js";
@@ -95,6 +96,7 @@ Danbooru.PreviewSizeMenuComponent = PreviewSizeMenuComponent;
 Danbooru.RelatedTag = RelatedTag;
 Danbooru.Shortcuts = Shortcuts;
 Danbooru.TagCounter = TagCounter;
+Danbooru.TagTooltip = TagTooltip;
 Danbooru.TimeSeriesComponent = TimeSeriesComponent;
 Danbooru.UploadPostComponent = UploadPostComponent;
 Danbooru.UploadMediaAsset = UploadMediaAsset;

--- a/app/javascript/src/javascripts/tag_tooltips.js
+++ b/app/javascript/src/javascripts/tag_tooltips.js
@@ -21,6 +21,7 @@ TagTooltip.initialize = function () {
     duration: TagTooltip.DURATION,
     touch: false,
 
+    onTrigger: TagTooltip.on_trigger,
     onShow: TagTooltip.on_show,
     onHide: TagTooltip.on_hide,
   }
@@ -37,6 +38,10 @@ TagTooltip.initialize = function () {
 // @return {Boolean} true if this tooltip is inside another tooltip
 TagTooltip.is_nested = function ($target) {
   return $target.closest("[data-tippy-root]").length > 0;
+};
+
+TagTooltip.on_trigger = function (instance) {
+  instance.reference.removeAttribute("title");
 };
 
 TagTooltip.on_show = async function (instance) {

--- a/app/javascript/src/javascripts/tag_tooltips.js
+++ b/app/javascript/src/javascripts/tag_tooltips.js
@@ -1,0 +1,109 @@
+import CurrentUser from './current_user';
+import Notice from './notice';
+import { createTooltip } from './utility';
+import { hideAll } from 'tippy.js';
+
+let TagTooltip = {};
+
+TagTooltip.SELECTOR = "a.search-tag, a[data-tag-name]";
+TagTooltip.SHOW_DELAY = 500;
+TagTooltip.HIDE_DELAY = 125;
+TagTooltip.DURATION = 250;
+TagTooltip.PRELOAD_TIMEOUT = 500;
+
+TagTooltip.initialize = function () {
+  if (TagTooltip.disabled()) {
+    return;
+  }
+
+  let options = {
+    delay: [TagTooltip.SHOW_DELAY, TagTooltip.HIDE_DELAY],
+    duration: TagTooltip.DURATION,
+    touch: false,
+
+    onShow: TagTooltip.on_show,
+    onHide: TagTooltip.on_hide,
+  }
+
+  createTooltip("tag-tooltip", {
+    target: TagTooltip.SELECTOR,
+    // A tag link may be inside another tooltip. In that case, append inside that ancestor tooltip's .tippy-box
+    // instead of the default #tooltips container.
+    appendTo: reference => reference.closest(".tippy-box") ?? document.querySelector("#tooltips"),
+    ...options
+  });
+};
+
+// @return {Boolean} true if this tooltip is inside another tooltip
+TagTooltip.is_nested = function ($target) {
+  return $target.closest("[data-tippy-root]").length > 0;
+};
+
+TagTooltip.on_show = async function (instance) {
+  let $target = $(instance.reference);
+  let $tooltip = $(instance.popper);
+
+  // Hide other open tooltips, unless this tooltip is nested inside another tooltip
+  if (!TagTooltip.is_nested($target)) {
+    hideAll({ exclude: instance });
+  }
+
+  // skip if tooltip has already been rendered.
+  if ($tooltip.has(".tag-tooltip").length) {
+    return;
+  }
+
+  let tag_name = $target.attr("data-tag-name") || $target.closest("[data-tag-name]").data("tag-name");
+
+  // A numeric tag name (e.g. "1") is ambiguous with a tag id, so prefix it with a "~" to force the
+  // controller to look it up by name instead (see Tag.find_by_id_or_name).
+  let tag_id = /^\d+$/.test(tag_name) ? `~${tag_name}` : tag_name;
+
+  try {
+    $tooltip.addClass("tooltip-loading");
+
+    instance._request = $.get(`/tags/${encodeURIComponent(tag_id)}`, { variant: "tooltip" });
+    let html = await instance._request;
+
+    // Wait for the embedded thumbnail (if any) to finish loading before revealing the tooltip, so it
+    // doesn't pop in a moment after the tooltip itself appears.
+    await TagTooltip.preload_image(html);
+
+    instance.setContent(html);
+    $tooltip.removeClass("tooltip-loading");
+  } catch (error) {
+    if (error.status !== 0 && error.statusText !== "abort") {
+      Notice.error(`Error displaying tooltip for tag ${tag_name} (error: ${error.status} ${error.statusText})`);
+    }
+  }
+};
+
+// @param {String} html - The tooltip's HTML, not yet attached to the document.
+// @return {Promise} Resolves once the tooltip's embed thumbnail (if any) has loaded, or after
+//   PRELOAD_TIMEOUT elapses, whichever comes first.
+TagTooltip.preload_image = function (html) {
+  let src = $(html).find(".tag-tooltip-embed img").attr("src");
+  if (!src) {
+    return Promise.resolve();
+  }
+
+  let image = Object.assign(new Image(), { src });
+  return Promise.race([
+    image.decode().catch(() => null),
+    new Promise(resolve => setTimeout(resolve, TagTooltip.PRELOAD_TIMEOUT)),
+  ]);
+};
+
+TagTooltip.on_hide = function (instance) {
+  if (instance._request?.state() === "pending") {
+    instance._request.abort();
+  }
+}
+
+TagTooltip.disabled = function (event) {
+  return CurrentUser.data("disable-post-tooltips");
+};
+
+$(document).ready(TagTooltip.initialize);
+
+export default TagTooltip

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -81,14 +81,15 @@ class DText
   #
   # @param references [Hash<Symbol, Array<ActiveRecord::Base>] The database records needed to render this DText.
   # @param current_user [User] The user viewing the DText (used for determining visibility of media embeds).
+  # @param static [Boolean] If true, render media embeds as static thumbnails instead of playable videos.
   # @return [String, nil] The HTML output
-  def format_text(references: DText.preprocess([dtext]), current_user: User.anonymous)
+  def format_text(references: DText.preprocess([dtext]), current_user: User.anonymous, static: false)
     return nil if dtext.nil?
 
     fragment = parsed_html.dup
 
     fragment.css("media-embed").each do |node|
-      replace_media_embed!(node, posts: references[:posts], media_assets: references[:media_assets], current_user:)
+      replace_media_embed!(node, posts: references[:posts], media_assets: references[:media_assets], current_user:, static:)
     end
 
     fragment.css("tag-request-embed").each do |node|
@@ -120,6 +121,7 @@ class DText
 
     if tag.present?
       node["class"] += " tag-type-#{tag.category}"
+      node["data-tag-name"] = tag.name
     end
 
     if tag.present? && tag.artist?
@@ -163,10 +165,10 @@ class DText
   #       </div>
   #       <div class="media-embed-caption">Caption.</div>
   #     </article>
-  def replace_media_embed!(node, posts:, media_assets:, current_user:)
+  def replace_media_embed!(node, posts:, media_assets:, current_user:, static: false, caption: true)
     type = node["data-type"]
     id = node["data-id"].to_i
-    caption = node.inner_html.presence
+    caption_text = node.inner_html.presence if caption
 
     if type == "post"
       asset = posts.find { it.id == id }&.media_asset
@@ -184,8 +186,8 @@ class DText
     if asset.nil? || !asset.active? || asset.is_flash? || !asset.policy(current_user).can_see_image?
       link_attributes = %{class="inactive-link flex items-center justify-center border rounded max-w-150px w-full aspect-square"}
       asset_html = %{<a #{link_attributes} href="#{href}">#{ApplicationController.helpers.image_icon}</a>}
-      caption ||= "This #{type} is unavailable."
-    elsif asset.is_image?
+      caption_text ||= "This #{type} is unavailable." if caption
+    elsif asset.is_image? || ((asset.is_ugoira? || asset.is_video?) && static)
       variant = asset.variant(:"720x720")
       asset_html = %{<a class="inline-block" href="#{href}"><img src="#{variant.file_url}" width="#{variant.width}" height="#{variant.height}"></a>}
     elsif asset.is_ugoira?
@@ -195,7 +197,7 @@ class DText
     end
 
     node.inner_html  = %{<div class="media-embed-image">#{asset_html}</div>}
-    node.inner_html += %{<div class="media-embed-caption p-2 text-xs text-center text-muted text-balance">#{caption}</div>} if caption.present?
+    node.inner_html += %{<div class="media-embed-caption p-2 text-xs text-center text-muted text-balance">#{caption_text}</div>} if caption_text.present?
   end
 
   # Replace a <tag-request-embed> node with the contents of the alias, implication, or bulk update request.
@@ -751,6 +753,21 @@ class DText
   # @return [String] a plain text string
   def excerpt(length: 160)
     strip_dtext.split(/\r\n|\r|\n/).first.to_s.truncate(length)
+  end
+
+  # Return the first paragraph and first visible media embed in this DText.
+  #
+  # @param current_user [User] The user viewing the DText.
+  # @param references [Hash<Symbol, Array<ActiveRecord::Base>] see {#format_text}
+  # @return [Hash] a hash with :paragraph (a Nokogiri node, or nil) and :embed (the rendered media embed
+  #   node, without a caption, or nil)
+  def tooltip_excerpt(current_user: User.anonymous, references: DText.preprocess([dtext]))
+    fragment = DText.parse_html(format_text(references:, current_user:, static: true))
+
+    embed = fragment.css(".dtext-media-embed").find { |node| node.at_css("img") }
+    embed&.at_css(".media-embed-caption")&.remove
+
+    { paragraph: fragment.at_css("p"), embed: }
   end
 
   # Parse a string of HTML to a document object.

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -15,11 +15,8 @@ class DText
   DEFAULT_EMOJI_LIST = DEFAULT_EMOJI_MAP.keys.map(&:downcase)
 
   # post #1234, pixiv #1234, etc. The canonical list is in lib/dtext_rb/ext/dtext/dtext.cpp.rl.
-  SHORTLINKS = %w[
-    alias appeal artist asset ban bur comment dmail favgroup feedback flag forum implication mod\ action modreport
-    note pool post topic user wiki
-    issue pull commit
-    artstation deviantart gelbooru nijie pawoo pixiv pixiv sankaku seiga twitter yandere
+  SHORTLINKS = [
+    "alias", "appeal", "artist", "asset", "ban", "bur", "comment", "dmail", "favgroup", "feedback", "flag", "forum", "implication", "mod action", "modreport", "note", "pool", "post", "topic", "user", "wiki", "issue", "pull", "commit", "artstation", "deviantart", "gelbooru", "nijie", "pawoo", "pixiv", "pixiv", "sankaku", "seiga", "twitter", "yandere",
   ]
 
   attr_reader :dtext, :inline, :disable_mentions, :media_embeds, :base_url, :domain, :alternate_domains, :emoji_list, :emoji_map, :options
@@ -114,7 +111,7 @@ class DText
   # Replace an <a class="dtext-wiki-link"> tag with a colorized link.
   def replace_wiki_link!(node, wiki_pages:, tags:, artists:)
     path = Addressable::URI.parse(node["href"]).path
-    name = path[%r!/wiki_pages/(.*)\z!i, 1]
+    name = path[%r{/wiki_pages/(.*)\z}i, 1]
     name = CGI.unescape(name)
     name = WikiPage.normalize_title(name)
     wiki = wiki_pages.find { it.title == name }
@@ -541,7 +538,7 @@ class DText
       when "br"
         "\n"
       when "text"
-        node.text.gsub(/_/, '\_').gsub(/\*/, '\*')
+        node.text.gsub("_", '\_').gsub("*", '\*')
       when "p", "h1", "h2", "h3", "h4", "h5", "h6"
         html_to_markdown(node) + "\n\n"
       else

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -233,7 +233,7 @@ class Tag < ApplicationRecord
 
     class_methods do
       def normalize_name(name)
-        name.to_s.downcase.strip.tr(" ", "_").to_s
+        name.to_s.downcase.strip.delete_prefix("~").tr(" ", "_").to_s
       end
 
       def create_for_list(names)
@@ -373,6 +373,10 @@ class Tag < ApplicationRecord
 
     def find_by_name_or_alias(name)
       find_by_name(TagAlias.to_aliased(normalize_name(name)))
+    end
+
+    def find_by_id_or_name(id)
+      (id =~ /\A\d+\z/) ? find(id) : find_by_name!(normalize_name(id))
     end
 
     def find_by_abbreviation(abbrev)

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -174,7 +174,7 @@
       </h2>
       Creator: <%= link_to_user @post_set.favgroup.creator %>
     <% elsif @post_set.has_blank_wiki? %>
-      <p>There is no wiki page yet for the tag <%= link_to_wiki @post_set.tag.pretty_name %>. <%= link_to "Create new wiki page", new_wiki_page_path(wiki_page: { title: @post_set.tag.name }), rel: "nofollow" %>.</p>
+      <p>There is no wiki page yet for the tag <%= link_to_wiki @post_set.tag.pretty_name %>. <%= link_to "Create one now", new_wiki_page_path(wiki_page: { title: @post_set.tag.name }), rel: "nofollow" %>.</p>
 
       <%= render "tag_relationships/alias_and_implication_list", tag: @post_set.tag %>
 

--- a/app/views/tags/show.html+tooltip.erb
+++ b/app/views/tags/show.html+tooltip.erb
@@ -1,0 +1,1 @@
+<%= render_tag_tooltip(@tag, current_user: CurrentUser.user) %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -69,7 +69,7 @@
             <% end %>
             <%= f.input :disable_tagged_filenames, as: :boolean, wrapper: "stacked-toggle-switch", hint: "Don't include tags in image filenames" %>
             <%= f.input :disable_mobile_gestures, as: :boolean, wrapper: "stacked-toggle-switch", hint: "Disable swipe left / swipe right gestures on mobile" %>
-            <%= f.input :disable_post_tooltips, as: :boolean, wrapper: "stacked-toggle-switch", hint: "Disable advanced tooltips when hovering over thumbnails" %>
+            <%= f.input :disable_post_tooltips, label: "Disable tooltips", as: :boolean, wrapper: "stacked-toggle-switch", hint: "Disable advanced tooltips when hovering over posts and tags" %>
             <%= f.input :enable_desktop_mode, as: :boolean, wrapper: "stacked-toggle-switch", hint: "Use the desktop layout on mobile" %>
 
             <%= f.input :favorite_tags, :label => "Frequent tags", :hint => "A list of tags that you use often. They will appear when using the list of Related Tags.", :input_html => { :data => { :autocomplete => "tag-query" } } %>

--- a/app/views/wiki_pages/_recent_changes.html.erb
+++ b/app/views/wiki_pages/_recent_changes.html.erb
@@ -2,7 +2,7 @@
   <h2>Recent Changes (<%= link_to "all", wiki_page_versions_path %>)</h2>
   <ul>
     <% WikiPage.order(updated_at: :desc).includes(:tag).limit(25).each do |page| %>
-      <li><%= link_to page.pretty_title, wiki_page_path(page), class: tag_class(page.tag) %></li>
+      <li><%= link_to page.pretty_title, wiki_page_path(page), class: tag_class(page.tag), "data-tag-name": page.tag&.name %></li>
     <% end %>
   </ul>
 </section>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -30,7 +30,7 @@
     <% if @wiki_page.new_record? %>
       <p>This wiki page does not exist.
         <% if policy(@wiki_page).create? %>
-          <%= link_to "Create new wiki page", new_wiki_page_path(wiki_page: { title: @wiki_page.title }), rel: "nofollow" %>.</p>
+          <%= link_to "Create one now", new_wiki_page_path(wiki_page: { title: @wiki_page.title }), rel: "nofollow" %>.</p>
         <% end %>
       </p>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -241,7 +241,7 @@ Rails.application.routes.draw do
   end
   resource :source, only: [:show]
   resource :status, only: [:show], controller: "status"
-  resources :tags
+  resources :tags, id: /.+?(?=\.json|\.xml|\.html)|.+/
   resources :tag_aliases, only: [:show, :index, :destroy]
   resources :tag_implications, only: [:show, :index, :destroy]
   resources :tag_versions, only: [:index, :show]

--- a/test/components/tag_tooltip_component_test.rb
+++ b/test/components/tag_tooltip_component_test.rb
@@ -5,7 +5,7 @@ class TagTooltipComponentTest < ViewComponent::TestCase
     should "not show the embed if it's from an explicit post and safe mode is enabled" do
       explicit_post = create(:post, rating: "e")
       tag = create(:tag, name: "touhou", post_count: 1)
-      create(:wiki_page, title: tag.name, body: "!post ##{explicit_post.id}")
+      create(:wiki_page, title: tag.name, body: "A description.\n\n!post ##{explicit_post.id}")
 
       CurrentUser.set(safe_mode: true) do
         render_inline(TagTooltipComponent.new(tag: tag, current_user: create(:user)))
@@ -18,7 +18,7 @@ class TagTooltipComponentTest < ViewComponent::TestCase
     should "show the embed if it's from a general post" do
       general_post = create(:post, rating: "g")
       tag = create(:tag, name: "touhou", post_count: 1)
-      create(:wiki_page, title: tag.name, body: "!post ##{general_post.id}")
+      create(:wiki_page, title: tag.name, body: "A description.\n\n!post ##{general_post.id}")
 
       CurrentUser.set(safe_mode: true) do
         render_inline(TagTooltipComponent.new(tag: tag, current_user: create(:user)))
@@ -26,6 +26,37 @@ class TagTooltipComponentTest < ViewComponent::TestCase
 
       assert_css(".tag-tooltip")
       assert_css(".tag-tooltip-embed")
+    end
+
+    should "not show the embed for an artist wiki" do
+      general_post = create(:post, rating: "g")
+      tag = create(:artist_tag, name: "touhou", post_count: 1)
+      create(:wiki_page, title: tag.name, body: "A description.\n\n!post ##{general_post.id}")
+
+      render_inline(TagTooltipComponent.new(tag: tag, current_user: create(:user)))
+
+      assert_css(".tag-tooltip")
+      assert_no_css(".tag-tooltip-embed")
+    end
+
+    should "not show the embed if the wiki page has no meaningful text" do
+      general_post = create(:post, rating: "g")
+      tag = create(:tag, name: "touhou", post_count: 1)
+      create(:wiki_page, title: tag.name, body: "!post ##{general_post.id}")
+
+      render_inline(TagTooltipComponent.new(tag: tag, current_user: create(:user)))
+
+      assert_css(".tag-tooltip")
+      assert_no_css(".tag-tooltip-embed")
+    end
+
+    should "not show the missing wiki page message if the wiki page has no leading paragraph" do
+      tag = create(:tag, name: "touhou", post_count: 1)
+      create(:wiki_page, title: tag.name, body: "h4. See Also\n* lmao")
+
+      render_inline(TagTooltipComponent.new(tag: tag, current_user: create(:user)))
+
+      assert_no_text("This tag doesn't have a wiki page")
     end
 
     should "show that the tag is aliased instead of the missing wiki page message" do

--- a/test/components/tag_tooltip_component_test.rb
+++ b/test/components/tag_tooltip_component_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class TagTooltipComponentTest < ViewComponent::TestCase
+  context "The TagTooltipComponent" do
+    should "not show the embed if it's from an explicit post and safe mode is enabled" do
+      explicit_post = create(:post, rating: "e")
+      tag = create(:tag, name: "touhou", post_count: 1)
+      create(:wiki_page, title: tag.name, body: "!post ##{explicit_post.id}")
+
+      CurrentUser.set(safe_mode: true) do
+        render_inline(TagTooltipComponent.new(tag: tag, current_user: create(:user)))
+      end
+
+      assert_css(".tag-tooltip")
+      assert_no_css(".tag-tooltip-embed")
+    end
+
+    should "show the embed if it's from a general post" do
+      general_post = create(:post, rating: "g")
+      tag = create(:tag, name: "touhou", post_count: 1)
+      create(:wiki_page, title: tag.name, body: "!post ##{general_post.id}")
+
+      CurrentUser.set(safe_mode: true) do
+        render_inline(TagTooltipComponent.new(tag: tag, current_user: create(:user)))
+      end
+
+      assert_css(".tag-tooltip")
+      assert_css(".tag-tooltip-embed")
+    end
+
+    should "show that the tag is aliased instead of the missing wiki page message" do
+      antecedent = create(:tag, name: "tohou", post_count: 1)
+      consequent = create(:tag, name: "touhou", post_count: 1)
+      create(:tag_alias, antecedent_name: antecedent.name, consequent_name: consequent.name)
+
+      render_inline(TagTooltipComponent.new(tag: antecedent, current_user: create(:user)))
+
+      assert_no_text("This tag doesn't have a wiki page")
+      assert_text("This tag is aliased to touhou")
+      assert_css(".tag-tooltip-text a.wiki-link[data-tag-name='touhou']")
+    end
+  end
+end

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -91,6 +91,59 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
         get tag_path(@tag)
         assert_response :success
       end
+
+      should "render given a tag name instead of an id" do
+        get tag_path(@tag.name)
+        assert_response :success
+      end
+
+      context "for a tooltip" do
+        should "render the tag's wiki page excerpt" do
+          create(:wiki_page, title: @tag.name, body: "A description of the tag.")
+
+          get tag_path(@tag.name, variant: "tooltip")
+          assert_response :success
+          assert_select ".tag-tooltip-text p", "A description of the tag."
+        end
+
+        should "render a message when the tag doesn't have a wiki page" do
+          get tag_path(@tag, variant: "tooltip")
+          assert_response :success
+          assert_select ".tag-tooltip-text", /doesn't have a wiki page/
+        end
+
+        should "show when the tag is deprecated" do
+          tag = create(:tag, name: "deprecated_tag", is_deprecated: true)
+
+          get tag_path(tag.name, variant: "tooltip")
+          assert_response :success
+          assert_select ".fineprint", /This tag is deprecated/
+        end
+
+        should "show when the tag implies another tag" do
+          implied = create(:tag, name: "implied_tag")
+          create(:tag_implication, antecedent_name: @tag.name, consequent_name: implied.name)
+
+          get tag_path(@tag.name, variant: "tooltip")
+          assert_response :success
+          assert_select ".fineprint", /This tag implicates implied_tag/
+          assert_select ".fineprint a[data-tag-name=?]", "implied_tag"
+        end
+
+        should "show a link to create a wiki page when there's none" do
+          get_auth tag_path(@tag.name, variant: "tooltip"), @user
+          assert_response :success
+          assert_select ".tag-tooltip-edit[href=?]", new_wiki_page_path(wiki_page: { title: @tag.name })
+        end
+
+        should "show a link to edit the existing deleted wiki page instead of creating a new one" do
+          wiki_page = create(:wiki_page, title: @tag.name, body: "A description of the tag.", is_deleted: true)
+
+          get_auth tag_path(@tag.name, variant: "tooltip"), @user
+          assert_response :success
+          assert_select ".tag-tooltip-edit[href=?]", edit_wiki_page_path(wiki_page)
+        end
+      end
     end
 
     context "edit action" do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
+  helper TagsHelper
+
   context "The application helper" do
     context "format_text method" do
       should "not raise an exception for invalid DText" do
@@ -8,6 +10,26 @@ class ApplicationHelperTest < ActionView::TestCase
 
         assert_nothing_raised { format_text(dtext) }
         assert_equal("", format_text(dtext))
+      end
+    end
+
+    context "link_to_wiki_or_artist method" do
+      should "render a colorized, tooltip-enabled link for a regular tag" do
+        tag = create(:copyright_tag, name: "touhou")
+        link = link_to_wiki_or_artist(tag)
+
+        assert_match(/#{Regexp.quote(wiki_page_path(tag.name))}/, link)
+        assert_match(/tag-type-#{tag.category}/, link)
+        assert_match(/data-tag-name="touhou"/, link)
+      end
+
+      should "render a colorized, tooltip-enabled link for an artist tag" do
+        tag = create(:artist_tag, name: "some_artist")
+        link = link_to_wiki_or_artist(tag)
+
+        assert_match(/#{Regexp.quote(show_or_new_artists_path(name: tag.name))}/, link)
+        assert_match(/tag-type-#{tag.category}/, link)
+        assert_match(/data-tag-name="some_artist"/, link)
       end
     end
 

--- a/test/system/tag_tooltip_test.rb
+++ b/test/system/tag_tooltip_test.rb
@@ -1,0 +1,106 @@
+require "application_system_test_case"
+
+class TagTooltipChromeTest < ChromeSystemTestCase
+  context "Tag tooltips" do
+    setup do
+      @tag = create(:tag, name: "touhou", category: Tag.categories.copyright, post_count: 1)
+      create(:wiki_page, title: @tag.name, body: "Touhou is a series of games.")
+      @post = create(:post, tag_string: @tag.name)
+    end
+
+    context "on a post's tag list" do
+      should "show the tooltip when hovering over the tag" do
+        visit post_path(@post)
+
+        find(".search-tag", text: "touhou").hover
+        assert_selector ".tag-tooltip"
+      end
+    end
+
+    context "for a wikiless artist tag" do
+      should "not prompt to create a wiki page" do
+        create(:tag, name: "some_artist", category: Tag.categories.artist, post_count: 1)
+        post = create(:post, tag_string: "some_artist")
+
+        visit post_path(post)
+
+        find(".search-tag", text: "some artist").hover
+        assert_selector ".tag-tooltip-text", text: "Artist."
+      end
+    end
+
+    context "for a tag with a video embed" do
+      should "show a static thumbnail" do
+        video_post = create(:post_with_file, filename: "webm/test-512x512.webm", tag_string: "videotag")
+        create(:wiki_page, title: "videotag", body: "!post ##{video_post.id}")
+        post = create(:post, tag_string: "videotag")
+
+        visit post_path(post)
+
+        find(".search-tag", text: "videotag").hover
+        assert_selector ".tag-tooltip"
+
+        assert_selector ".tag-tooltip .tag-tooltip-embed img"
+        assert_no_selector ".tag-tooltip .video-component"
+      end
+    end
+
+    context "on a [[tag]] dtext link" do
+      should "show the tooltip" do
+        user = create(:user, created_at: 1.month.ago)
+        comment = as(user) { create(:comment, post: @post, body: "[[touhou]]") }
+
+        visit comment_path(comment)
+        find(".dtext-wiki-link", text: "touhou").hover
+        assert_selector ".tag-tooltip"
+      end
+    end
+
+    context "hovering over multiple tags in a row" do
+      should "hide the previous tooltip instead of showing both at once" do
+        create(:tag, name: "1girl", post_count: 1)
+        post = create(:post, tag_string: "touhou 1girl")
+
+        visit post_path(post)
+
+        find(".search-tag", text: "touhou").hover
+        assert_selector ".tag-tooltip"
+
+        find(".search-tag", text: "1girl").hover
+        assert_selector ".tag-tooltip", count: 1
+      end
+    end
+
+    context "on a tag inside a post tooltip's tag list" do
+      should "not hide the post tooltip" do
+        create(:post, tag_string: @tag.name)
+
+        visit posts_path
+
+        first(".post-preview img").hover
+        assert_selector ".post-tooltip-body"
+
+        find(".post-tooltip-body .search-tag", text: "touhou").hover
+        assert_selector ".tag-tooltip"
+        assert_selector ".post-tooltip-body"
+      end
+
+      should "not inherit the parent's tooltip size" do
+        long_tag = create(:tag, name: "long_wiki_tag", post_count: 1)
+        create(:wiki_page, title: long_tag.name, body: "word " * 200)
+        create(:post, tag_string: "#{@tag.name} #{long_tag.name}")
+
+        visit posts_path
+
+        first(".post-preview img").hover
+        assert_selector ".post-tooltip-body"
+
+        find(".post-tooltip-body .search-tag", text: "long_wiki_tag").hover
+        assert_selector ".tag-tooltip"
+
+        # The tag tooltip must escape the post tooltip's scrollable body, or it would get clipped/squashed to fit inside it.
+        assert_no_selector ".post-tooltip-body .tag-tooltip"
+      end
+    end
+  end
+end

--- a/test/system/tag_tooltip_test.rb
+++ b/test/system/tag_tooltip_test.rb
@@ -56,6 +56,21 @@ class TagTooltipChromeTest < ChromeSystemTestCase
       end
     end
 
+    context "on a [[tag]] dtext link to a wikiless tag" do
+      should "remove the native title tooltip" do
+        create(:tag, name: "no_wiki", post_count: 1)
+        user = create(:user, created_at: 1.month.ago)
+        comment = as(user) { create(:comment, post: @post, body: "[[no_wiki]]") }
+
+        visit comment_path(comment)
+        assert_selector ".dtext-wiki-link[title='This wiki page does not exist']", text: "no_wiki"
+
+        find(".dtext-wiki-link", text: "no_wiki").hover
+        assert_selector ".tag-tooltip"
+        assert_no_selector ".dtext-wiki-link[title]", text: "no_wiki"
+      end
+    end
+
     context "hovering over multiple tags in a row" do
       should "hide the previous tooltip instead of showing both at once" do
         create(:tag, name: "1girl", post_count: 1)

--- a/test/unit/d_text_test.rb
+++ b/test/unit/d_text_test.rb
@@ -131,7 +131,7 @@ class DTextTest < ActiveSupport::TestCase
         create(:tag, name: "m&m", category: Tag.categories.artist)
         create(:artist, name: "m&m")
 
-        assert_equal('<p><a class="dtext-link dtext-wiki-link tag-type-1" href="/artists/show_or_new?name=m%26m">m&amp;m</a></p>', format_text("[[m&m]]"))
+        assert_equal('<p><a class="dtext-link dtext-wiki-link tag-type-1" href="/artists/show_or_new?name=m%26m" data-tag-name="m&amp;m">m&amp;m</a></p>', format_text("[[m&m]]"))
       end
 
       should "not link general tags to artist pages" do
@@ -398,6 +398,47 @@ class DTextTest < ActiveSupport::TestCase
         assert_equal([], DText.new("[code]@foo[/code]").mentions)
         assert_equal([], DText.new("foo@bar.com").mentions)
         # assert_equal(["foo"], DText.new("@foo", disable_mentions: true).mentions) # XXX
+      end
+    end
+
+    context "#tooltip_excerpt" do
+      should "return the first paragraph and the first visible embed" do
+        post = create(:post_with_file, filename: "jpg/test.jpg") # a 500x335 landscape image
+        dtext = DText.new("First paragraph.\n\n!post ##{post.id}\n\nSecond paragraph.", media_embeds: true)
+        excerpt = dtext.tooltip_excerpt
+
+        assert_equal("<p>First paragraph.</p>", excerpt[:paragraph].to_html)
+        assert_equal("article", excerpt[:embed].name)
+        assert(excerpt[:embed].at_css("a[href=\"/posts/#{post.id}\"] img").present?)
+      end
+
+      should "render the embed without a caption" do
+        post = create(:post_with_file, filename: "jpg/test.jpg")
+        dtext = DText.new("!post ##{post.id}\n\nCaption text.", media_embeds: true)
+        embed = dtext.tooltip_excerpt[:embed]
+
+        assert_nil(embed.at_css(".media-embed-caption"))
+      end
+
+      should "return nils when there is no paragraph or embed" do
+        excerpt = DText.new("", media_embeds: true).tooltip_excerpt
+
+        assert_nil(excerpt[:paragraph])
+        assert_nil(excerpt[:embed])
+      end
+
+      should "skip embeds that don't resolve to a visible image" do
+        excerpt = DText.new("!post #1234567", media_embeds: true).tooltip_excerpt
+
+        assert_nil(excerpt[:embed])
+      end
+
+      should "skip embeds the current user isn't allowed to see" do
+        post = create(:post_with_file, filename: "jpg/test.jpg", is_banned: true)
+        dtext = DText.new("!post ##{post.id}", media_embeds: true)
+
+        assert_nil(dtext.tooltip_excerpt(current_user: create(:user))[:embed])
+        assert(dtext.tooltip_excerpt(current_user: create(:approver_user))[:embed].present?)
       end
     end
   end


### PR DESCRIPTION
Initial draft. Will go through some vigorous testing on testbooru (& betabooru after) before it's ready.

Fixes #4934.

Among the various things brought  by this pull, it also adds support for urls like http://danbooru.donmai.us/tags/1girl, just like wiki pages.
It also colors tags inside topics' BURs and implication notices (it wasn't like that before, for some reason - I guess we never remembered to implement that). Fixes #4976.


Some notes:
* picks first paragraph (everything until double newline) and embed
* animated embeds show the static thumbnail
* reuses the setting to disable post tooltips
* very wide images are shown at the top of the tooltip, the rest on the side, like Wikipedia does 
* artists are just shown "Artist." if they don't already have a wiki page, since we discourage creation of artist wikis
* tooltips can be triggered from other tooltips, including post tooltips

Doubts/todos/reported bugs:
- [ ] not sure about the size of wide images, they might need to be enlarged since it looks weird right now
- [ ] nested tooltips on dark mode look a bit weird because they share the same bg color, but not sure what can be done to make them look better (see screenshots)
- [x] maybe strip newlines for paragraph? see the 1girl example: sometimes it looks weird when the first sentence is short or wraps around for one word. 
- [x] need to check for weird titles: tags with too long names, special characters, etc
- [ ] wide images probably need to be larger to feel "just right". Tall images already fill the gap most times, while wide images do not
- [ ] should we show the edit button in the tooltip for unregistered users? it might invite more vandalism
- [ ] tagless wikis have no preview, but they probably should (help: pages, list_of, etc)
- [ ] add tooltip suport to /tags, /tag_implications, /tag_aliases, and /related_tag, /media_assets/*
- [x] spoilers don't work
- [ ] https://testbooru.donmai.us/forum_topics/20 some experiments here
- [x] tooltips should have a minimum width, so we avoid tooltips with little text being super squashed by the embed
- [x] maybe just display all the body up to the first header, but truncate with transparence like wikipedia does.
- [ ] for betabooru, only initially deploy on the forums/comments (dtext) to gauge reception and perform adjustments

Addressed feedbacks:
* embeds aren't displayed for artists (we don't want people to start adding previews to those pages)
* embeds and body aren't displayed for tags without meaningful text (like just headers and embeds), so that people are forced to write meaningful content

Previews:

<img width="427" height="206" alt="image" src="https://github.com/user-attachments/assets/a947b4fc-b552-4d90-b329-d0d28003d220" />
<img width="416" height="246" alt="image" src="https://github.com/user-attachments/assets/baacd6ed-3dd2-499f-b70d-b631d4ff0c89" />
<img width="418" height="299" alt="image" src="https://github.com/user-attachments/assets/d4e0b55c-9179-4432-960d-35632280c07a" />
<img width="408" height="275" alt="image" src="https://github.com/user-attachments/assets/633ef2a2-55af-4fe9-8e32-9c171d8fd31b" />
<img width="414" height="255" alt="image" src="https://github.com/user-attachments/assets/53072491-965f-4dc1-b2d7-3c786d483e51" />
<img width="219" height="131" alt="image" src="https://github.com/user-attachments/assets/af6c2847-4278-40b9-9588-26ecb8b7d0de" />
<img width="368" height="138" alt="image" src="https://github.com/user-attachments/assets/9e842e12-9857-42cd-a5b4-77436b53ab96" />
